### PR TITLE
Favorite Properties Fix

### DIFF
--- a/common/changes/@bentley/property-grid-react/favorite-properties-fix_2020-08-26-14-25.json
+++ b/common/changes/@bentley/property-grid-react/favorite-properties-fix_2020-08-26-14-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/property-grid-react",
+      "comment": "Fix for property panel not maintaining favorite properties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/property-grid-react",
+  "email": "diegopinate@users.noreply.github.com"
+}

--- a/packages/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/property-grid/src/components/PropertyGrid.tsx
@@ -135,13 +135,15 @@ export class PropertyGrid extends React.Component<
   public componentWillReceiveProps(nextProps: PropertyGridProps) {
     if (this.props.iModelConnection) {
       // Remove old listener, create a new data provider, and re-add the listener
-      if (nextProps.iModelConnection) {
+      if (nextProps.iModelConnection &&
+        nextProps.iModelConnection !== this.props.iModelConnection) {
         this._dataProvider.onDataChanged.removeListener(
           this._dataChangedHandler,
         );
         this._dataProvider = new PropertyDataProvider(
           this.props.iModelConnection!,
           nextProps.rulesetId,
+          nextProps.enableFavoriteProperties,
         );
         this._dataProvider.onDataChanged.addListener(this._dataChangedHandler);
       }


### PR DESCRIPTION
Fix property data provider being destroyed on receiving props. Only do it on iModel Connection changes, and if so, maintain enableFavoriteProperties prop.