### PR TITLE
[Tree widget]: Cleanup visibility tests

### DIFF
--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -43,7 +43,7 @@
     "lint:stylelint": "stylelint \"./src/**/*.css\"",
     "lint:fix": "npm run lint:eslint -- --fix && npm run lint:stylelint -- --fix",
     "pseudolocalize": "betools pseudolocalize --englishDir ./public/locales/en --out ./lib/public/locales/en-PSEUDO",
-    "test:dev": "node --experimental-test-module-mocks --enable-source-maps --import ../../../node-hooks/ignore-styles/register.cjs ./node_modules/mocha/bin/mocha.js --config ./.mocharc.json",
+    "test:dev": "cross-env NODE_ENV=development node --experimental-test-module-mocks --enable-source-maps --import ../../../node-hooks/ignore-styles/register.cjs ./node_modules/mocha/bin/mocha.js --config ./.mocharc.json",
     "test": "npm run test:dev -- --parallel --jobs=4",
     "test:e2e": "node ../../../scripts/run-e2e-with-docker.js tree-widget",
     "test:e2e:local": "node ../../../scripts/run-e2e-tests.js",

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../../../IModelUtils.js";
 import { TestUtils } from "../../../TestUtils.js";
 import { createIModelAccess } from "../../Common.js";
+import { validateHierarchyVisibility } from "../../common/VisibilityValidation.js";
 import { createTreeWidgetTestingViewport } from "../../TreeUtils.js";
 import {
   createCategoryHierarchyNode,
@@ -39,15 +40,16 @@ import {
   createSubCategoryHierarchyNode,
   createSubModelCategoryHierarchyNode,
 } from "./Utils.js";
-import { validateHierarchyVisibility } from "./VisibilityValidation.js";
+import { validateNodeVisibility } from "./VisibilityValidation.js";
 
 import type { Id64Arg, Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { InstanceKey } from "@itwin/presentation-common";
 import type { GroupingHierarchyNode, HierarchyNodeIdentifiersPath, NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
+import type { Props } from "@itwin/presentation-shared";
 import type { CategoriesTreeHierarchyConfiguration } from "../../../../tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.js";
+import type { VisibilityExpectations } from "../../common/VisibilityValidation.js";
 import type { TreeWidgetTestingViewport } from "../../TreeUtils.js";
-import type { VisibilityExpectations } from "./VisibilityValidation.js";
 
 describe("CategoriesTreeVisibilityHandler", () => {
   before(async () => {
@@ -165,7 +167,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
       });
       const { handler, provider, viewport } = visibilityTestData;
 
-      await validateHierarchyVisibility({
+      await validateCategoriesTreeHierarchyVisibility({
         provider,
         handler,
         viewport,
@@ -205,7 +207,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -259,18 +261,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "visible",
-            [keys.definitionContainerChild.id]: "visible",
-            [keys.indirectCategory.id]: "visible",
-            [keys.indirectSubCategory.id]: "visible",
+              [keys.definitionContainerChild.id]: "visible",
+                [keys.indirectCategory.id]: "visible",
+                  [keys.indirectSubCategory.id]: "visible",
+
             [keys.definitionContainerRoot2.id]: "hidden",
-            [keys.category2.id]: "hidden",
-            [keys.subCategory2.id]: "hidden",
+              [keys.category2.id]: "hidden",
+                [keys.subCategory2.id]: "hidden",
           },
         });
       });
@@ -299,15 +303,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.definitionContainerChild.id]: "visible",
-            [keys.directCategory.id]: "hidden",
-            [keys.indirectCategory.id]: "visible",
+              [keys.directCategory.id]: "hidden",
+
+              [keys.definitionContainerChild.id]: "visible",
+                [keys.indirectCategory.id]: "visible",
           },
         });
       });
@@ -338,16 +344,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.definitionContainerChild.id]: "visible",
-            [keys.definitionContainerChild2.id]: "hidden",
-            [keys.indirectCategory2.id]: "hidden",
-            [keys.indirectCategory.id]: "visible",
+              [keys.definitionContainerChild.id]: "visible",
+                [keys.indirectCategory.id]: "visible",
+
+              [keys.definitionContainerChild2.id]: "hidden",
+                [keys.indirectCategory2.id]: "hidden",
           },
         });
       });
@@ -380,7 +388,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -413,7 +421,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -454,15 +462,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
-            [keys.category2.id]: "hidden",
             [keys.category.id]: "visible",
-            [keys.subCategory2.id]: "hidden",
-            [keys.subCategory.id]: "visible",
+              [keys.subCategory.id]: "visible",
+
+            [keys.category2.id]: "hidden",
+              [keys.subCategory2.id]: "hidden",
           },
         });
       });
@@ -504,16 +514,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainer.id]: "hidden",
-            [keys.category2.id]: "hidden",
-            [keys.category.id]: "visible",
-            [keys.subCategory2.id]: "hidden",
-            [keys.subCategory.id]: "visible",
+              [keys.category.id]: "visible",
+                [keys.subCategory.id]: "visible",
+
+              [keys.category2.id]: "hidden",
+                [keys.subCategory2.id]: "hidden",
           },
         });
       });
@@ -555,16 +567,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.category2.id]: "hidden",
-            [keys.category.id]: "visible",
-            [keys.subCategory2.id]: "hidden",
-            [keys.subCategory.id]: "visible",
+              [keys.category.id]: "visible",
+                [keys.subCategory.id]: "visible",
+
+              [keys.category2.id]: "hidden",
+                [keys.subCategory2.id]: "hidden",
           },
         });
       });
@@ -600,16 +614,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.definitionContainerChild.id]: "hidden",
-            [keys.indirectCategory.id]: "hidden",
-            [keys.category.id]: "visible",
-            [keys.subCategory.id]: "visible",
+              [keys.category.id]: "visible",
+                [keys.subCategory.id]: "visible",
+
+              [keys.definitionContainerChild.id]: "hidden",
+                [keys.indirectCategory.id]: "hidden",
           },
         });
       });
@@ -646,14 +662,15 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.category.id]: "partial",
-            [keys.subCategory.id]: "visible",
-            [keys.subCategory2.id]: "hidden",
+              [keys.subCategory.id]: "visible",
+              [keys.subCategory2.id]: "hidden",
           },
         });
       });
@@ -683,14 +700,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
-            [keys.category2.id]: "hidden",
             [keys.category.id]: "partial",
-            [keys.subCategory.id]: "visible",
+              [keys.subCategory.id]: "visible",
+
+            [keys.category2.id]: "hidden",
           },
         });
       });
@@ -721,14 +740,15 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.category.id]: "partial",
-            [keys.subCategory.id]: "visible",
+              [keys.category.id]: "partial",
+                [keys.subCategory.id]: "visible",
           },
         });
       });
@@ -769,16 +789,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "hidden",
-            [keys.categoryOfDefinitionContainer.id]: "hidden",
-            [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+              [keys.categoryOfDefinitionContainer.id]: "hidden",
+                [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+
             [keys.category.id]: "partial",
-            [keys.subCategory.id]: "visible",
+              [keys.subCategory.id]: "visible",
           },
         });
       });
@@ -818,7 +840,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
@@ -875,20 +897,22 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
-              [keys.definitionContainerRoot2.id]: "hidden",
               [keys.definitionContainerRoot.id]: "visible",
-              [keys.definitionContainerChild.id]: "visible",
-              [keys.category2.id]: "hidden",
-              [keys.element2.id]: "hidden",
-              [keys.indirectCategory.id]: "visible",
-              [keys.indirectElement.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.indirectSubCategory.id]: "visible",
+                [keys.definitionContainerChild.id]: "visible",
+                  [keys.indirectCategory.id]: "visible",
+                    [keys.indirectElement.id]: "visible",
+                    [keys.indirectSubCategory.id]: "visible",
+
+              [keys.definitionContainerRoot2.id]: "hidden",
+                [keys.category2.id]: "hidden",
+                  [keys.element2.id]: "hidden",
+                  [keys.subCategory2.id]: "hidden",
             },
           });
         });
