### PR TITLE
move react and react-dom to peerDependencies

### DIFF
--- a/common/changes/@bentley/imodel-select-react/bug-imodel-select-react-deps_2021-03-30-23-54.json
+++ b/common/changes/@bentley/imodel-select-react/bug-imodel-select-react-deps_2021-03-30-23-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-select-react",
+      "comment": "Move react and react-dom to peerDependencies",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/imodel-select-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/imodel-select/package.json
+++ b/packages/imodel-select/package.json
@@ -31,8 +31,6 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "i18next": "^10.2.2",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
     "react-redux": "^7.2.0",
     "redux": "^4.0.3"
   },
@@ -65,6 +63,8 @@
     "@types/react-dom": "^16.8.0",
     "@types/react-redux": "^7.0.1",
     "cpx": "^1.5.0",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "rimraf": "^3.0.2",
     "tslint": "^5.11.0",
     "typescript": "~3.7.4"
@@ -90,6 +90,8 @@
     "@bentley/ui-core": "^2.0.0",
     "@bentley/ui-framework": "^2.0.0",
     "@bentley/ui-ninezone": "^2.0.0",
-    "@bentley/webgl-compatibility": "^2.0.0"
+    "@bentley/webgl-compatibility": "^2.0.0",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   }
 }


### PR DESCRIPTION
keeping them as dependencies can cause duplicate versions of react-dom to be loaded, causing multiple errors