### PR TITLE
Allow copyright linter to run at the same time as other steps

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -66,7 +66,8 @@
       "commandKind": "global",
       "summary": "Run copyright linter using lintstaged",
       "autoinstallerName": "rush-lintstaged",
-      "shellCommand": "lint-staged --quiet --config common/scripts/.lintstagedrc.json"
+      "shellCommand": "lint-staged --quiet --config common/scripts/.lintstagedrc.json",
+      "safeForSimultaneousRushProcesses": false
     }
   ]
 }


### PR DESCRIPTION
The rush publish command runs a git commit as a sub-process which triggers the copyright linter git hook. Since it was not marked as safe to run at the same time as other Rush commands, the rush publish and rush copyright:linter were conflicting with each other.