### PR TITLE
Tree widget resize

### DIFF
--- a/common/changes/@bentley/tree-widget-react/tree-widget-resize_2021-03-23-15-44.json
+++ b/common/changes/@bentley/tree-widget-react/tree-widget-resize_2021-03-23-15-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/tree-widget-react",
+      "comment": "Change .component-selectable-content to block to display to fix resize flicker.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/tree-widget-react",
+  "email": "45079789+NancyMcCallB@users.noreply.github.com"
+}

--- a/packages/tree-widget/src/components/TreeWidgetComponent.scss
+++ b/packages/tree-widget/src/components/TreeWidgetComponent.scss
@@ -13,7 +13,7 @@
   flex-direction: column;
 
   .components-selectable-content {
-    display: flex;
+    display: block;
     flex-direction: column;
     height: 100%;
     width: 100%;


### PR DESCRIPTION
Reported by a user in imodeljs git repo: https://github.com/imodeljs/imodeljs/discussions/1005

The tree widget can get into a flickering refresh state when it is resized. I solved this by changing the components-selectable-content class from display: flex to display: block. This seems to keep it out of a endless resize loop when the scroll bars are added.

I tested in docked and undocked states and did not see any problems.