### PR TITLE
patch: don't recreate jsxElement every render

### DIFF
--- a/common/changes/@bentley/imodel-react-hooks/fix-dont-recreate-html-element_2021-01-21-16-39.json
+++ b/common/changes/@bentley/imodel-react-hooks/fix-dont-recreate-html-element_2021-01-21-16-39.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-react-hooks",
+      "comment": "fixed jsxElement resetting on updates",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/imodel-react-hooks",
+  "email": "16315257+MichaelBelousov@users.noreply.github.com"
+}

--- a/packages/imodel-react-hooks/src/IModelJsViewProvider.tsx
+++ b/packages/imodel-react-hooks/src/IModelJsViewProvider.tsx
@@ -1,8 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
-
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import {
   DecorateContext,
@@ -27,9 +26,9 @@ export interface MarkerDecorationContext {
   enqueueViewInvalidation: () => void;
 }
 
-export const MarkerDecorationContext = makeContextWithProviderRequired<
-  MarkerDecorationContext
->("MarkerDecorationContext");
+export const MarkerDecorationContext = makeContextWithProviderRequired<MarkerDecorationContext>(
+  "MarkerDecorationContext"
+);
 
 const isViewportValidForDecorations = (v: Viewport) =>
   "invalidateDecorations" in v;
@@ -83,7 +82,11 @@ export const IModelJsViewProvider = ({
 
   const enqueueViewInvalidation = useCallback(
     () =>
-      setTimeout(() => IModelApp.viewManager.invalidateDecorationsAllViews()),
+      setTimeout(() =>
+        IModelApp.viewManager.forEachViewport((vp) => {
+          if (viewFilter?.(vp) ?? true) vp.invalidateDecorations();
+        })
+      ),
     []
   );
 

--- a/packages/imodel-react-hooks/src/IModelJsViewProvider.tsx
+++ b/packages/imodel-react-hooks/src/IModelJsViewProvider.tsx
@@ -82,11 +82,11 @@ export const IModelJsViewProvider = ({
 
   const enqueueViewInvalidation = useCallback(
     () =>
-      setTimeout(() =>
+      setTimeout(() => {
         IModelApp.viewManager.forEachViewport((vp) => {
           if (viewFilter?.(vp) ?? true) vp.invalidateDecorations();
         })
-      ),
+      }),
     []
   );
 

--- a/packages/imodel-react-hooks/src/Marker/useMarker.ts
+++ b/packages/imodel-react-hooks/src/Marker/useMarker.ts
@@ -1,13 +1,12 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
-
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import { Point2d, Range1dProps, WritableXAndY } from "@bentley/geometry-core";
 import { ColorDef } from "@bentley/imodeljs-common";
 import { Marker, MarkerImage } from "@bentley/imodeljs-frontend";
-import { useContext, useEffect, useMemo, useRef } from "react";
+import React, { useContext, useEffect, useMemo, useRef } from "react";
 import ReactDOM from "react-dom";
 
 import { MarkerDecorationContext } from "../IModelJsViewProvider";
@@ -201,11 +200,10 @@ export const useMarker = <T extends {} = {}>(options: UseMarkerOptions<T>) => {
     }
   }, [marker, options.scaleFactor]);
 
-  const htmlElementRef = useRef<HTMLDivElement>();
+  const htmlElementRef = useRef(document.createElement("div"));
 
   useEffect(() => {
     if (options.jsxElement) {
-      htmlElementRef.current = document.createElement("div");
       ReactDOM.render(options.jsxElement, htmlElementRef.current);
       marker.htmlElement = htmlElementRef.current;
     } else {

--- a/packages/imodel-react-hooks/src/Marker/useMarker.ts
+++ b/packages/imodel-react-hooks/src/Marker/useMarker.ts
@@ -100,6 +100,7 @@ export const useMarker = <T extends {} = {}>(options: UseMarkerOptions<T>) => {
     size: _size,
     imageSize: _imageSize,
     imageOffset: _imageOffset,
+    jsxElement,
     ...normallyMemoizedOptionValues
   } = options;
 


### PR DESCRIPTION
patch change
- should allow you to animate correctly since updates don't delete the root element
- should increase performance when using jsxElement
- it should have worked this way from the beginning, can't believe I just noticed
- used viewFilter when invalidating viewports to not invalidate all of them