@@ -918,17 +942,19 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "visible",
-              [keys.directCategory.id]: "hidden",
-              [keys.indirectCategory.id]: "visible",
-              [keys.indirectElement.id]: "visible",
-              [keys.directElement.id]: "hidden",
+                [keys.directCategory.id]: "hidden",
+                  [keys.directElement.id]: "hidden",
+
+                [keys.definitionContainerChild.id]: "visible",
+                  [keys.indirectCategory.id]: "visible",
+                    [keys.indirectElement.id]: "visible",
             },
           });
         });
@@ -973,18 +999,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "visible",
-              [keys.definitionContainerChild2.id]: "hidden",
-              [keys.indirectCategory2.id]: "hidden",
-              [keys.indirectCategory.id]: "visible",
-              [keys.indirectElement.id]: "visible",
-              [keys.indirectElement2.id]: "hidden",
+                [keys.definitionContainerChild.id]: "visible",
+                  [keys.indirectCategory.id]: "visible",
+                    [keys.indirectElement.id]: "visible",
+
+                [keys.definitionContainerChild2.id]: "hidden",
+                  [keys.indirectCategory2.id]: "hidden",
+                    [keys.indirectElement2.id]: "hidden",
             },
           });
         });
@@ -1018,7 +1046,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
@@ -1052,7 +1080,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
@@ -1094,17 +1122,19 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
-              [keys.category2.id]: "hidden",
               [keys.category.id]: "visible",
-              [keys.element.id]: "visible",
-              [keys.element2.id]: "hidden",
-              [keys.subCategory2.id]: "hidden",
-              [keys.subCategory.id]: "visible",
+                [keys.element.id]: "visible",
+                [keys.subCategory.id]: "visible",
+
+              [keys.category2.id]: "hidden",
+                [keys.element2.id]: "hidden",
+                [keys.subCategory2.id]: "hidden",
             },
           });
         });
@@ -1147,18 +1177,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
-              [keys.definitionContainer.id]: "hidden",
-              [keys.category2.id]: "hidden",
               [keys.category.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.subCategory.id]: "visible",
-              [keys.element.id]: "visible",
-              [keys.element2.id]: "hidden",
+                [keys.subCategory.id]: "visible",
+                [keys.element.id]: "visible",
+
+              [keys.definitionContainer.id]: "hidden",
+                [keys.category2.id]: "hidden",
+                  [keys.subCategory2.id]: "hidden",
+                  [keys.element2.id]: "hidden",
             },
           });
         });
@@ -1201,18 +1233,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "partial",
-              [keys.category2.id]: "hidden",
-              [keys.category.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.subCategory.id]: "visible",
-              [keys.element2.id]: "hidden",
-              [keys.element.id]: "visible",
+                [keys.category.id]: "visible",
+                  [keys.subCategory.id]: "visible",
+                  [keys.element.id]: "visible",
+
+                [keys.category2.id]: "hidden",
+                  [keys.subCategory2.id]: "hidden",
+                  [keys.element2.id]: "hidden",
             },
           });
         });
@@ -1249,18 +1283,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           const { handler, provider, viewport } = visibilityTestData;
 
           await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "hidden",
-              [keys.indirectCategory.id]: "hidden",
-              [keys.category.id]: "visible",
-              [keys.subCategory.id]: "visible",
-              [keys.indirectElement.id]: "hidden",
-              [keys.element.id]: "visible",
+                [keys.definitionContainerChild.id]: "hidden",
+                  [keys.indirectCategory.id]: "hidden",
+                    [keys.indirectElement.id]: "hidden",
+
+                [keys.category.id]: "visible",
+                  [keys.subCategory.id]: "visible",
+                  [keys.element.id]: "visible",
             },
           });
         });
@@ -1297,15 +1333,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
           setupInitialDisplayState({ viewport, elements: [{ id: keys.element.id, visible: false }] });
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
 
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-              [keys.element.id]: "hidden",
+                [keys.subCategory.id]: "visible",
+                [keys.subCategory2.id]: "hidden",
+                [keys.element.id]: "hidden",
             },
           });
         });
@@ -1343,16 +1380,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
-              [keys.category2.id]: "hidden",
               [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [keys.element.id]: "hidden",
-              [keys.element2.id]: "hidden",
+                [keys.subCategory.id]: "visible",
+                [keys.element.id]: "hidden",
+
+              [keys.category2.id]: "hidden",
+                [keys.element2.id]: "hidden",
             },
           });
         });
@@ -1385,15 +1424,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
           setupInitialDisplayState({ viewport, elements: [{ id: keys.element.id, visible: false }] });
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [keys.element.id]: "hidden",
+                [keys.category.id]: "partial",
+                  [keys.subCategory.id]: "visible",
+                  [keys.element.id]: "hidden",
             },
           });
         });
@@ -1451,18 +1491,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "hidden",
-              [keys.categoryOfDefinitionContainer.id]: "hidden",
-              [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+                [keys.categoryOfDefinitionContainer.id]: "hidden",
+                  [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+                  [keys.elementOfDefinitionContainer.id]: "hidden",
+
               [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [keys.element.id]: "hidden",
-              [keys.elementOfDefinitionContainer.id]: "hidden",
+                [keys.subCategory.id]: "visible",
+                [keys.element.id]: "hidden",
             },
           });
         });
@@ -1503,16 +1545,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
             true,
           );
 
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-              [keys.subCategory2.id]: "hidden",
-              [keys.element.id]: "visible",
-              [keys.element2.id]: "hidden",
+                [keys.subCategory.id]: "hidden",
+                [keys.subCategory2.id]: "hidden",
+                [keys.element.id]: "visible",
+                [keys.element2.id]: "hidden",
             },
           });
         });
@@ -1546,16 +1589,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
             createElementHierarchyNode({ modelId: keys.physicalModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
             true,
           );
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
-              [keys.category2.id]: "hidden",
               [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-              [keys.element.id]: "visible",
-              [keys.element2.id]: "hidden",
+                [keys.subCategory.id]: "hidden",
+                [keys.element.id]: "visible",
+
+              [keys.category2.id]: "hidden",
+                [keys.element2.id]: "hidden",
             },
           });
         });
@@ -1590,15 +1635,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
             createElementHierarchyNode({ modelId: keys.physicalModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
             true,
           );
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-              [keys.element.id]: "visible",
+                [keys.category.id]: "partial",
+                  [keys.subCategory.id]: "hidden",
+                  [keys.element.id]: "visible",
             },
           });
         });
@@ -1657,18 +1703,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), true);
-          await validateHierarchyVisibility({
+          await validateCategoriesTreeHierarchyVisibility({
             provider,
             handler,
             viewport,
+            // prettier-ignore
             expectations: {
               [keys.definitionContainerRoot.id]: "hidden",
-              [keys.categoryOfDefinitionContainer.id]: "hidden",
-              [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+                [keys.categoryOfDefinitionContainer.id]: "hidden",
+                  [keys.subCategoryOfDefinitionContainer.id]: "hidden",
+                  [keys.elementOfDefinitionContainer.id]: "hidden",
+
               [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [keys.element.id]: "hidden",
-              [keys.elementOfDefinitionContainer.id]: "hidden",
+                [keys.subCategory.id]: "visible",
+                [keys.element.id]: "hidden",
             },
           });
         });
@@ -1731,13 +1779,14 @@ describe("CategoriesTreeVisibilityHandler", () => {
               name: "modeled element's children display is turned on when its class grouping node display is turned on",
               getTargetNode: (ids: IModelWithSubModelIds) =>
                 createClassGroupingHierarchyNode({ categoryId: ids.category.id, modelElementsMap: new Map([[ids.model.id, [ids.modeledElement.id]]]) }),
+              // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "visible",
 
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "visible",
-                [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                [ids.subModelElement?.id ?? ""]: "visible",
+                  [ids.modeledElement.id]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
+                      [ids.subModelElement?.id ?? ""]: "visible",
               }),
             },
             {
@@ -1749,37 +1798,40 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   elementId: ids.modeledElement.id,
                   hasChildren: true,
                 }),
+              // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "visible",
 
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "visible",
-                [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                [ids.subModelElement?.id ?? ""]: "visible",
+                  [ids.modeledElement.id]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
+                      [ids.subModelElement?.id ?? ""]: "visible",
               }),
             },
             {
               name: "modeled element's children display is turned on when its sub-model display is turned on",
               getTargetNode: (ids: IModelWithSubModelIds) => createModelHierarchyNode(ids.modeledElement.id, true),
+              // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "visible",
 
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "partial",
-                [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                [ids.subModelElement?.id ?? ""]: "visible",
+                  [ids.modeledElement.id]: "partial",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
+                      [ids.subModelElement?.id ?? ""]: "visible",
               }),
             },
             {
               name: "modeled element, its model and category have partial visibility when its sub-model element's category display is turned on",
               getTargetNode: (ids: IModelWithSubModelIds) => createSubModelCategoryHierarchyNode(ids.modeledElement.id, ids.subModelCategory?.id, true),
+              // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "visible",
 
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "partial",
-                [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                [ids.subModelElement?.id ?? ""]: "visible",
+                  [ids.modeledElement.id]: "partial",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
+                      [ids.subModelElement?.id ?? ""]: "visible",
               }),
             },
             {
@@ -1790,13 +1842,14 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   categoryId: ids.subModelCategory?.id,
                   elementId: ids.subModelElement?.id,
                 }),
