### PR TITLE
measure-tools-react: support customizing the widget placement in the ui items provider

### DIFF
--- a/common/changes/@itwin/measure-tools-react/measurement-uiitemsprovider-customizellocation_2022-10-19-13-26.json
+++ b/common/changes/@itwin/measure-tools-react/measurement-uiitemsprovider-customizellocation_2022-10-19-13-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/measure-tools-react",
+      "comment": "customize widget placement in ui items provider",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/measure-tools-react"
+}

--- a/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
+++ b/packages/itwin/measure-tools/src/ui-2.0/MeasureToolsUiProvider.tsx
@@ -25,6 +25,12 @@ import { UiFramework } from "@itwin/appui-react";
 export interface MeasureToolsUiProviderOptions {
   itemPriority?: number;
   groupPriority?: number;
+  widgetPlacement?: {
+    location: StagePanelLocation;
+    section?: StagePanelSection;
+    // eslint-disable-next-line deprecation/deprecation
+    zoneLocation?: AbstractZoneLocation;
+  };
 }
 
 export class MeasureToolsUiItemsProvider implements UiItemsProvider {
@@ -110,18 +116,23 @@ export class MeasureToolsUiItemsProvider implements UiItemsProvider {
     zoneLocation?: AbstractZoneLocation
   ): ReadonlyArray<AbstractWidgetProps> {
     const widgets: AbstractWidgetProps[] = [];
+
+    const preferredLocation = this._props?.widgetPlacement?.location ?? StagePanelLocation.Right;
+    const preferredSection = this._props?.widgetPlacement?.section ?? StagePanelSection.Start;
+    // eslint-disable-next-line deprecation/deprecation
+    const preferredZoneLocation = this._props?.widgetPlacement?.zoneLocation ?? AbstractZoneLocation.CenterRight;
+
     if (
       (
         stageUsage === StageUsage.General &&
-        location === StagePanelLocation.Right &&
-        section === StagePanelSection.Start &&
+        location === preferredLocation &&
+        section === preferredSection &&
         UiFramework.uiVersion !== "1"
       ) ||
       (
         !section &&
         stageUsage === StageUsage.General &&
-        // eslint-disable-next-line deprecation/deprecation
-        zoneLocation === AbstractZoneLocation.CenterRight
+        zoneLocation === preferredZoneLocation
       )
     ) {
       widgets.push({


### PR DESCRIPTION
Allow the widget provided by the measure tools ui items provider to have its placement in the ui overridden to accommodate app preferences 