### PR TITLE
Fix scss issue found in Dart Sass

### DIFF
--- a/common/changes/@bentley/imodel-select-react/imodelselect-fix-sass_2021-02-23-20-31.json
+++ b/common/changes/@bentley/imodel-select-react/imodelselect-fix-sass_2021-02-23-20-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-select-react",
+      "comment": "Fix IModelList.scss compatibility with Dart Sass",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/imodel-select-react",
+  "email": "31107829+calebmshafer@users.noreply.github.com"
+}

--- a/packages/imodel-select/src/components/IModelList.scss
+++ b/packages/imodel-select/src/components/IModelList.scss
@@ -37,9 +37,9 @@ $imodel-select-cards-border-color: $buic-foreground-disabled;
     border: 1px solid #ccc;
     font-size: 18px;
     cursor: pointer;
-    -webkit-transition: color background-color.2s ease;
-    -moz-transition: color background-color.2s ease;
-    -o-transition: color background-color.2s ease;
+    -webkit-transition: color background-color .2s ease;
+    -moz-transition: color background-color .2s ease;
+    -o-transition: color background-color .2s ease;
     transition: color background-color 0.2s ease;
   }
 

--- a/packages/imodel-select/src/components/IModelList.scss
+++ b/packages/imodel-select/src/components/IModelList.scss
@@ -37,9 +37,6 @@ $imodel-select-cards-border-color: $buic-foreground-disabled;
     border: 1px solid #ccc;
     font-size: 18px;
     cursor: pointer;
-    -webkit-transition: color background-color .2s ease;
-    -moz-transition: color background-color .2s ease;
-    -o-transition: color background-color .2s ease;
     transition: color background-color 0.2s ease;
   }
 


### PR DESCRIPTION
I moved Desktop Starter up to the latest version of Dart Sass and found the following error.  I just added a space and everything seems to be okay :).  Someone with more knowledge of scss can tell me if that was the "correct" solution.

```
SassError: Expected identifier.
   ╷
39 │     -webkit-transition: color background-color.2s ease;
```