### PR TITLE
Prevent infinite spinner in imodel-select

### DIFF
--- a/common/changes/@bentley/imodel-select-react/imodel-select-prevent-infinite-spinner_2021-04-13-14-21.json
+++ b/common/changes/@bentley/imodel-select-react/imodel-select-prevent-infinite-spinner_2021-04-13-14-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/imodel-select-react",
+      "comment": "Prevent infinite spinner when getProjects fails.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/imodel-select-react",
+  "email": "10091419+GerardasB@users.noreply.github.com"
+}

--- a/packages/imodel-select/src/components/IModelSelector.tsx
+++ b/packages/imodel-select/src/components/IModelSelector.tsx
@@ -2,6 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+
 import * as React from "react";
 import classnames from "classnames";
 import { IModelApp } from "@bentley/imodeljs-frontend";
@@ -90,6 +91,13 @@ export class IModelSelector extends React.Component<IModelSelectorProps, IModelS
             })
           );
         if (projectInfos.length > 0) this._selectProject(projectInfos[0]);
+      })
+      .catch(() => {
+        if (!this._isMounted)
+          return;
+        this.setState({
+          isLoadingProjects: false,
+        });
       });
   }
 


### PR DESCRIPTION
This PR handles getProjects error and resets isLoadingProjects state to prevent rendering the spinner indefinitely.