+              // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "partial",
 
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "partial",
-                [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                [ids.subModelElement?.id ?? ""]: "visible",
+                  [ids.modeledElement.id]: "partial",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
+                      [ids.subModelElement?.id ?? ""]: "visible",
               }),
             },
           ],
@@ -1833,11 +1886,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
             {
               name: "children are visible when category display is turned on",
               getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode(ids.category.id, true),
+              // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "hidden",
 
                 [ids.category.id]: "visible",
-                [ids.modeledElement.id]: "visible",
+                  [ids.modeledElement.id]: "visible",
               }),
             },
             {
@@ -1845,11 +1899,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) =>
                 createClassGroupingHierarchyNode({ categoryId: ids.category.id, modelElementsMap: new Map([[ids.model.id, [ids.modeledElement.id]]]) }),
               // Category has partial visibility, since its sub-category is not visible
+              // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "hidden",
 
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "visible",
+                  [ids.modeledElement.id]: "visible",
               }),
             },
             {
@@ -1862,11 +1917,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   hasChildren: false,
                 }),
               // Category has partial visibility, since its sub-category is not visible
+              //prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
                 [ids.subModelCategory?.id ?? ""]: "hidden",
 
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "visible",
+                  [ids.modeledElement.id]: "visible",
               }),
             },
           ],
@@ -1907,9 +1963,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) =>
                 createClassGroupingHierarchyNode({ categoryId: ids.category.id, modelElementsMap: new Map([[ids.model.id, [ids.modeledElement.id]]]) }),
               // Category has partial visibility, since its sub-category is not visible
+              // prettier-ignore
               expectations: (ids) => ({
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "visible",
+                  [ids.modeledElement.id]: "visible",
               }),
             },
             {
@@ -1922,9 +1979,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   hasChildren: false,
                 }),
               // Category has partial visibility, since its sub-category is not visible
+              // prettier-ignore
               expectations: (ids) => ({
                 [ids.category.id]: "partial",
-                [ids.modeledElement.id]: "visible",
+                  [ids.modeledElement.id]: "visible",
               }),
             },
           ],
@@ -1954,21 +2012,21 @@ describe("CategoriesTreeVisibilityHandler", () => {
               const { handler, provider, viewport } = visibilityTestData;
 
               const nodeToChangeVisibility = getTargetNode(createdIds);
-              await validateHierarchyVisibility({
+              await validateCategoriesTreeHierarchyVisibility({
                 provider,
                 handler,
                 viewport,
                 expectations: "all-hidden",
               });
               await handler.changeVisibility(nodeToChangeVisibility, true);
-              await validateHierarchyVisibility({
+              await validateCategoriesTreeHierarchyVisibility({
                 provider,
                 handler,
                 viewport,
                 expectations: expectations(createdIds),
               });
               await handler.changeVisibility(nodeToChangeVisibility, false);
-              await validateHierarchyVisibility({
+              await validateCategoriesTreeHierarchyVisibility({
                 provider,
                 handler,
                 viewport,
@@ -2002,7 +2060,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           override: "show",
         });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2039,7 +2097,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           override: "show",
         });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2068,7 +2126,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: true });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2095,7 +2153,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: true });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2128,7 +2186,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
       });
       const { handler, provider, viewport } = visibilityTestData;
 
-      await validateHierarchyVisibility({
+      await validateCategoriesTreeHierarchyVisibility({
         provider,
         handler,
         viewport,
@@ -2168,7 +2226,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2222,18 +2280,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerRoot.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
-            [keys.definitionContainerRoot2.id]: "visible",
             [keys.definitionContainerRoot.id]: "hidden",
-            [keys.definitionContainerChild.id]: "hidden",
-            [keys.indirectCategory.id]: "hidden",
-            [keys.category2.id]: "visible",
-            [keys.indirectSubCategory.id]: "hidden",
-            [keys.subCategory2.id]: "visible",
+              [keys.definitionContainerChild.id]: "hidden",
+                [keys.indirectCategory.id]: "hidden",
+                  [keys.indirectSubCategory.id]: "hidden",
+
+            [keys.definitionContainerRoot2.id]: "visible",
+              [keys.category2.id]: "visible",
+                [keys.subCategory2.id]: "visible",
           },
         });
       });
@@ -2259,15 +2319,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.definitionContainerChild.id]: "hidden",
-            [keys.indirectCategory.id]: "hidden",
-            [keys.directCategory.id]: "visible",
+              [keys.directCategory.id]: "visible",
+
+              [keys.definitionContainerChild.id]: "hidden",
+                [keys.indirectCategory.id]: "hidden",
           },
         });
       });
@@ -2295,16 +2357,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.definitionContainerChild.id]: "hidden",
-            [keys.definitionContainerChild2.id]: "visible",
-            [keys.indirectCategory.id]: "hidden",
-            [keys.indirectCategory2.id]: "visible",
+              [keys.definitionContainerChild.id]: "hidden",
+                [keys.indirectCategory.id]: "hidden",
+
+              [keys.definitionContainerChild2.id]: "visible",
+                [keys.indirectCategory2.id]: "visible",
           },
         });
       });
@@ -2337,7 +2401,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createDefinitionContainerHierarchyNode(keys.definitionContainerChild.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2370,7 +2434,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2411,15 +2475,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.category.id]: "hidden",
+              [keys.subCategory.id]: "hidden",
+
             [keys.category2.id]: "visible",
-            [keys.subCategory2.id]: "visible",
-            [keys.subCategory.id]: "hidden",
+              [keys.subCategory2.id]: "visible",
           },
         });
       });
@@ -2461,16 +2527,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
-            [keys.definitionContainer.id]: "visible",
-            [keys.category2.id]: "visible",
             [keys.category.id]: "hidden",
-            [keys.subCategory2.id]: "visible",
-            [keys.subCategory.id]: "hidden",
+              [keys.subCategory.id]: "hidden",
+
+            [keys.definitionContainer.id]: "visible",
+              [keys.category2.id]: "visible",
+                [keys.subCategory2.id]: "visible",
           },
         });
       });
@@ -2512,16 +2580,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.category.id]: "hidden",
-            [keys.category2.id]: "visible",
-            [keys.subCategory.id]: "hidden",
-            [keys.subCategory2.id]: "visible",
+              [keys.category.id]: "hidden",
+                [keys.subCategory.id]: "hidden",
+
+              [keys.category2.id]: "visible",
+                [keys.subCategory2.id]: "visible",
           },
         });
       });
@@ -2557,16 +2627,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createCategoryHierarchyNode(keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.definitionContainerChild.id]: "visible",
-            [keys.category.id]: "hidden",
-            [keys.indirectCategory.id]: "visible",
-            [keys.subCategory.id]: "hidden",
+              [keys.category.id]: "hidden",
+                [keys.subCategory.id]: "hidden",
+
+              [keys.definitionContainerChild.id]: "visible",
+                [keys.indirectCategory.id]: "visible",
           },
         });
       });
@@ -2601,14 +2673,15 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.category.id]: "partial",
-            [keys.subCategory.id]: "hidden",
-            [keys.subCategory2.id]: "visible",
+              [keys.subCategory.id]: "hidden",
+              [keys.subCategory2.id]: "visible",
           },
         });
       });
