### PR TITLE
Turn multi-process support to true this time

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -67,7 +67,7 @@
       "summary": "Run copyright linter using lintstaged",
       "autoinstallerName": "rush-lintstaged",
       "shellCommand": "lint-staged --quiet --config common/scripts/.lintstagedrc.json",
-      "safeForSimultaneousRushProcesses": false
+      "safeForSimultaneousRushProcesses": true
     }
   ]
 }


### PR DESCRIPTION
Somehow in #134 I set this to `false` which is completely useless as that's the default.  Switching it to the appropriate `true` to allow for the parallel processing.