### PR TITLE
Enabled property group nesting in property-grid package

### DIFF
--- a/common/changes/@bentley/property-grid-react/property-group-nesting_2020-09-29-18-57.json
+++ b/common/changes/@bentley/property-grid-react/property-group-nesting_2020-09-29-18-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/property-grid-react",
+      "comment": "Add nested property grouping",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@bentley/property-grid-react",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/packages/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/property-grid/src/components/PropertyGrid.tsx
@@ -97,13 +97,15 @@ export class PropertyGrid extends React.Component<
   constructor(props: PropertyGridProps) {
     super(props);
 
-    this._dataProvider =
-      props.dataProvider ??
-      new PropertyDataProvider(
-        props.iModelConnection,
-        props.rulesetId,
-        props.enableFavoriteProperties,
-      );
+  if (props.dataProvider) this._dataProvider = props.dataProvider;
+  else {
+    this._dataProvider = new PropertyDataProvider(
+      props.iModelConnection,
+      props.rulesetId,
+      props.enableFavoriteProperties
+    );
+    this._dataProvider.isNestedPropertyCategoryGroupingEnabled = true;
+  }
 
     this._dataChangedHandler = this._onDataChanged.bind(this);
     this.state = { className: "", sharedFavorites: [] };

--- a/packages/property-grid/src/components/PropertyGrid.tsx
+++ b/packages/property-grid/src/components/PropertyGrid.tsx
@@ -97,15 +97,16 @@ export class PropertyGrid extends React.Component<
   constructor(props: PropertyGridProps) {
     super(props);
 
-  if (props.dataProvider) this._dataProvider = props.dataProvider;
-  else {
-    this._dataProvider = new PropertyDataProvider(
-      props.iModelConnection,
-      props.rulesetId,
-      props.enableFavoriteProperties
-    );
-    this._dataProvider.isNestedPropertyCategoryGroupingEnabled = true;
-  }
+    if (props.dataProvider) {
+      this._dataProvider = props.dataProvider;
+    } else {
+      this._dataProvider = new PropertyDataProvider(
+        props.iModelConnection,
+        props.rulesetId,
+        props.enableFavoriteProperties,
+      );
+      this._dataProvider.isNestedPropertyCategoryGroupingEnabled = true;
+    }
 
     this._dataChangedHandler = this._onDataChanged.bind(this);
     this.state = { className: "", sharedFavorites: [] };


### PR DESCRIPTION
PBI: https://dev.azure.com/bentleycs/beconnect/_workitems/edit/444702/

Enabled property group nesting, unless the data provider is passed in through props (in which case we don't want to overwrite what is passed in). 