### PR TITLE
[Tree widget]: Adjust sub-categories visibility handling on `next`

### DIFF
--- a/change/@itwin-tree-widget-react-a09fd793-37dd-49fb-9579-425e301d8b14.json
+++ b/change/@itwin-tree-widget-react-a09fd793-37dd-49fb-9579-425e301d8b14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix enabling sub-category display in categories tree making other categories also visible, when their elements are under hidden model.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "check": "beachball check",
     "check:dev": "beachball check --config beachball.config.dev.js",
     "change": "beachball change --no-commit",
-    "change:dev": "beachball change --config beachball.config.dev.js --no-commit",
+    "change:next": "beachball change --config beachball.config.dev.js --no-commit -b origin/tree-widget/next",
     "cspell:contents": "cspell .",
     "cspell:filenames": "node scripts/cspellFileNames.js",
     "cspell": "pnpm run cspell:contents && pnpm run cspell:filenames",

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
@@ -532,6 +532,10 @@ export class CategoriesTreeIdsCache implements Disposable {
     );
   }
 
+  public getCategoriesOfElementModel(modelId: Id64String): Observable<Id64Set | undefined> {
+    return this.getElementModelsCategories().pipe(map((elementModelsCategories) => elementModelsCategories.get(modelId)?.categoryIds));
+  }
+
   public getModelCategoryIds(modelId: Id64String): Observable<Id64Array> {
     return this.getElementModelsCategories().pipe(
       map((elementModelsCategories) => {


### PR DESCRIPTION
Changes from https://github.com/iTwin/viewer-components-react/pull/1556. Categories already made sure to not enable unrelated categories, but changing sub-categories didn't do that.