@@ -2638,14 +2711,16 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.category.id]: "partial",
+              [keys.subCategory.id]: "hidden",
+
             [keys.category2.id]: "visible",
-            [keys.subCategory.id]: "hidden",
           },
         });
       });
@@ -2676,14 +2751,15 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "partial",
-            [keys.category.id]: "partial",
-            [keys.subCategory.id]: "hidden",
+              [keys.category.id]: "partial",
+                [keys.subCategory.id]: "hidden",
           },
         });
       });
@@ -2724,16 +2800,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createSubCategoryHierarchyNode(keys.subCategory.id, keys.category.id), false);
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.definitionContainerRoot.id]: "visible",
-            [keys.categoryOfDefinitionContainer.id]: "visible",
-            [keys.subCategoryOfDefinitionContainer.id]: "visible",
+              [keys.categoryOfDefinitionContainer.id]: "visible",
+                [keys.subCategoryOfDefinitionContainer.id]: "visible",
+
             [keys.category.id]: "partial",
-            [keys.subCategory.id]: "hidden",
+              [keys.subCategory.id]: "hidden",
           },
         });
       });
@@ -2760,7 +2838,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           override: "hide",
         });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2790,7 +2868,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           override: "hide",
         });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2818,7 +2896,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: false });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2844,7 +2922,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: false });
 
-        await validateHierarchyVisibility({
+        await validateCategoriesTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -2892,4 +2970,11 @@ function setupInitialDisplayState(props: {
   viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => visible).map(({ id }) => id), display: true });
   viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => !visible).map(({ id }) => id), display: false });
   viewport.renderFrame();
+}
+
+async function validateCategoriesTreeHierarchyVisibility(props: Omit<Props<typeof validateHierarchyVisibility>, "validateNodeVisibility">) {
+  return validateHierarchyVisibility({
+    ...props,
+    validateNodeVisibility,
+  });
 }

--- a/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeVisibilityHandler.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../IModelUtils.js";
 import { initializeITwinJs, terminateITwinJs } from "../../Initialize.js";
 import { createIModelAccess } from "../Common.js";
+import { validateHierarchyVisibility } from "../common/VisibilityValidation.js";
 import { createTreeWidgetTestingViewport } from "../TreeUtils.js";
 import {
   createClassificationHierarchyNode,
@@ -34,11 +35,11 @@ import {
   insertClassificationTable,
   insertElementHasClassificationsRelationship,
 } from "./Utils.js";
-import { validateHierarchyVisibility } from "./VisibilityValidation.js";
+import { validateNodeVisibility } from "./VisibilityValidation.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyNodeIdentifiersPath, HierarchySearchPath } from "@itwin/presentation-hierarchies";
-import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
+import type { ECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
 import type { ClassificationsTreeSearchTargets } from "../../../tree-widget-react/components/trees/classifications-tree/internal/visibility/SearchResultsTree.js";
 import type { SearchResultsTree } from "../../../tree-widget-react/components/trees/common/internal/visibility/BaseSearchResultsTree.js";
 import type { TreeWidgetViewport } from "../../../tree-widget-react/components/trees/common/TreeWidgetViewport.js";
@@ -128,7 +129,7 @@ describe("ClassificationsTreeVisibilityHandler", () => {
       });
       const { handler, provider, viewport } = visibilityTestData;
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider,
         handler,
         viewport,
@@ -170,7 +171,7 @@ describe("ClassificationsTreeVisibilityHandler", () => {
       });
       const { handler, provider, viewport } = visibilityTestData;
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider,
         handler,
         viewport,
@@ -216,7 +217,7 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createClassificationTableHierarchyNode({ id: keys.table.id }), true);
-        await validateHierarchyVisibility({
+        await validateClassificationsTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -269,7 +270,7 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createClassificationHierarchyNode({ id: keys.childClassification.id }), true);
-        await validateHierarchyVisibility({
+        await validateClassificationsTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -348,18 +349,20 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createClassificationHierarchyNode({ id: keys.childClassification1.id }), true);
-        await validateHierarchyVisibility({
+        await validateClassificationsTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.table.id]: "partial",
-            [keys.parentClassification.id]: "partial",
-            [keys.childClassification1.id]: "visible",
-            [keys.parentPhysicalElement1.id]: "visible",
-            [keys.childPhysicalElement1.id]: "visible",
-            [keys.childClassification2.id]: "hidden",
-            [keys.parentPhysicalElement2.id]: "hidden",
+              [keys.parentClassification.id]: "partial",
+                [keys.childClassification1.id]: "visible",
+                  [keys.parentPhysicalElement1.id]: "visible",
+                    [keys.childPhysicalElement1.id]: "visible",
+
+                [keys.childClassification2.id]: "hidden",
+                  [keys.parentPhysicalElement2.id]: "hidden",
           },
         });
       });
@@ -436,18 +439,20 @@ describe("ClassificationsTreeVisibilityHandler", () => {
           createPhysicalElementHierarchyNode({ id: keys.targetPhysicalElement.id, categoryId: keys.spatialCategory.id, modelId: keys.physicalModel.id }),
           true,
         );
-        await validateHierarchyVisibility({
+        await validateClassificationsTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.table.id]: "partial",
-            [keys.parentClassification.id]: "partial",
-            [keys.childClassification.id]: "partial",
-            [keys.parentPhysicalElement.id]: "hidden",
-            [keys.siblingPhysicalElement.id]: "hidden",
-            [keys.targetPhysicalElement.id]: "visible",
-            [keys.childPhysicalElement.id]: "hidden",
+              [keys.parentClassification.id]: "partial",
+                [keys.childClassification.id]: "partial",
+                  [keys.parentPhysicalElement.id]: "hidden",
+                    [keys.siblingPhysicalElement.id]: "hidden",
+
+                    [keys.targetPhysicalElement.id]: "visible",
+                      [keys.childPhysicalElement.id]: "hidden",
           },
         });
       });
@@ -491,7 +496,7 @@ describe("ClassificationsTreeVisibilityHandler", () => {
       });
       const { handler, provider, viewport } = visibilityTestData;
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider,
         handler,
         viewport,
@@ -535,7 +540,7 @@ describe("ClassificationsTreeVisibilityHandler", () => {
       });
       const { handler, provider, viewport } = visibilityTestData;
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider,
         handler,
         viewport,
