### PR TITLE
Bug/fix 3D view filter in isSpatialView function

### DIFF
--- a/common/changes/@bentley/markup-frontstage-react/bug-fix-view-type-filter_2020-10-15-21-49.json
+++ b/common/changes/@bentley/markup-frontstage-react/bug-fix-view-type-filter_2020-10-15-21-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/markup-frontstage-react",
+      "comment": "Fix isSpatialView functionality to filter 3D view type and remove export from jsonStringify",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/markup-frontstage-react",
+  "email": "52217155+archana-maharjan@users.noreply.github.com"
+}

--- a/packages/markup-frontstage/src/services/SavedView.ts
+++ b/packages/markup-frontstage/src/services/SavedView.ts
@@ -85,7 +85,7 @@ export const parseFromEmphasizeElements = (
  * Convert given object to string or undefined if it's undefined.
  * @param args name of the argument object.
  */
-export const jsonStringify = <T>(args: T): string | undefined => {
+const jsonStringify = <T>(args: T): string | undefined => {
   return args !== undefined ? JSON.stringify(args) : undefined;
 };
 
@@ -246,7 +246,7 @@ export const createSavedViewData = (vp: Viewport): SavedViewData => {
  */
 export const isSpatialSavedView = (view: SavedViewData) => {
   // view.is2d can be undefined for spatialSavedView that are added before 2D saved view feature is added.
-  return !!view.is2d && "models" in view;
+  return !view.is2d && "models" in view;
 };
 
 /**


### PR DESCRIPTION
This PR contains the fix for isSpatialView functionality, because of which 2D view state was delivered instead of 3D view state to the frontstage.