### PR TITLE
imodel-content-tree: Non-geometric models' content display improvements

### DIFF
--- a/common/changes/@bentley/imodel-content-tree-react/imodel-content-tree-non-geometric-model-content-display-improvements_2021-02-26-06-52.json
+++ b/common/changes/@bentley/imodel-content-tree-react/imodel-content-tree-non-geometric-model-content-display-improvements_2021-02-26-06-52.json
@@ -1,0 +1,21 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-content-tree-react",
+      "comment": "Directly under non-geometric models node show only elements that have no parent",
+      "type": "minor"
+    },
+    {
+      "packageName": "@bentley/imodel-content-tree-react",
+      "comment": "Group elements under non-geometric models by class",
+      "type": "minor"
+    },
+    {
+      "packageName": "@bentley/imodel-content-tree-react",
+      "comment": "For every element node under non-geometric model load its child elements as child nodes",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@bentley/imodel-content-tree-react",
+  "email": "grigasp@users.noreply.github.com"
+}

--- a/packages/imodel-content-tree/src/components/Hierarchy.json
+++ b/packages/imodel-content-tree/src/components/Hierarchy.json
@@ -188,7 +188,30 @@
           ],
           "suppressSimilarAncestorsCheck": true,
           "groupByClass": false,
-          "groupByLabel": false
+          "groupByLabel": false,
+          "nestedRules": [
+            {
+              "ruleType": "ChildNodes",
+              "condition": "ParentNode.IsOfClass(\"SpatialCategory\", \"BisCore\")",
+              "specifications": [
+                {
+                  "specType": "RelatedInstanceNodes",
+                  "relationshipPaths": [
+                    {
+                      "relationship": {
+                        "schemaName": "BisCore",
+                        "className": "GeometricElement3dIsInCategory"
+                      },
+                      "direction": "Backward"
+                    }
+                  ],
+                  "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
+                  "groupByClass": true,
+                  "groupByLabel": false
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -218,7 +241,30 @@
           ],
           "suppressSimilarAncestorsCheck": true,
           "groupByClass": false,
-          "groupByLabel": false
+          "groupByLabel": false,
+          "nestedRules": [
+            {
+              "ruleType": "ChildNodes",
+              "condition": "ParentNode.IsOfClass(\"DrawingCategory\", \"BisCore\")",
+              "specifications": [
+                {
+                  "specType": "RelatedInstanceNodes",
+                  "relationshipPaths": [
+                    {
+                      "relationship": {
+                        "schemaName": "BisCore",
+                        "className": "GeometricElement2dIsInCategory"
+                      },
+                      "direction": "Backward"
+                    }
+                  ],
+                  "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
+                  "groupByClass": true,
+                  "groupByLabel": false
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -240,49 +286,7 @@
               }
             ]
           ],
-          "suppressSimilarAncestorsCheck": true,
-          "groupByClass": false,
-          "groupByLabel": false
-        }
-      ]
-    },
-    {
-      "ruleType": "ChildNodes",
-      "condition": "ParentNode.IsOfClass(\"SpatialCategory\", \"BisCore\")",
-      "specifications": [
-        {
-          "specType": "RelatedInstanceNodes",
-          "relationshipPaths": [
-            {
-              "relationship": {
-                "schemaName": "BisCore",
-                "className": "GeometricElement3dIsInCategory"
-              },
-              "direction": "Backward"
-            }
-          ],
-          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
-          "groupByClass": true,
-          "groupByLabel": false
-        }
-      ]
-    },
-    {
-      "ruleType": "ChildNodes",
-      "condition": "ParentNode.IsOfClass(\"DrawingCategory\", \"BisCore\")",
-      "specifications": [
-        {
-          "specType": "RelatedInstanceNodes",
-          "relationshipPaths": [
-            {
-              "relationship": {
-                "schemaName": "BisCore",
-                "className": "GeometricElement2dIsInCategory"
-              },
-              "direction": "Backward"
-            }
-          ],
-          "instanceFilter": "this.Model.Id = parent.parent.ECInstanceId ANDALSO this.Parent = NULL",
+          "instanceFilter": "this.Parent = NULL",
           "groupByClass": true,
           "groupByLabel": false
         }


### PR DESCRIPTION
Changed several things for stuff displayed under non-geometric Models:
- Directly under the Model node show only Elements that have no parent (removes SubCategories that used to appear directly under Model).
- Group those elements by class (identifies the type of node).
- For every Element node load its child Elements as child nodes (puts SubCategories under their parent Category).
