### PR TITLE
add vcr team as default codeowners. mainly so approvals for lockfiles…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,19 +8,19 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*  @calebmshafer
+*  @imodeljs/viewer-components-reviewers
 
 /packages/imodel-select  @wilmaier @calebmshafer
 /common/changes/@bentley/imodel-select-react  @wilmaier @calebmshafer
 
 /packages/markup-frontstage  @JoeZman @archana-maharjan
-/common/changes/@bentley/markup-frontstage-react @JoeZman @archana-maharjan
+/common/changes/@bentley/markup-frontstage-react  @JoeZman @archana-maharjan
 
 /packages/property-grid  @JoeZman @aruniverse @diegopinate
 /common/changes/@bentley/property-grid-react  @JoeZman @aruniverse @diegopinate
 
 /packages/tree-widget  @JoeZman @diegopinate @aruniverse @JValiunas @michaalx
-/common/changes/@bentley/tree-widget-react @JoeZman @diegopinate @aruniverse @JValiunas @michaalx
+/common/changes/@bentley/tree-widget-react  @JoeZman @diegopinate @aruniverse @JValiunas @michaalx
 
 /packages/imodel-content-tree  @grigasp
-/common/changes/@bentley/imodel-content-tree-react @grigasp
+/common/changes/@bentley/imodel-content-tree-react  @grigasp


### PR DESCRIPTION
add imjs/vcr team as default codeowner for the monorepo. mainly so approvals for lockfile arent dependent on only one person