### PR TITLE
Long names cutting off in properties panel

### DIFF
--- a/common/changes/@bentley/property-grid-react/longname-in-properties-panel_2020-12-03-16-08.json
+++ b/common/changes/@bentley/property-grid-react/longname-in-properties-panel_2020-12-03-16-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/property-grid-react",
+      "comment": "removed height on property panel header",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/property-grid-react",
+  "email": "cortneysmithbentley@users.noreply.github.com"
+}

--- a/packages/property-grid/src/components/ElementList.scss
+++ b/packages/property-grid/src/components/ElementList.scss
@@ -11,7 +11,6 @@
 }
 
 .property-grid-react-element-list-header {
-  height: 52px; // specific size based on property grid header
   display: flex;
   padding-top: $uicore-xs;
 }

--- a/packages/property-grid/src/components/PropertyGrid.scss
+++ b/packages/property-grid/src/components/PropertyGrid.scss
@@ -38,7 +38,6 @@
 }
 
 .property-grid-react-panel-header {
-  height: 52px;
   display: flex;
   padding-top: $uicore-xs;
 }


### PR DESCRIPTION
Fix for an issue with long names cutting off in the properties panel. Removed the height restriction for the header div. Tested and it works fine for both short and long names without the hardcoded height. 