@@ -581,7 +586,7 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createClassificationTableHierarchyNode({ id: keys.table.id }), false);
-        await validateHierarchyVisibility({
+        await validateClassificationsTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
@@ -663,25 +668,27 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const { handler, provider, viewport } = visibilityTestData;
 
         await handler.changeVisibility(createClassificationHierarchyNode({ id: keys.childClassification1.id }), false);
-        await validateHierarchyVisibility({
+        await validateClassificationsTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.table.id]: "partial",
-            [keys.parentClassification.id]: "partial",
-            [keys.childClassification1.id]: "hidden",
-            [keys.parentPhysicalElement1.id]: "hidden",
-            [keys.childPhysicalElement1.id]: "hidden",
-            [keys.childClassification2.id]: "visible",
-            [keys.parentPhysicalElement2.id]: "visible",
+              [keys.parentClassification.id]: "partial",
+                [keys.childClassification1.id]: "hidden",
+                  [keys.parentPhysicalElement1.id]: "hidden",
+                    [keys.childPhysicalElement1.id]: "hidden",
+
+                [keys.childClassification2.id]: "visible",
+                  [keys.parentPhysicalElement2.id]: "visible",
           },
         });
       });
     });
 
     describe("geometric element", () => {
-      it("hiding geometric element makes ancestors partially visible, and the element hidden", async function () {
+      it("hiding geometric element makes ancestors partially visible, element and its children hidden", async function () {
         await using buildIModelResult = await buildIModel(this, async (builder) => {
           await importClassificationSchema(builder);
 
@@ -752,25 +759,27 @@ describe("ClassificationsTreeVisibilityHandler", () => {
           createPhysicalElementHierarchyNode({ id: keys.targetPhysicalElement.id, categoryId: keys.spatialCategory.id, modelId: keys.physicalModel.id }),
           false,
         );
-        await validateHierarchyVisibility({
+        await validateClassificationsTreeHierarchyVisibility({
           provider,
           handler,
           viewport,
+          // prettier-ignore
           expectations: {
             [keys.table.id]: "partial",
-            [keys.parentClassification.id]: "partial",
-            [keys.childClassification.id]: "partial",
-            [keys.parentPhysicalElement.id]: "visible",
-            [keys.siblingPhysicalElement.id]: "visible",
-            [keys.targetPhysicalElement.id]: "hidden",
-            [keys.childPhysicalElement.id]: "visible",
+              [keys.parentClassification.id]: "partial",
+                [keys.childClassification.id]: "partial",
+                  [keys.parentPhysicalElement.id]: "visible",
+                    [keys.siblingPhysicalElement.id]: "visible",
+
+                    [keys.targetPhysicalElement.id]: "hidden",
+                      [keys.childPhysicalElement.id]: "visible",
           },
         });
       });
     });
   });
 
-  describe("filtered nodes", () => {
+  describe("search nodes", () => {
     async function createFilteredVisibilityTestData({
       imodel,
       searchPaths,
@@ -788,26 +797,29 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         viewType: view,
         visibleByDefault,
       });
-      const handler = createClassificationsTreeVisibilityHandler({ idsCache, viewport, imodelAccess, searchPaths });
+      const visibilityHandlerWithSearchPaths = createClassificationsTreeVisibilityHandler({ idsCache, searchPaths, imodelAccess, viewport });
+      const defaultVisibilityHandler = createClassificationsTreeVisibilityHandler({ idsCache, imodelAccess, viewport });
       const defaultProvider = createProvider({ idsCache, imodelAccess });
-      const filteredProvider = createProvider({ idsCache, imodelAccess, searchPaths });
+      const providerWithSearchPaths = createProvider({ idsCache, imodelAccess, searchPaths });
       return {
-        handler,
+        defaultVisibilityHandler,
+        visibilityHandlerWithSearchPaths,
         defaultProvider,
-        filteredProvider,
+        providerWithSearchPaths,
         imodel,
         imodelAccess,
         viewport,
         [Symbol.dispose]() {
           idsCache[Symbol.dispose]();
-          handler[Symbol.dispose]();
+          defaultVisibilityHandler[Symbol.dispose]();
+          visibilityHandlerWithSearchPaths[Symbol.dispose]();
           defaultProvider[Symbol.dispose]();
-          filteredProvider[Symbol.dispose]();
+          providerWithSearchPaths[Symbol.dispose]();
         },
       };
     }
 
-    it("showing filtered geometric element changes visibility for nodes in search paths", async function () {
+    it("showing parent geometric element of search target changes visibility for nodes in search paths", async function () {
       await using buildIModelResult = await buildIModel(this, async (builder) => {
         await importClassificationSchema(builder);
 
@@ -817,29 +829,45 @@ describe("ClassificationsTreeVisibilityHandler", () => {
 
         const physicalModel = insertPhysicalModelWithPartition({ builder, codeValue: "physical model" });
         const spatialCategory = insertSpatialCategory({ builder, codeValue: "spatial category" });
-        const element1 = insertPhysicalElement({
+        const parentOfSearchTargetElement = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory.id,
-          codeValue: "3d element1",
+          codeValue: "3d parent of search target",
         });
-        const element2 = insertPhysicalElement({
+        const searchTargetChildElement = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory.id,
-          codeValue: "3d element2",
+          codeValue: "3d search target",
+          parentId: parentOfSearchTargetElement.id,
         });
-        insertElementHasClassificationsRelationship({ builder, elementId: element1.id, classificationId: classification.id });
-        insertElementHasClassificationsRelationship({ builder, elementId: element2.id, classificationId: classification.id });
+        const childElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory.id,
+          codeValue: "3d child",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const siblingElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory.id,
+          codeValue: "3d sibling",
+        });
+        insertElementHasClassificationsRelationship({ builder, elementId: parentOfSearchTargetElement.id, classificationId: classification.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: siblingElement.id, classificationId: classification.id });
 
         return {
           table,
           classification,
           physicalModel,
           spatialCategory,
-          element1,
-          element2,
-          searchPaths: [[table, classification, element1]],
+          parentOfSearchTargetElement,
+          searchTargetChildElement,
+          childElement,
+          siblingElement,
+          searchPaths: [[table, classification, parentOfSearchTargetElement, searchTargetChildElement]],
         };
       });
 
@@ -849,42 +877,148 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         searchPaths,
         view: "3d",
       });
-      const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
+      const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
 
-      await handler.changeVisibility(
+      await visibilityHandlerWithSearchPaths.changeVisibility(
         createPhysicalElementHierarchyNode({
-          id: keys.element1.id,
+          id: keys.parentOfSearchTargetElement.id,
           categoryId: keys.spatialCategory.id,
           modelId: keys.physicalModel.id,
+          parentKeys: [keys.table, keys.classification],
           search: {
-            isSearchTarget: true,
-            childrenTargetPaths: [],
+            isSearchTarget: false,
+            childrenTargetPaths: [[keys.searchTargetChildElement]],
           },
         }),
         true,
       );
 
-      await validateHierarchyVisibility({
-        provider: filteredProvider,
-        handler,
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: providerWithSearchPaths,
+        handler: visibilityHandlerWithSearchPaths,
         viewport,
         expectations: "all-visible",
       });
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider: defaultProvider,
-        handler,
+        handler: defaultVisibilityHandler,
         viewport,
+        // prettier-ignore
         expectations: {
           [keys.table.id]: "partial",
-          [keys.classification.id]: "partial",
-          [keys.element1.id]: "visible",
-          [keys.element2.id]: "hidden",
+            [keys.classification.id]: "partial",
+              [keys.siblingElement.id]: "hidden",
+
+              [keys.parentOfSearchTargetElement.id]: "visible",
+                [keys.searchTargetChildElement.id]: "visible",
+                [keys.childElement.id]: "hidden",
         },
       });
     });
 
-    it("showing filtered drawing element changes visibility for nodes in search paths", async function () {
+    it("showing search target geometric element changes visibility for nodes in search paths", async function () {
+      await using buildIModelResult = await buildIModel(this, async (builder) => {
+        await importClassificationSchema(builder);
+
+        const system = insertClassificationSystem({ builder, codeValue: rootClassificationSystemCode });
+        const table = insertClassificationTable({ builder, parentId: system.id, codeValue: "ClassificationTable" });
+        const classification = insertClassification({ builder, modelId: table.id, codeValue: "Classification" });
+
+        const physicalModel = insertPhysicalModelWithPartition({ builder, codeValue: "physical model" });
+        const spatialCategory = insertSpatialCategory({ builder, codeValue: "spatial category" });
+        const parentOfSearchTargetElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory.id,
+          codeValue: "3d parent of search target",
+        });
+        const searchTargetChildElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory.id,
+          codeValue: "3d search target child",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const childElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory.id,
+          codeValue: "3d child",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const siblingElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory.id,
+          codeValue: "3d sibling",
+        });
+        insertElementHasClassificationsRelationship({ builder, elementId: parentOfSearchTargetElement.id, classificationId: classification.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: siblingElement.id, classificationId: classification.id });
+
+        return {
+          table,
+          classification,
+          physicalModel,
+          spatialCategory,
+          parentOfSearchTargetElement,
+          searchTargetChildElement,
+          childElement,
+          siblingElement,
+          searchPaths: [[table, classification, parentOfSearchTargetElement, searchTargetChildElement]],
+        };
+      });
+
+      const { imodel, searchPaths, ...keys } = buildIModelResult;
+      using visibilityTestData = await createFilteredVisibilityTestData({
+        imodel,
+        searchPaths,
+        view: "3d",
+      });
+      const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+
+      await visibilityHandlerWithSearchPaths.changeVisibility(
+        createPhysicalElementHierarchyNode({
+          id: keys.searchTargetChildElement.id,
+          categoryId: keys.spatialCategory.id,
+          modelId: keys.physicalModel.id,
+          parentKeys: [keys.table, keys.classification, keys.parentOfSearchTargetElement],
+          search: { isSearchTarget: true },
+        }),
+        true,
+      );
+
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: providerWithSearchPaths,
+        handler: visibilityHandlerWithSearchPaths,
+        viewport,
+        // prettier-ignore
+        expectations: {
+          [keys.table.id]: "partial",
+            [keys.classification.id]: "partial",
+              [keys.parentOfSearchTargetElement.id]: "partial",
+                [keys.searchTargetChildElement.id]: "visible",
+        },
+      });
+
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: defaultProvider,
+        handler: defaultVisibilityHandler,
+        viewport,
+        // prettier-ignore
+        expectations: {
+          [keys.table.id]: "partial",
+            [keys.classification.id]: "partial",
+              [keys.siblingElement.id]: "hidden",
+
+              [keys.parentOfSearchTargetElement.id]: "hidden",
+                [keys.searchTargetChildElement.id]: "visible",
+                [keys.childElement.id]: "hidden",
+        },
+      });
+    });
+
+    it("showing parent drawing element of search target changes visibility for nodes in search paths", async function () {
       await using buildIModelResult = await buildIModel(this, async (builder) => {
         await importClassificationSchema(builder);
 
@@ -893,29 +1027,45 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const classification = insertClassification({ builder, modelId: table.id, codeValue: "Classification" });
         const drawingModel = insertDrawingModelWithPartition({ builder, codeValue: "drawing model" });
         const drawingCategory = insertDrawingCategory({ builder, codeValue: "drawing category" });
-        const element1 = insertDrawingGraphic({
+        const parentOfSearchTargetElement = insertDrawingGraphic({
           builder,
           modelId: drawingModel.id,
           categoryId: drawingCategory.id,
-          codeValue: "2d element1",
+          codeValue: "2d parent of search target",
         });
-        const element2 = insertDrawingGraphic({
+        const searchTargetChildElement = insertDrawingGraphic({
           builder,
           modelId: drawingModel.id,
           categoryId: drawingCategory.id,
-          codeValue: "2d element2",
+          codeValue: "2d search target",
+          parentId: parentOfSearchTargetElement.id,
         });
-        insertElementHasClassificationsRelationship({ builder, elementId: element1.id, classificationId: classification.id });
-        insertElementHasClassificationsRelationship({ builder, elementId: element2.id, classificationId: classification.id });
+        const childElement = insertDrawingGraphic({
+          builder,
+          modelId: drawingModel.id,
+          categoryId: drawingCategory.id,
+          codeValue: "2d child",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const siblingElement = insertDrawingGraphic({
+          builder,
+          modelId: drawingModel.id,
+          categoryId: drawingCategory.id,
+          codeValue: "2d sibling",
+        });
+        insertElementHasClassificationsRelationship({ builder, elementId: parentOfSearchTargetElement.id, classificationId: classification.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: siblingElement.id, classificationId: classification.id });
 
         return {
           table,
           classification,
           drawingModel,
           drawingCategory,
-          element1,
-          element2,
-          searchPaths: [[table, classification, element1]],
+          parentOfSearchTargetElement,
+          searchTargetChildElement,
+          childElement,
+          siblingElement,
+          searchPaths: [[table, classification, parentOfSearchTargetElement, searchTargetChildElement]],
         };
       });
 
@@ -925,42 +1075,147 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         searchPaths,
         view: "2d",
       });
-      const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
+      const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
 
-      await handler.changeVisibility(
+      await visibilityHandlerWithSearchPaths.changeVisibility(
         createDrawingElementHierarchyNode({
-          id: keys.element1.id,
+          id: keys.parentOfSearchTargetElement.id,
           categoryId: keys.drawingCategory.id,
           modelId: keys.drawingModel.id,
+          parentKeys: [keys.table, keys.classification],
           search: {
-            isSearchTarget: true,
-            childrenTargetPaths: [],
+            isSearchTarget: false,
+            childrenTargetPaths: [[keys.searchTargetChildElement]],
           },
         }),
         true,
       );
 
-      await validateHierarchyVisibility({
-        provider: filteredProvider,
-        handler,
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: providerWithSearchPaths,
+        handler: visibilityHandlerWithSearchPaths,
         viewport,
         expectations: "all-visible",
       });
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider: defaultProvider,
-        handler,
+        handler: defaultVisibilityHandler,
         viewport,
+        // prettier-ignore
         expectations: {
           [keys.table.id]: "partial",
-          [keys.classification.id]: "partial",
-          [keys.element1.id]: "visible",
-          [keys.element2.id]: "hidden",
+            [keys.classification.id]: "partial",
+              [keys.siblingElement.id]: "hidden",
+
+              [keys.parentOfSearchTargetElement.id]: "visible",
+                [keys.searchTargetChildElement.id]: "visible",
+                [keys.childElement.id]: "hidden",
         },
       });
     });
 
-    it("showing filtered classification changes visibility for nodes in search paths", async function () {
+    it("showing search target drawing element changes visibility for nodes in search paths", async function () {
+      await using buildIModelResult = await buildIModel(this, async (builder) => {
+        await importClassificationSchema(builder);
+
+        const system = insertClassificationSystem({ builder, codeValue: rootClassificationSystemCode });
+        const table = insertClassificationTable({ builder, parentId: system.id, codeValue: "ClassificationTable" });
+        const classification = insertClassification({ builder, modelId: table.id, codeValue: "Classification" });
+        const drawingModel = insertDrawingModelWithPartition({ builder, codeValue: "drawing model" });
+        const drawingCategory = insertDrawingCategory({ builder, codeValue: "drawing category" });
+        const parentOfSearchTargetElement = insertDrawingGraphic({
+          builder,
+          modelId: drawingModel.id,
+          categoryId: drawingCategory.id,
+          codeValue: "2d parent of search target",
+        });
+        const searchTargetChildElement = insertDrawingGraphic({
+          builder,
+          modelId: drawingModel.id,
+          categoryId: drawingCategory.id,
+          codeValue: "2d search target",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const childElement = insertDrawingGraphic({
+          builder,
+          modelId: drawingModel.id,
+          categoryId: drawingCategory.id,
+          codeValue: "2d child",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const siblingElement = insertDrawingGraphic({
+          builder,
+          modelId: drawingModel.id,
+          categoryId: drawingCategory.id,
+          codeValue: "2d sibling",
+        });
+        insertElementHasClassificationsRelationship({ builder, elementId: parentOfSearchTargetElement.id, classificationId: classification.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: siblingElement.id, classificationId: classification.id });
+
+        return {
+          table,
+          classification,
+          drawingModel,
+          drawingCategory,
+          parentOfSearchTargetElement,
+          searchTargetChildElement,
+          childElement,
+          siblingElement,
+          searchPaths: [[table, classification, parentOfSearchTargetElement, searchTargetChildElement]],
+        };
+      });
+
+      const { imodel, searchPaths, ...keys } = buildIModelResult;
+      using visibilityTestData = await createFilteredVisibilityTestData({
+        imodel,
+        searchPaths,
+        view: "2d",
+      });
+      const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+
+      await visibilityHandlerWithSearchPaths.changeVisibility(
+        createDrawingElementHierarchyNode({
+          id: keys.searchTargetChildElement.id,
+          categoryId: keys.drawingCategory.id,
+          modelId: keys.drawingModel.id,
+          parentKeys: [keys.table, keys.classification, keys.parentOfSearchTargetElement],
+          search: { isSearchTarget: true },
+        }),
+        true,
+      );
+
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: providerWithSearchPaths,
+        handler: visibilityHandlerWithSearchPaths,
+        viewport,
+        // prettier-ignore
+        expectations: {
+          [keys.table.id]: "partial",
+            [keys.classification.id]: "partial",
+              [keys.parentOfSearchTargetElement.id]: "partial",
+                [keys.searchTargetChildElement.id]: "visible",
+        },
+      });
+
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: defaultProvider,
+        handler: defaultVisibilityHandler,
+        viewport,
+        // prettier-ignore
+        expectations: {
+          [keys.table.id]: "partial",
+            [keys.classification.id]: "partial",
+              [keys.siblingElement.id]: "hidden",
+
+              [keys.parentOfSearchTargetElement.id]: "hidden",
+                [keys.searchTargetChildElement.id]: "visible",
+                [keys.childElement.id]: "hidden",
+        },
+      });
+    });
+
+    it("showing classification of search target element changes visibility for nodes in search paths", async function () {
       await using buildIModelResult = await buildIModel(this, async (builder) => {
         await importClassificationSchema(builder);
 
@@ -971,27 +1226,41 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const physicalModel = insertPhysicalModelWithPartition({ builder, codeValue: "physical model" });
         const spatialCategory1 = insertSpatialCategory({ builder, codeValue: "spatial category1" });
         const spatialCategory2 = insertSpatialCategory({ builder, codeValue: "spatial category2" });
-        const element1 = insertPhysicalElement({
+        const parentOfSearchTargetElement = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory1.id,
-          codeValue: "3d element1",
+          codeValue: "3d parent of search target",
         });
-        const element2 = insertPhysicalElement({
+        const searchTargetChildElement = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory1.id,
-          codeValue: "3d element2",
+          codeValue: "3d search target",
+          parentId: parentOfSearchTargetElement.id,
         });
-        const element3 = insertPhysicalElement({
+        const childElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory1.id,
+          codeValue: "3d child",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const siblingElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory1.id,
+          codeValue: "3d sibling",
+        });
+        const elementFromOtherClassification = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory2.id,
-          codeValue: "3d element3",
+          codeValue: "3d other classification",
         });
-        insertElementHasClassificationsRelationship({ builder, elementId: element1.id, classificationId: classification1.id });
-        insertElementHasClassificationsRelationship({ builder, elementId: element2.id, classificationId: classification1.id });
-        insertElementHasClassificationsRelationship({ builder, elementId: element3.id, classificationId: classification2.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: parentOfSearchTargetElement.id, classificationId: classification1.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: siblingElement.id, classificationId: classification1.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: elementFromOtherClassification.id, classificationId: classification2.id });
 
         return {
           table,
@@ -1000,10 +1269,12 @@ describe("ClassificationsTreeVisibilityHandler", () => {
           physicalModel,
           spatialCategory1,
           spatialCategory2,
-          element1,
-          element2,
-          element3,
-          searchPaths: [[table, classification1, element1]],
+          parentOfSearchTargetElement,
+          searchTargetChildElement,
+          childElement,
+          siblingElement,
+          elementFromOtherClassification,
+          searchPaths: [[table, classification1, parentOfSearchTargetElement, searchTargetChildElement]],
         };
       });
 
@@ -1013,42 +1284,47 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         searchPaths,
         view: "3d",
       });
-      const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
-      await handler.changeVisibility(
+      const { visibilityHandlerWithSearchPaths, defaultVisibilityHandler, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+      await visibilityHandlerWithSearchPaths.changeVisibility(
         createClassificationHierarchyNode({
           id: keys.classification1.id,
           search: {
             isSearchTarget: false,
-            childrenTargetPaths: [[keys.element1]],
+            childrenTargetPaths: [[keys.parentOfSearchTargetElement, keys.searchTargetChildElement]],
           },
           parentKeys: [keys.table],
         }),
         true,
       );
 
-      await validateHierarchyVisibility({
-        provider: filteredProvider,
-        handler,
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: providerWithSearchPaths,
+        handler: visibilityHandlerWithSearchPaths,
         viewport,
         expectations: "all-visible",
       });
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider: defaultProvider,
-        handler,
+        handler: defaultVisibilityHandler,
         viewport,
+        // prettier-ignore
         expectations: {
           [keys.table.id]: "partial",
-          [keys.classification1.id]: "partial",
-          [keys.element1.id]: "visible",
-          [keys.element2.id]: "hidden",
-          [keys.classification2.id]: "hidden",
-          [keys.element3.id]: "hidden",
+            [keys.classification1.id]: "partial",
+              [keys.siblingElement.id]: "hidden",
+
+              [keys.parentOfSearchTargetElement.id]: "visible",
+                [keys.searchTargetChildElement.id]: "visible",
+                [keys.childElement.id]: "hidden",
+
+            [keys.classification2.id]: "hidden",
+              [keys.elementFromOtherClassification.id]: "hidden",
         },
       });
     });
 
-    it("showing filtered classification table changes visibility for nodes in search paths", async function () {
+    it("showing classification table of search target element changes visibility for nodes in search paths", async function () {
       await using buildIModelResult = await buildIModel(this, async (builder) => {
         await importClassificationSchema(builder);
 
@@ -1059,27 +1335,41 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         const physicalModel = insertPhysicalModelWithPartition({ builder, codeValue: "physical model" });
         const spatialCategory1 = insertSpatialCategory({ builder, codeValue: "spatial category1" });
         const spatialCategory2 = insertSpatialCategory({ builder, codeValue: "spatial category2" });
-        const element1 = insertPhysicalElement({
+        const parentOfSearchTargetElement = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory1.id,
-          codeValue: "3d element1",
+          codeValue: "3d parent of search target",
         });
-        const element2 = insertPhysicalElement({
+        const searchTargetChildElement = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory1.id,
-          codeValue: "3d element2",
+          codeValue: "3d search target",
+          parentId: parentOfSearchTargetElement.id,
         });
-        const element3 = insertPhysicalElement({
+        const childElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory1.id,
+          codeValue: "3d child",
+          parentId: parentOfSearchTargetElement.id,
+        });
+        const siblingElement = insertPhysicalElement({
+          builder,
+          modelId: physicalModel.id,
+          categoryId: spatialCategory1.id,
+          codeValue: "3d sibling",
+        });
+        const elementFromOtherClassification = insertPhysicalElement({
           builder,
           modelId: physicalModel.id,
           categoryId: spatialCategory2.id,
-          codeValue: "3d element3",
+          codeValue: "3d other classification",
         });
-        insertElementHasClassificationsRelationship({ builder, elementId: element1.id, classificationId: classification1.id });
-        insertElementHasClassificationsRelationship({ builder, elementId: element2.id, classificationId: classification1.id });
-        insertElementHasClassificationsRelationship({ builder, elementId: element3.id, classificationId: classification2.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: parentOfSearchTargetElement.id, classificationId: classification1.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: siblingElement.id, classificationId: classification1.id });
+        insertElementHasClassificationsRelationship({ builder, elementId: elementFromOtherClassification.id, classificationId: classification2.id });
 
         return {
           table,
@@ -1088,10 +1378,12 @@ describe("ClassificationsTreeVisibilityHandler", () => {
           physicalModel,
           spatialCategory1,
           spatialCategory2,
-          element1,
-          element2,
-          element3,
-          searchPaths: [[table, classification1, element1]],
+          parentOfSearchTargetElement,
+          searchTargetChildElement,
+          childElement,
+          siblingElement,
+          elementFromOtherClassification,
+          searchPaths: [[table, classification1, parentOfSearchTargetElement, searchTargetChildElement]],
         };
       });
 
@@ -1101,37 +1393,42 @@ describe("ClassificationsTreeVisibilityHandler", () => {
         searchPaths,
         view: "3d",
       });
-      const { handler, viewport, defaultProvider, filteredProvider } = visibilityTestData;
-      await handler.changeVisibility(
+      const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+      await visibilityHandlerWithSearchPaths.changeVisibility(
         createClassificationTableHierarchyNode({
           hasChildren: true,
           id: keys.table.id,
           search: {
             isSearchTarget: false,
-            childrenTargetPaths: [[keys.classification1, keys.element1]],
+            childrenTargetPaths: [[keys.classification1, keys.parentOfSearchTargetElement, keys.searchTargetChildElement]],
           },
         }),
         true,
       );
 
-      await validateHierarchyVisibility({
-        provider: filteredProvider,
-        handler,
+      await validateClassificationsTreeHierarchyVisibility({
+        provider: providerWithSearchPaths,
+        handler: visibilityHandlerWithSearchPaths,
         viewport,
         expectations: "all-visible",
       });
 
-      await validateHierarchyVisibility({
+      await validateClassificationsTreeHierarchyVisibility({
         provider: defaultProvider,
-        handler,
+        handler: defaultVisibilityHandler,
         viewport,
+        // prettier-ignore
         expectations: {
           [keys.table.id]: "partial",
-          [keys.classification1.id]: "partial",
-          [keys.element1.id]: "visible",
-          [keys.element2.id]: "hidden",
-          [keys.classification2.id]: "hidden",
-          [keys.element3.id]: "hidden",
+            [keys.classification1.id]: "partial",
+              [keys.siblingElement.id]: "hidden",
+
+              [keys.parentOfSearchTargetElement.id]: "visible",
+                [keys.searchTargetChildElement.id]: "visible",
+                [keys.childElement.id]: "hidden",
+
+            [keys.classification2.id]: "hidden",
+              [keys.elementFromOtherClassification.id]: "hidden",
         },
       });
     });
@@ -1163,5 +1460,12 @@ function createClassificationsTreeVisibilityHandler(props: {
       });
     },
     viewport: props.viewport,
+  });
+}
+
+async function validateClassificationsTreeHierarchyVisibility(props: Omit<Props<typeof validateHierarchyVisibility>, "validateNodeVisibility">) {
+  return validateHierarchyVisibility({
+    ...props,
+    validateNodeVisibility,
   });
 }

--- a/packages/itwin/tree-widget/src/test/trees/common/VisibilityValidation.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/VisibilityValidation.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { EMPTY, expand, from, mergeMap } from "rxjs";
+import { toVoidPromise } from "../../../tree-widget-react-internal.js";
+
+import type { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+import type { HierarchyVisibilityHandler } from "../../../tree-widget-react.js";
+import type { Visibility } from "../../../tree-widget-react/components/trees/common/internal/Tooltip.js";
+import type { TreeWidgetTestingViewport } from "../TreeUtils.js";
+
+export interface VisibilityExpectations {
+  [id: string]: Visibility;
+}
+
+export interface ValidateNodeProps {
+  handler: HierarchyVisibilityHandler;
+  viewport: TreeWidgetTestingViewport;
+  expectations: "all-visible" | "all-hidden" | VisibilityExpectations;
+}
+
+export async function validateHierarchyVisibility({
+  provider,
+  validateNodeVisibility,
+  ...props
+}: ValidateNodeProps & {
+  provider: HierarchyProvider;
+  validateNodeVisibility: (props: ValidateNodeProps & { node: HierarchyNode }) => Promise<void>;
+}) {
+  props.viewport.renderFrame();
+  // This promise allows handler change event to fire if it was scheduled.
+  await new Promise((resolve) => setTimeout(resolve));
+  await toVoidPromise(
+    from(provider.getNodes({ parentNode: undefined })).pipe(
+      expand((node) => (node.children ? provider.getNodes({ parentNode: node }) : EMPTY)),
+      mergeMap(async (node) => validateNodeVisibility({ ...props, node })),
+    ),
+  );
+}

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeFiltering.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeFiltering.test.ts
@@ -30,7 +30,7 @@ import {
 } from "../../IModelUtils.js";
 import { createIModelAccess } from "../Common.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { createClassGroupingHierarchyNode, createModelsTreeProvider, getNodeParentKeys } from "./Utils.js";
+import { createClassGroupingHierarchyNode, createModelsTreeProvider } from "./Utils.js";
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -1025,7 +1025,7 @@ describe("Models tree", () => {
               modelId: model2.id,
               categoryId: category.id,
               elements: [physicalElement21.id, physicalElement22.id],
-              parentKeys: pathUntilTargetElement.map((key) => ({ type: "instances", instanceKeys: [key] })),
+              parentKeys: pathUntilTargetElement,
             });
             return { rootSubject, model2, category, physicalElement21, physicalElement22, pathUntilTargetElement, groupingNode };
           },
@@ -1109,14 +1109,14 @@ describe("Models tree", () => {
               modelId: model.id,
               categoryId: category.id,
               elements: [rootElement.id],
-              parentKeys: [adjustedModelKey(model), category].map((key) => ({ type: "instances", instanceKeys: [key] })),
+              parentKeys: [adjustedModelKey(model), category],
             });
             const targetGroupingNode = createClassGroupingHierarchyNode({
               className: testElement1.className,
               modelId: model.id,
               categoryId: category.id,
               elements: [testElement1.id, testElement2.id],
-              parentKeys: getNodeParentKeys([adjustedModelKey(model), category, groupingNode.key, adjustedElementKey(rootElement)]),
+              parentKeys: [adjustedModelKey(model), category, groupingNode.key, adjustedElementKey(rootElement)],
             });
             return { rootSubject, model, category, rootElement, testElement1, testElement2, pathUntilTargetElement, targetGroupingNode };
           },
@@ -1220,7 +1220,7 @@ describe("Models tree", () => {
               modelId: model.id,
               categoryId: category.id,
               elements: [rootElement.id],
-              parentKeys: getNodeParentKeys([adjustedModelKey(model), category]),
+              parentKeys: [adjustedModelKey(model), category],
             });
 
             const physicalElementGroupingNode = createClassGroupingHierarchyNode({
@@ -1228,14 +1228,14 @@ describe("Models tree", () => {
               modelId: model.id,
               categoryId: category.id,
               elements: [physicalElement1.id, physicalElement2.id],
-              parentKeys: getNodeParentKeys([adjustedModelKey(model), category, groupingNode.key, adjustedElementKey(rootElement)]),
+              parentKeys: [adjustedModelKey(model), category, groupingNode.key, adjustedElementKey(rootElement)],
             });
             const testElementGroupingNode = createClassGroupingHierarchyNode({
               className: testElement1.className,
               modelId: model.id,
               categoryId: category.id,
               elements: [testElement1.id, testElement2.id],
-              parentKeys: getNodeParentKeys([adjustedModelKey(model), category, groupingNode.key, adjustedElementKey(rootElement)]),
+              parentKeys: [adjustedModelKey(model), category, groupingNode.key, adjustedElementKey(rootElement)],
             });
             return {
               rootSubject,
@@ -1344,27 +1344,21 @@ describe("Models tree", () => {
               modelId: model.id,
               categoryId: category.id,
               elements: [parentElement.id],
-              parentKeys: getNodeParentKeys(pathUntilParentElement),
+              parentKeys: pathUntilParentElement,
             });
             const middleElementGroupingNode = createClassGroupingHierarchyNode({
               className: middleElement.className,
               modelId: model.id,
               categoryId: category.id,
               elements: [middleElement.id],
-              parentKeys: getNodeParentKeys([...pathUntilParentElement, parentElementGroupingNode.key, parentElement]),
+              parentKeys: [...pathUntilParentElement, parentElementGroupingNode.key, parentElement],
             });
             const childElementGroupingNode = createClassGroupingHierarchyNode({
               className: childElement.className,
               modelId: model.id,
               categoryId: category.id,
               elements: [childElement.id],
-              parentKeys: getNodeParentKeys([
-                ...pathUntilParentElement,
-                parentElementGroupingNode.key,
-                parentElement,
-                middleElementGroupingNode.key,
-                middleElement,
-              ]),
+              parentKeys: [...pathUntilParentElement, parentElementGroupingNode.key, parentElement, middleElementGroupingNode.key, middleElement],
             });
             return {
               rootSubject,
@@ -1469,7 +1463,7 @@ describe("Models tree", () => {
               modelId: model.id,
               categoryId: category.id,
               elements: [element.id],
-              parentKeys: pathUntilTargetElement.map((key) => ({ type: "instances", instanceKeys: [key] })),
+              parentKeys: pathUntilTargetElement,
             });
             return { rootSubject, model, category, element, pathUntilTargetElement, groupingNode };
           },
@@ -1528,14 +1522,14 @@ describe("Models tree", () => {
               modelId: model.id,
               categoryId: category1.id,
               elements: [element1.id],
-              parentKeys: [model, category1].map((key) => ({ type: "instances", instanceKeys: [key] })),
+              parentKeys: [model, category1],
             });
             const groupingNode2 = createClassGroupingHierarchyNode({
               className: element2.className,
               modelId: model.id,
               categoryId: category2.id,
               elements: [element2.id],
-              parentKeys: [model, category2].map((key) => ({ type: "instances", instanceKeys: [key] })),
+              parentKeys: [model, category2],
             });
             return {
               rootSubject,


### PR DESCRIPTION
Changes:
1. Changed tests to run on development environment.
2. Unified `validateNodeVisibility` functions used by models, categories and classifications trees.
3. Changed `visibilityExpectations` to `expectations` in models tree visibility tests and changed the type to be the same as in other trees.
4. Added some tests to models tree that are skipped for now, but should be re-enabled after completing https://github.com/iTwin/viewer-components-react/issues/1513