### PR TITLE
imodel-content-tree: Handle GraphicalPartition3d similar to PhysicalPartition

### DIFF
--- a/common/changes/@bentley/imodel-content-tree-react/imodel-content-tree-handle-GraphicalPartition3ds_2020-10-16-11-36.json
+++ b/common/changes/@bentley/imodel-content-tree-react/imodel-content-tree-handle-GraphicalPartition3ds_2020-10-16-11-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-content-tree-react",
+      "comment": "Handle GraphicalPartition3d similar to PhysicalPartition - it should not be displayed if there's a 'GraphicalPartition3d.Model.Content' attribute in JsonProperties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/imodel-content-tree-react",
+  "email": "grigasp@users.noreply.github.com"
+}

--- a/packages/imodel-content-tree/src/components/Hierarchy.json
+++ b/packages/imodel-content-tree/src/components/Hierarchy.json
@@ -103,7 +103,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") = NULL AND json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") = NULL",
           "groupByClass": false,
           "groupByLabel": false
         },
@@ -133,7 +133,7 @@
               "isRequired": true
             }
           ],
-          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL",
+          "instanceFilter": "(parent.ECInstanceId = partition.Parent.Id OR json_extract(parent.JsonProperties, \"$.Subject.Model.TargetPartition\") = printf(\"0x%x\", partition.ECInstanceId)) AND NOT this.IsPrivate AND (json_extract(partition.JsonProperties, \"$.PhysicalPartition.Model.Content\") <> NULL OR json_extract(partition.JsonProperties, \"$.GraphicalPartition3d.Model.Content\") <> NULL)",
           "hideNodesInHierarchy": true,
           "groupByClass": false,
           "groupByLabel": false


### PR DESCRIPTION
Nodes of Models that model PhysicalPartitions are node displayed, if the partition's JsonProperties has 'PhysicalPartition.Model.Content' attribute. Similar behavior should apply to GraphicalPartition3d - it's model should not be displayed if it's JsonProperties has 'GraphicalPartition3d.Model.Content' attribute.