### PR TITLE
fix search styling issues

### DIFF
--- a/common/changes/@bentley/tree-widget-react/bug-search-styling_2020-12-14-21-02.json
+++ b/common/changes/@bentley/tree-widget-react/bug-search-styling_2020-12-14-21-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/tree-widget-react",
+      "comment": "Fix styling issues in search bar",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/tree-widget-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/tree-widget/src/components/search-bar/SearchBar.scss
+++ b/packages/tree-widget/src/components/search-bar/SearchBar.scss
@@ -12,6 +12,7 @@
   // "..." group button
   .search-bar-group-button2 {
     opacity: 0;
+    display: none;
     animation: hide ease-in 0.1s;
     animation-fill-mode: forwards;
 
@@ -25,9 +26,6 @@
 
   // button container
   .search-bar-button-container {
-    position: absolute;
-    left: 0;
-    right: 30px;
     display: flex;
     align-items: center;
 
@@ -36,6 +34,7 @@
     }
 
     &.hide {
+      display: none;
       animation: hide ease-in 0.25s;
       animation-delay: 0.3s;
       animation-fill-mode: forwards;
@@ -74,7 +73,7 @@
       visibility: hidden;
       opacity: 0;
       overflow: hidden;
-      transition: all 0.5s ease;
+      transition: all 0.25s ease;
 
       &.show {
         visibility: visible;


### PR DESCRIPTION
in UI 2.0 with resizable widgets, absolute positioning is causing overlap. Also adjusted transition time:

![image](https://user-images.githubusercontent.com/6283674/102135215-a5b8dd00-3e25-11eb-8971-bf99f4dd77ee.png)
