### PR TITLE
Clear text in search box when the close button is clicked

### DIFF
--- a/common/changes/@bentley/tree-widget-react/zachz-modelTreeClearfix_2020-07-09-14-48.json
+++ b/common/changes/@bentley/tree-widget-react/zachz-modelTreeClearfix_2020-07-09-14-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/tree-widget-react",
+      "comment": "Model tree search box will now properly clear itself in addition to closing when its \"X\" icon is hit",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/tree-widget-react",
+  "email": "zjzoltek@users.noreply.github.com"
+}

--- a/packages/tree-widget/src/components/search-bar/SearchBar.tsx
+++ b/packages/tree-widget/src/components/search-bar/SearchBar.tsx
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import classnames from "classnames";
 import { CommonProps } from "@bentley/ui-core";

--- a/packages/tree-widget/src/components/search-bar/SearchBar.tsx
+++ b/packages/tree-widget/src/components/search-bar/SearchBar.tsx
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import classnames from "classnames";
 import { CommonProps } from "@bentley/ui-core";
@@ -54,7 +54,7 @@ interface SearchBarState {
 export class SearchBar extends React.PureComponent<
   SearchBarProps,
   SearchBarState
-  > {
+> {
   private _target: HTMLElement | null = null;
   private _searchBox = React.createRef<SearchBox>();
 
@@ -75,7 +75,7 @@ export class SearchBar extends React.PureComponent<
   }
 
   private _onToggleSearch = (
-    _event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    _event?: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {
     const showSearch = !this.state.showSearch;
     this.setState({ showSearch }, () => {
@@ -146,6 +146,7 @@ export class SearchBar extends React.PureComponent<
             onFilterClear={this.props.onFilterClear}
             onFilterStart={this.props.onFilterStart}
             resultCount={this.props.resultCount}
+            onIconClick={this._onToggleSearch}
             onSelectedChanged={this.props.onSelectedChanged}
           />
         </div>

--- a/packages/tree-widget/src/components/search-bar/SearchBox.scss
+++ b/packages/tree-widget/src/components/search-bar/SearchBox.scss
@@ -83,4 +83,8 @@
       color: $buic-accessory-primary;
     }
   }
+
+  .searchbox-close-button {
+    z-index: 1000;
+  }
 }

--- a/packages/tree-widget/src/components/search-bar/SearchBox.tsx
+++ b/packages/tree-widget/src/components/search-bar/SearchBox.tsx
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 /** @module SearchBox */
 
 import * as React from "react";

--- a/packages/tree-widget/src/components/search-bar/SearchBox.tsx
+++ b/packages/tree-widget/src/components/search-bar/SearchBox.tsx
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 /** @module SearchBox */
 
 import * as React from "react";
@@ -67,7 +67,7 @@ interface SearchBoxState {
 export class SearchBox extends React.PureComponent<
   SearchBoxProps,
   SearchBoxState
-  > {
+> {
   private _inputElement: HTMLInputElement | null = null;
   private _timeoutId: number = 0;
 
@@ -248,7 +248,7 @@ export class SearchBox extends React.PureComponent<
           />
         </div>
         <span
-          className="searchbox-step-button icon icon-close"
+          className="searchbox-step-button icon icon-close searchbox-close-button"
           onClick={this._handleIconClick}
         />
       </div>


### PR DESCRIPTION
Fix for bug: Model Tree Search - Clear doesn't remove search

description + repro steps:

Clicking the 'X' on the search does not remove the search criteria.

Steps:
Open Model Tree
Click search box
enter search criteria - tree filters as expected
Click the 'X' in the search box to clear the search
Result - the search box closes but the filter is still applied to the tree
User most close and reopen the model tree to see the full tree.
The 'X' should clear the search filter.

