### PR TITLE
Tree widget: Remove limit when filtering classifications tree by target items

### DIFF
--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/UseClassificationsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/UseClassificationsTreeDefinition.ts
@@ -93,6 +93,7 @@ export function useClassificationsTreeDefinition(props: UseClassificationsTreeDe
             }),
             imodelAccess,
             abortSignal,
+            limit: typeof searchTerm !== "string" ? "unbounded" : undefined,
             ...(typeof searchTerm === "string" ? { label: searchTerm } : { targetItems: searchTerm }),
           }),
         ),


### PR DESCRIPTION
Remove filter targets limit when filtering tree by target item keys.