### PR TITLE
Feat/support view2d

### DIFF
--- a/common/changes/@bentley/markup-frontstage-react/feat-support-view2d_2020-10-09-16-13.json
+++ b/common/changes/@bentley/markup-frontstage-react/feat-support-view2d_2020-10-09-16-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/markup-frontstage-react",
+      "comment": "Support markup in View2D",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@bentley/markup-frontstage-react",
+  "email": "52217155+archana-maharjan@users.noreply.github.com"
+}

--- a/packages/markup-frontstage/src/components/ui/MarkupFrontstageProvider.tsx
+++ b/packages/markup-frontstage/src/components/ui/MarkupFrontstageProvider.tsx
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
+
 import {
   EmphasizeElements,
   EmphasizeElementsProps,
@@ -220,7 +221,10 @@ export class MarkupFrontstageProvider extends FrontstageProvider {
   private _svgRect = (svg: string | SVGSVGElement) => {
     if (typeof svg === "string") {
       const dom = new DOMParser().parseFromString(svg, "image/svg+xml");
-      if (dom.getElementsByTagName("parsererror").length > 0) {
+      if (
+        dom.getElementsByTagName("parsererror") &&
+        dom.getElementsByTagName("parsererror").length > 0
+      ) {
         throw new UiError(
           MarkupFrontstage.loggerCategory(MarkupFrontstageProvider),
           `MarkupData.svg is invalid: ${

--- a/packages/markup-frontstage/src/components/ui/MarkupFrontstageProvider.tsx
+++ b/packages/markup-frontstage/src/components/ui/MarkupFrontstageProvider.tsx
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 import {
   EmphasizeElements,
   EmphasizeElementsProps,
@@ -34,7 +35,7 @@ import React from "react";
 import { MarkupFrontstage } from "../../MarkupFrontstage";
 import MarkupSettingsPanel from "../toolbar/MarkupSettingsPanel";
 import { MarkupToolWidget } from "../toolbar/MarkupToolWidget";
-import { createSavedViewData } from "../../services/SavedView";
+import { createMarkupSavedViewData } from "../../services/SavedView";
 import {
   AddMarkupEvent,
   MarkupFrontstageConstants,
@@ -179,14 +180,17 @@ export class MarkupFrontstageProvider extends FrontstageProvider {
       MarkupFrontstageConstants.VIEW_LAYOUT_ID
     );
     const currentViewPort = contentControl?.viewport;
-    const savedView = currentViewPort && createSavedViewData(currentViewPort);
+    const savedView =
+      currentViewPort && createMarkupSavedViewData(currentViewPort);
     const markupData = await MarkupApp.stop();
     try {
       if (savedView) {
         savedView.markup = markupData.svg;
-        savedView.emphasizedElementsProps = JSON.stringify(
-          this._emphasizedElementsProps
-        );
+        savedView.emphasizedElementsProps = savedView.is2d
+          ? savedView.emphasizedElementsProps
+          : this._emphasizedElementsProps
+          ? JSON.stringify(this._emphasizedElementsProps)
+          : undefined;
         this.onAddMarkupEvent.raiseEvent({
           savedView,
           thumbImage: markupData.image,
@@ -220,7 +224,7 @@ export class MarkupFrontstageProvider extends FrontstageProvider {
         throw new UiError(
           MarkupFrontstage.loggerCategory(MarkupFrontstageProvider),
           `MarkupData.svg is invalid: ${
-          dom.getElementsByTagName("parsererror")[0].textContent
+            dom.getElementsByTagName("parsererror")[0].textContent
           }`
         );
       } else {
@@ -238,9 +242,9 @@ export class MarkupFrontstageProvider extends FrontstageProvider {
     if (view) {
       const markupData = this._svg
         ? {
-          rect: this._svgRect(this._svg),
-          svg: this._svg,
-        }
+            rect: this._svgRect(this._svg),
+            svg: this._svg,
+          }
         : undefined;
       if (this._emphasizedElementsProps) {
         this._createEmphasizedElements(this._emphasizedElementsProps, view);

--- a/packages/markup-frontstage/src/markup-frontstage-react.ts
+++ b/packages/markup-frontstage/src/markup-frontstage-react.ts
@@ -2,7 +2,8 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-export * from "./MarkupFrontstage";
+
 export * from "./components/ui/MarkupFrontstageProvider";
 export * from "./components/toolbar/MarkupSettingsPanel";
+export * from "./MarkupFrontstage";
 export * from "./util/MarkupTypes";

--- a/packages/markup-frontstage/src/services/SavedView.ts
+++ b/packages/markup-frontstage/src/services/SavedView.ts
@@ -135,7 +135,6 @@ export const create2DSavedView = (
       classFullName: SheetViewState.classFullName,
       code: Code.createEmpty(),
     };
-    const common2dViewProps = create2dViewProps(vp);
     common2dViewProps.sheetAttachments = viewState.attachmentIds;
     common2dViewProps.sheetProps = jsonStringify(sheetProps);
     return common2dViewProps;

--- a/packages/markup-frontstage/src/services/SavedView.ts
+++ b/packages/markup-frontstage/src/services/SavedView.ts
@@ -221,7 +221,7 @@ export const createSavedViewData = (vp: Viewport): SavedViewData => {
     alwaysDrawn,
     categories,
     changeSetId,
-    displayStyleProps: jsonStringify(viewState.displayStyle?.toJSON()),
+    displayStyleProps: jsonStringify(viewState?.displayStyle?.toJSON()),
     iModelId,
     is2d: false,
     models,

--- a/packages/markup-frontstage/src/services/SavedView.ts
+++ b/packages/markup-frontstage/src/services/SavedView.ts
@@ -195,13 +195,13 @@ export const createSavedViewData = (vp: Viewport): SavedViewData => {
   const state = {
     cameraAngle: viewState.camera.getLensAngle().radians,
     cameraFocalLength: viewState.camera.focusDist,
-    cameraPosition: viewState.camera.getEyePoint().toJSON(),
-    extents: viewState.extents.toJSON(),
+    cameraPosition: viewState.camera?.getEyePoint()?.toJSON(),
+    extents: viewState.extents?.toJSON(),
     flags: viewState.viewFlags,
     isCameraOn: viewState.isCameraOn,
     is2d: false,
-    origin: viewState.origin.toJSON(),
-    rotation: viewState.rotation.toJSON(),
+    origin: viewState.origin?.toJSON(),
+    rotation: viewState.rotation?.toJSON(),
   };
 
   // Ensure the skybox is turned off
@@ -222,7 +222,7 @@ export const createSavedViewData = (vp: Viewport): SavedViewData => {
     alwaysDrawn,
     categories,
     changeSetId,
-    displayStyleProps: JSON.stringify(viewState.displayStyle.toJSON()),
+    displayStyleProps: jsonStringify(viewState.displayStyle?.toJSON()),
     iModelId,
     is2d: false,
     models,

--- a/packages/markup-frontstage/src/services/SavedView.ts
+++ b/packages/markup-frontstage/src/services/SavedView.ts
@@ -2,12 +2,21 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { ColorDef } from "@bentley/imodeljs-common";
+
+import {
+  Code,
+  ColorDef,
+  SheetProps,
+  ViewStateProps,
+} from "@bentley/imodeljs-common";
 import {
   AppearanceOverrideProps,
   DisplayStyle3dState,
+  DrawingViewState,
   EmphasizeElements,
   FeatureOverrideType,
+  IModelConnection,
+  SheetViewState,
   SpatialViewState,
   Viewport,
 } from "@bentley/imodeljs-frontend";
@@ -71,9 +80,72 @@ export const parseFromEmphasizeElements = (
 };
 
 /**
- * Creates saved view data
+ * Creates a drawing saved view.
+ * @param vp the name of the view port.
+ */
+const createDrawingSavedView = (vp: Viewport): SavedViewData => {
+  const viewState = vp.view as DrawingViewState;
+  if (!viewState) {
+    throw new Error("Invalid viewport");
+  }
+
+  const categorySelectorProps = viewState.categorySelector.toJSON();
+  const viewDefinitionProps = viewState.toJSON();
+  const displayStyleProps = viewState.displayStyle.toJSON();
+  const ee = EmphasizeElements.get(vp);
+  const emphasizedElementsProps = ee
+    ? JSON.stringify(ee.toJSON(vp))
+    : undefined;
+
+  return {
+    categorySelectorProps: JSON.stringify(categorySelectorProps),
+    displayStyleProps: JSON.stringify(displayStyleProps),
+    emphasizedElementsProps,
+    is2d: true,
+    viewDefinitionProps: JSON.stringify(viewDefinitionProps),
+  };
+};
+
+/**
+ * Creates a sheet saved view
+ * @param vp the name of the view port.
+ */
+const createSheetSavedView = (vp: Viewport): SavedViewData => {
+  const viewState = vp.view as SheetViewState;
+  if (!viewState) {
+    throw new Error("Invalid viewport");
+  }
+  const categorySelectorProps = viewState.categorySelector.toJSON();
+  const viewDefinitionProps = viewState.toJSON();
+  const displayStyleProps = viewState.displayStyle.toJSON();
+  const sheetSize = viewState.sheetSize;
+  const sheetAttachments = viewState.attachmentIds;
+  const sheetProps: SheetProps = {
+    width: sheetSize.x,
+    height: sheetSize.y,
+    model: viewState.model,
+    classFullName: SheetViewState.classFullName,
+    code: Code.createEmpty(),
+  };
+  const ee = EmphasizeElements.get(vp);
+  const emphasizedElementsProps = ee
+    ? JSON.stringify(ee.toJSON(vp))
+    : undefined;
+
+  return {
+    categorySelectorProps: JSON.stringify(categorySelectorProps),
+    displayStyleProps: JSON.stringify(displayStyleProps),
+    emphasizedElementsProps,
+    is2d: true,
+    sheetProps: JSON.stringify(sheetProps),
+    sheetAttachments: sheetAttachments,
+    viewDefinitionProps: JSON.stringify(viewDefinitionProps),
+  };
+};
+
+/**
+ * Creates 3d saved view data
  * @param vp View port from which view definition to be made
- * @param thumbName name of the thumb name.
  */
 export const createSavedViewData = (vp: Viewport): SavedViewData => {
   const viewState = vp.view as SpatialViewState;
@@ -147,22 +219,125 @@ export const createSavedViewData = (vp: Viewport): SavedViewData => {
 
   const data: SavedViewData = {
     alwaysDrawn,
-    neverDrawn,
     categories,
-    models,
-    version,
-    projectId,
-    iModelId,
     changeSetId,
-    sourceId,
-    userView: true,
-    state,
     displayStyleProps: JSON.stringify(viewState.displayStyle.toJSON()),
+    iModelId,
+    is2d: false,
+    models,
+    neverDrawn,
     perModelCategoryVisibility,
+    projectId,
+    sourceId,
+    state,
+    userView: true,
+    version,
   };
 
   // Parse all data from emphasize elements (e.g. colorization, isolates, hidden, emphasize)
   parseFromEmphasizeElements(vp, data);
 
   return data;
+};
+
+/**
+ * Determines whether or not given saved view is spatial.
+ * @param view name of the Saved View.
+ */
+export const isSpatialSavedView = (view: SavedViewData) => {
+  return (view.is2d === undefined || !view.is2d) && "models" in view;
+};
+
+/**
+ * Determines whether or not given view is Drawing.
+ * @param view name fo the Saved View.
+ */
+export const isDrawingSavedView = (view: SavedViewData) => {
+  return view.is2d !== undefined && view.is2d && !("sheetProps" in view);
+};
+
+/**
+ * Determines whether or not given view is Sheet.
+ * @param view name of the Saved View.
+ */
+export const isSheetSavedView = (view: SavedViewData) => {
+  return view.is2d !== undefined && view.is2d && "sheetProps" in view;
+};
+
+/**
+ * Creates a drawing view state from the data object.
+ * @param iModelConnection the name of the IModel Connection.
+ * @param savedView the naem of the Saved View.
+ */
+export const createDrawingViewState = async (
+  iModelConnection: IModelConnection,
+  savedView: SavedViewData
+): Promise<DrawingViewState | undefined> => {
+  const props: ViewStateProps = {
+    viewDefinitionProps: savedView.viewDefinitionProps
+      ? JSON.parse(savedView.viewDefinitionProps)
+      : undefined,
+    categorySelectorProps: savedView.categorySelectorProps
+      ? JSON.parse(savedView.categorySelectorProps)
+      : undefined,
+    displayStyleProps: savedView.displayStyleProps
+      ? JSON.parse(savedView.displayStyleProps)
+      : undefined,
+  };
+  const viewState = DrawingViewState.createFromProps(
+    props,
+    iModelConnection
+  ) as DrawingViewState;
+  await viewState.load();
+  return viewState;
+};
+
+/**
+ * Creates a sheet view state from the data object.
+ * @param iModelConnection the name of the IModelConnection.
+ * @param savedView the naem of the Saved View.
+ */
+export const createSheetViewState = async (
+  iModelConnection: IModelConnection,
+  savedView: SavedViewData
+): Promise<SheetViewState | undefined> => {
+  if (
+    savedView.sheetProps === undefined ||
+    savedView.sheetAttachments === undefined
+  ) {
+    return undefined;
+  }
+  const props: ViewStateProps = {
+    viewDefinitionProps: savedView.viewDefinitionProps
+      ? JSON.parse(savedView.viewDefinitionProps)
+      : undefined,
+    categorySelectorProps: savedView.categorySelectorProps
+      ? JSON.parse(savedView.categorySelectorProps)
+      : undefined,
+    displayStyleProps: savedView.displayStyleProps
+      ? JSON.parse(savedView.displayStyleProps)
+      : undefined,
+    sheetProps: savedView.sheetProps
+      ? JSON.parse(savedView.sheetProps)
+      : undefined,
+    sheetAttachments: savedView.sheetAttachments,
+  };
+  const viewState = SheetViewState.createFromProps(props, iModelConnection);
+  await viewState.load();
+  return viewState;
+};
+
+/**
+ * Creates a markup saved view data from the viewport, it could return a
+ * View2d(Sheet or Drawings) or a View3d(Spatial views) object
+ * @param vp the name of the view port.
+ */
+export const createMarkupSavedViewData = (vp: Viewport): SavedViewData => {
+  if (vp.view.isSpatialView()) {
+    return createSavedViewData(vp);
+  } else if (vp.view.isDrawingView()) {
+    return createDrawingSavedView(vp);
+  } else {
+    return createSheetSavedView(vp);
+  }
 };

--- a/packages/markup-frontstage/src/util/SavedViewTypes.ts
+++ b/packages/markup-frontstage/src/util/SavedViewTypes.ts
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 /**
  * Color overrides for element ids
  */
@@ -39,40 +40,50 @@ export interface SavedViewState {
  * Format for the Blob data in the BIM Review Share
  */
 export interface SavedViewData {
-  /** id for persisted saved view */
-  id?: string;
-  /** List of elements that are hidden */
-  neverDrawn?: string[];
   /** List of elements that are isolated */
   alwaysDrawn?: string[];
+  /** Viewed categories */
+  categories?: string[];
+  /** Category Selector Props */
+  categorySelectorProps?: string;
+  /** changeset of the iModel that contains the saved view */
+  changeSetId?: string;
+  /** Display Style Props */
+  displayStyleProps?: string;
+  /** Emphasized Elements if any as JSON*/
+  emphasizedElementsProps?: string;
+  /** id for persisted saved view */
+  id?: string;
+  /** iModel that contains the saved view */
+  iModelId?: string;
+  /** Is view 2D */
+  is2d?: boolean;
+  /** markup svg */
+  markup?: string;
+  /** Viewed models */
+  models?: string[];
+  /** List of elements that are hidden */
+  neverDrawn?: string[];
   /** List of elements to show colorized (green) while default becomes gray */
   nonGrayedElements?: string[];
   /** List of color and transparency overrides */
   overrides?: OverrideData[];
-  /** Viewed categories */
-  categories: string[];
-  /** Viewed models */
-  models: string[];
-  /** Version */
-  version: string;
-  /** View source Id in iModel */
-  sourceId: string;
-  /** If the view was created by an user */
-  userView: boolean;
-  /** Data related to the view (camera angle, extents, flags, etc.) */
-  state: SavedViewState;
-  /** Display Style Props */
-  displayStyleProps?: string;
-  /** Project that contains the iModel that contains the saved view */
-  projectId?: string;
-  /** iModel that contains the saved view */
-  iModelId?: string;
-  /** changeset of the iModel that contains the saved view */
-  changeSetId?: string;
   /** model/category overrides */
   perModelCategoryVisibility?: PerModelCategoryVisibilityProps[];
-  /** markup svg */
-  markup?: string;
-  /**Emphasized Elements if any as JSON*/
-  emphasizedElementsProps?: string;
+  /** Project that contains the iModel that contains the saved view */
+  projectId?: string;
+  /** Sheet Attachments */
+  sheetAttachments?: string[];
+  /** Sheet props */
+  sheetProps?: string;
+  /** View source Id in iModel */
+  sourceId?: string;
+  /** Data related to the view (camera angle, extents, flags, etc.) */
+  state?: SavedViewState;
+  /** If the view was created by an user */
+  userView?: boolean;
+  /** Version */
+  version?: string;
+  /** 2D view definition props */
+  viewDefinitionProps?: string;
 }


### PR DESCRIPTION
This PR contains view2D support feature in addition to Markup Frontstage React package. The SavedViewData provided by the MakrupFrontstage used to only support SpatielView, now with this new addition, it also supports SheetView and DrawingView. In order to not break existing consumers, I've added 2D view properties in SavedViewData, instead of creating BaseSavedViewData(with both common 3Dview and 2Dview), (3DSavedViewData, 2DSavedViewData)inheriting from BaseSavedViewData.