### PR TITLE
[Tree widget]: fix "no current row" error

### DIFF
--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/VisibilityUtils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/VisibilityUtils.ts
@@ -217,13 +217,13 @@ export async function loadCategoriesFromViewport(vp: TreeWidgetViewport) {
 
   const categories: CategoryInfo[] = [];
   const rows = await (async () => {
-      const result = new Array<Id64String>();
-      for await (const row of vp.iModel.createQueryReader(ecsql, undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames })) {
-        result.push(row.id);
-      }
-      return result;
-    })();
-    (await vp.iModel.categories.getCategoryInfo(rows)).forEach((val) => {
+    const result = new Array<Id64String>();
+    for await (const row of vp.iModel.createQueryReader(ecsql, undefined, { rowFormat: QueryRowFormat.UseJsPropertyNames })) {
+      result.push(row.id);
+    }
+    return result;
+  })();
+  (await vp.iModel.categories.getCategoryInfo(rows)).forEach((val) => {
     categories.push({ categoryId: val.id, subCategoryIds: val.subCategories.size ? [...val.subCategories.keys()] : undefined });
   });
   return categories;


### PR DESCRIPTION
Previously, using `CategoriesTreeComponent` would cause this error to be logged to console:
<img width="745" height="95" alt="image" src="https://github.com/user-attachments/assets/938e5274-fd3e-4e40-bc53-f4dfc2fe2a73" />
This was happening due to how we were loading and accessing queried rows.
Before:
```ts
const rows = await (async () => {
    const result = new Array<any>();
    for await (const row of vp.iModel.createQueryReader(...) {
      result.push(row);
    }
    return result;
  })();
  const ids = rows.map((row) => row.id));
  ```
  After:
  ```ts
const ids = await (async () => {
    const result = new Array<string>();
    for await (const row of vp.iModel.createQueryReader(...) {
      result.push(row.id);
    }
    return result;
  })();
  ```