### PR TITLE
Remove the explicit version bump, rely on the 'rush publish' to publish and commit

### DIFF
--- a/common/config/azure-pipelines/templates/build-publish.yaml
+++ b/common/config/azure-pipelines/templates/build-publish.yaml
@@ -2,9 +2,9 @@ steps:
   - checkout: self
     persistCredentials: true
   - template: ./build.yaml
-  - script: node common/scripts/install-run-rush.js version --bump --version-policy imodel-select --target-branch $(Build.SourceBranchName)
-    displayName: rush version
-    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
+  # - script: node common/scripts/install-run-rush.js version --bump --version-policy imodel-select --target-branch $(Build.SourceBranchName)
+  #   displayName: rush version
+  #   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
   - script: node common/scripts/install-run-rush.js publish --apply --publish --include-all --target-branch $(Build.SourceBranchName) --add-commit-details --set-access-level public
     displayName: rush publish
     condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))

--- a/common/config/azure-pipelines/templates/build-publish.yaml
+++ b/common/config/azure-pipelines/templates/build-publish.yaml
@@ -2,9 +2,6 @@ steps:
   - checkout: self
     persistCredentials: true
   - template: ./build.yaml
-  # - script: node common/scripts/install-run-rush.js version --bump --version-policy imodel-select --target-branch $(Build.SourceBranchName)
-  #   displayName: rush version
-  #   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
   - script: node common/scripts/install-run-rush.js publish --apply --publish --include-all --target-branch $(Build.SourceBranchName) --add-commit-details --set-access-level public
     displayName: rush publish
     condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))


### PR DESCRIPTION
@aruniverse I think this should fix the issue.  It's how we handle some of our other internal repos.

The `rush publish` command in this case will handle both pushing the version bump to the repo and publishing the packages. 