### PR TITLE
[Tree widget]: Enable performance test for next branch

### DIFF
--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -340,12 +340,15 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
   private getSubModels(props: Parameters<BaseIdsCache["getSubModels"]>[0]): ReturnType<BaseIdsCache["getSubModels"]> {
     if ("modelIds" in props) {
       return from(Id64.iterable(props.modelIds)).pipe(
-        mergeMap((modelId) =>
-          from(this.#props.idsCache.getModelCategoryIds(modelId)).pipe(
+        mergeMap((modelId) => {
+          if (props.categoryId) {
+            return from(this.#props.idsCache.getCategoriesModeledElements(modelId, props.categoryId)).pipe(map((subModels) => ({ id: modelId, subModels })));
+          }
+          return from(this.#props.idsCache.getModelCategoryIds(modelId)).pipe(
             mergeMap((categoryIds) => from(this.#props.idsCache.getCategoriesModeledElements(modelId, categoryIds))),
             map((subModels) => ({ id: modelId, subModels })),
-          ),
-        ),
+          );
+        }),
       );
     }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -240,14 +240,17 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
   private getSubModels(props: Parameters<BaseIdsCache["getSubModels"]>[0]): ReturnType<BaseIdsCache["getSubModels"]> {
     if ("modelIds" in props) {
       return from(Id64.iterable(props.modelIds)).pipe(
-        mergeMap((modelId) =>
-          from(this.#props.idsCache.getModelCategoryIds(modelId)).pipe(
+        mergeMap((modelId) => {
+          if (props.categoryId) {
+            return from(this.#props.idsCache.getCategoriesModeledElements(modelId, props.categoryId)).pipe(map((subModels) => ({ id: modelId, subModels })));
+          }
+          return from(this.#props.idsCache.getModelCategoryIds(modelId)).pipe(
             mergeMap(({ drawing, spatial }) => merge(drawing, spatial)),
             toArray(),
             mergeMap((categoryIds) => from(this.#props.idsCache.getCategoriesModeledElements(modelId, categoryIds))),
             map((subModels) => ({ id: modelId, subModels })),
-          ),
-        ),
+          );
+        }),
       );
     }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -74,7 +74,7 @@ export interface BaseIdsCache {
   getModels: (props: { categoryIds: Id64Arg }) => Observable<{ id: Id64String; models: Id64Arg | undefined }>;
   getCategories: (props: { modelIds: Id64Arg }) => Observable<{ id: Id64String; drawingCategories?: Id64Arg; spatialCategories?: Id64Arg }>;
   getSubModels: (
-    props: { modelIds: Id64Arg } | { categoryIds: Id64Arg; modelId: Id64String | undefined },
+    props: { modelIds: Id64Arg; categoryId?: Id64String } | { categoryIds: Id64Arg; modelId: Id64String | undefined },
   ) => Observable<{ id: Id64String; subModels: Id64Arg | undefined }>;
   getAllCategories: () => Observable<{ drawingCategories?: Id64Set; spatialCategories?: Id64Set }>;
 }
@@ -366,7 +366,7 @@ export class BaseVisibilityHelper implements Disposable {
           return merge(
             // For hidden models we only need to check subModels
             hiddenModels.length > 0
-              ? this.#props.baseIdsCache.getSubModels({ modelIds: hiddenModels }).pipe(
+              ? this.#props.baseIdsCache.getSubModels({ modelIds: hiddenModels, categoryId }).pipe(
                   mergeMap(({ subModels }) => {
                     if (subModels && Id64.sizeOf(subModels) > 0) {
                       return this.getModelsVisibilityStatus({

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -325,12 +325,15 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
   private getSubModels(props: Parameters<BaseIdsCache["getSubModels"]>[0]): ReturnType<BaseIdsCache["getSubModels"]> {
     if ("modelIds" in props) {
       return from(Id64.iterable(props.modelIds)).pipe(
-        mergeMap((modelId) =>
-          from(this.#props.idsCache.getModelCategoryIds(modelId)).pipe(
+        mergeMap((modelId) => {
+          if (props.categoryId) {
+            return from(this.#props.idsCache.getCategoriesModeledElements(modelId, props.categoryId)).pipe(map((subModels) => ({ id: modelId, subModels })));
+          }
+          return from(this.#props.idsCache.getModelCategoryIds(modelId)).pipe(
             mergeMap((categoryIds) => from(this.#props.idsCache.getCategoriesModeledElements(modelId, categoryIds))),
             map((subModels) => ({ id: modelId, subModels })),
-          ),
-        ),
+          );
+        }),
       );
     }
 


### PR DESCRIPTION
closes [#1454](https://github.com/iTwin/viewer-components-react/issues/1454)

This was happening due to two reasons:
1. To determine category visibility, `BaseVisibilityHelper.getCategoriesVisibilityStatus` is called. This in turn calls `getSubModels` for hidden models. Every visibility handler (models, categories, classifications) implements this function. In each case, to get sub-models contained by these hidden models we first have to get their categories, and then using categories with those hidden models we determine sub-models. Process:
    - for each category (there are 50k of them), we would first get element models (1 model and it is hidden)
    - for this hidden model we get it's categories (50k of them)
    - for each category + model we would get subModels
    
    Because of this, determining visbility of each category takes a lot of time to complete, and memory gets filled with observables before visbility can be validated.
2. The structure of `50k categories` iModel. The iModel is a little unrealistic: 
    - it has 50k categories;
    - All of these categories are contained by the same definition container.
    
Fixed both of these problems:
1. `getCategoriesVisibilityStatus` already has categoryId for those hidden models. Changed `getSubModels` to accept `categoryId` with `modelIds`. (This already fixes the problem without changing iModel structure).
2. Changed the structure of the iModel. Now it has one root definition container, this root container has 50 child definition containers, and each child definition container has 1k categories.