### PR TITLE
Fix publish build by excluding `--include-all` flag to allow bump

### DIFF
--- a/common/config/azure-pipelines/templates/build-publish.yaml
+++ b/common/config/azure-pipelines/templates/build-publish.yaml
@@ -2,7 +2,7 @@ steps:
   - checkout: self
     persistCredentials: true
   - template: ./build.yaml
-  - script: node common/scripts/install-run-rush.js publish --apply --publish --include-all --target-branch $(Build.SourceBranchName) --add-commit-details --set-access-level public
+  - script: node common/scripts/install-run-rush.js publish --apply --publish --target-branch $(Build.SourceBranchName) --set-access-level public
     displayName: rush publish
     condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
     env:


### PR DESCRIPTION
The `--include-all` flag help docs read "will be published if their version is newer than published version" which makes it seem like it will only publish if the bump has happened prior to this step.

I ran it locally without "--publish", which actually stops it from committing the changes, but everything seemed to have worked in terms of using the changelogs to apply the version bump and then hopefully the publish step.