### PR TITLE
Avoid nested scrollbars

### DIFF
--- a/common/changes/@bentley/tree-widget-react/avoidNestedScrollbars_2021-03-24-17-49.json
+++ b/common/changes/@bentley/tree-widget-react/avoidNestedScrollbars_2021-03-24-17-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/tree-widget-react",
+      "comment": "Avoid Nested ScrollBars in Tree View widget",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/tree-widget-react",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/packages/tree-widget/src/components/TreeWidgetComponent.scss
+++ b/packages/tree-widget/src/components/TreeWidgetComponent.scss
@@ -14,9 +14,9 @@
 
   .components-selectable-content {
     display: block;
-    flex-direction: column;
     height: 100%;
     width: 100%;
+    overflow: hidden;
   }
 
   .components-selectable-content-header {


### PR DESCRIPTION
Let the tree provide the only scroll bar and avoid nested scrollbars within widget.