### PR TITLE
Fix: Model/Category trees incorrect height

### DIFF
--- a/common/changes/@bentley/tree-widget-react/Fix--Model-Category-trees-incorrect-height_2021-07-19-16-54.json
+++ b/common/changes/@bentley/tree-widget-react/Fix--Model-Category-trees-incorrect-height_2021-07-19-16-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/tree-widget-react",
+      "comment": "Model/Category tree was not resizing properly, missing flex=1.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/tree-widget-react",
+  "email": "JoeZman@users.noreply.github.com"
+}

--- a/packages/tree-widget/src/components/TreeWidgetComponent.scss
+++ b/packages/tree-widget/src/components/TreeWidgetComponent.scss
@@ -13,10 +13,7 @@
   flex-direction: column;
 
   .components-selectable-content {
-    display: block;
-    height: 100%;
-    width: 100%;
-    overflow: hidden;
+    flex: 1;
   }
 
   .components-selectable-content-header {

--- a/packages/tree-widget/src/components/trees/ModelsTree.scss
+++ b/packages/tree-widget/src/components/trees/ModelsTree.scss
@@ -7,7 +7,6 @@
 
 .tree-widget-models-tree-container {
   flex: 1;
-  margin-bottom: $uicore-s;
 }
 
 .tree-widget-models-tree-toolbar-icon {


### PR DESCRIPTION
Model & Category were incorrectly sized in the Tree widget.  Since the parent is flexbox, the tree should set flex=1, to size the remaining space.  Also, it was adding unnecessary padding.