### PR TITLE
Disable view overlay (solar timeline)

### DIFF
--- a/common/changes/@bentley/markup-frontstage-react/Disable-view-overlay--solar-timeline-_2021-04-27-21-22.json
+++ b/common/changes/@bentley/markup-frontstage-react/Disable-view-overlay--solar-timeline-_2021-04-27-21-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/markup-frontstage-react",
+      "comment": "Hide the solar timeline for the markup frontstage.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/markup-frontstage-react",
+  "email": "JoeZman@users.noreply.github.com"
+}

--- a/packages/markup-frontstage/src/components/ui/MarkupFrontstageProvider.tsx
+++ b/packages/markup-frontstage/src/components/ui/MarkupFrontstageProvider.tsx
@@ -95,6 +95,7 @@ export class MarkupFrontstageProvider extends FrontstageProvider {
             viewState: this._viewState,
             iModelConnection: this._iModelConnection,
             rulesetId: this._rulesetId,
+            disableDefaultViewOverlay: true,
           },
         },
       ],


### PR DESCRIPTION
For the markup frontstage, always disable the view overlay (solar timeline).  