### PR TITLE
Fix main and typings field in imodel-content-tree package

### DIFF
--- a/common/changes/@bentley/imodel-content-tree-react/fix-pkg-fields_2020-10-07-16-21.json
+++ b/common/changes/@bentley/imodel-content-tree-react/fix-pkg-fields_2020-10-07-16-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-content-tree-react",
+      "comment": "Fix 'main' and 'typings' fields by removing the '-react' to match the name of the barrel file instead of package name.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/imodel-content-tree-react",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/packages/imodel-content-tree/package.json
+++ b/packages/imodel-content-tree/package.json
@@ -17,8 +17,8 @@
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
-  "main": "lib/imodel-content-tree-react.js",
-  "typings": "lib/imodel-content-tree-react",
+  "main": "lib/imodel-content-tree.js",
+  "typings": "lib/imodel-content-tree",
   "scripts": {
     "build": "tsc 1>&2 && npm run copy:assets",
     "clean": "rimraf lib",


### PR DESCRIPTION
Without this change consumers of the package are not able to correctly import using the `import { } from "@bentley/imodel-content-tree"`. Fix the name of the main and typings within the package.json to correctly match the barrel file.