### PR TITLE
[Tree widget]: Move caches under common folder

### DIFF
--- a/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
@@ -7,16 +7,16 @@ import { expect } from "chai";
 import { firstValueFrom } from "rxjs";
 import sinon from "sinon";
 import {
-  AlwaysAndNeverDrawnElementInfo,
+  AlwaysAndNeverDrawnElementInfoCache,
   SET_CHANGE_DEBOUNCE_TIME,
-} from "../../../../tree-widget-react/components/trees/common/internal/AlwaysAndNeverDrawnElementInfo.js";
+} from "../../../../tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import { createFakeSinonViewport } from "../../Common.js";
 
 import type { Id64String } from "@itwin/core-bentley";
-import type { MapEntry } from "../../../../tree-widget-react/components/trees/common/internal/AlwaysAndNeverDrawnElementInfo.js";
+import type { MapEntry } from "../../../../tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { ChildrenTree } from "../../../../tree-widget-react/components/trees/common/internal/Utils.js";
 
-describe("AlwaysAndNeverDrawnElementInfo", () => {
+describe("AlwaysAndNeverDrawnElementInfoCache", () => {
   beforeEach(() => {
     // without this option tests sometimes fail with strange errors
     sinon.useFakeTimers({ shouldClearNativeTimers: true });
@@ -31,7 +31,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
       const vp = createFakeSinonViewport();
       const event = setType === "always" ? vp.onAlwaysDrawnChanged : vp.onNeverDrawnChanged;
       (() => {
-        using _ = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+        using _ = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
         expect(event.numberOfListeners).to.eq(1);
       })();
       expect(event.numberOfListeners).to.eq(0);
@@ -44,7 +44,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: new Set(),
       });
 
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       expect(result).to.deep.eq(new Map());
@@ -58,7 +58,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: undefined,
       });
 
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       expect(result).to.deep.eq(new Map());
@@ -79,7 +79,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         queryHandler,
       });
 
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       const expectedResult: ChildrenTree<MapEntry> = new Map();
@@ -101,7 +101,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         queryHandler,
       });
 
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       const expectedResult: ChildrenTree<MapEntry> = new Map();
@@ -127,7 +127,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         queryHandler,
       });
 
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       const expectedResult: ChildrenTree<MapEntry> = new Map();
@@ -158,7 +158,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: set,
       });
 
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       await firstValueFrom(info.getElementsTree({ setType, modelIds: "0x2" }));
       expect(vp.iModel.createQueryReader).to.be.calledOnce;
@@ -190,7 +190,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         queryHandler,
       });
 
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result1 = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       const expectedResult: ChildrenTree<MapEntry> = new Map();
@@ -217,7 +217,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: set,
         queryHandler,
       });
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result1 = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       const expectedResult: ChildrenTree<MapEntry> = new Map();
@@ -249,7 +249,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
       const vp = createFakeSinonViewport({
         [`${setType}Drawn`]: set,
       });
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       await firstValueFrom(info.getElementsTree({ setType, modelIds: "0x2" }));
       expect(vp.iModel.createQueryReader).to.be.calledOnce;
@@ -278,7 +278,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: new Set(["0x30"]),
         queryHandler,
       });
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId }));
       expect(result).to.deep.eq(new Map());
@@ -300,7 +300,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: new Set([elementId]),
         queryHandler,
       });
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId, categoryIds: categoryId }));
       const expectedResult: ChildrenTree<MapEntry> = new Map();
@@ -320,7 +320,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: new Set([elementId, childElementId]),
         queryHandler,
       });
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId, categoryIds: categoryId, parentElementIdsPath: [elementId] }));
       const expectedResult: ChildrenTree<MapEntry> = new Map();
@@ -339,7 +339,7 @@ describe("AlwaysAndNeverDrawnElementInfo", () => {
         [`${setType}Drawn`]: new Set([elementId]),
         queryHandler,
       });
-      using info = new AlwaysAndNeverDrawnElementInfo({ viewport });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport });
       await sinon.clock.tickAsync(SET_CHANGE_DEBOUNCE_TIME);
       const result = await firstValueFrom(info.getElementsTree({ setType, modelIds: modelId, categoryIds: categoryId }));
       expect(result).to.deep.eq(new Map());

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
@@ -5,9 +5,9 @@
 
 import { defer, EMPTY, forkJoin, from, map, mergeMap, of, reduce, shareReplay, toArray } from "rxjs";
 import { Guid, Id64 } from "@itwin/core-bentley";
+import { ElementChildrenCache } from "../../common/internal/caches/ElementChildrenCache.js";
+import { ModelCategoryElementsCountCache } from "../../common/internal/caches/ModelCategoryElementsCountCache.js";
 import { CLASS_NAME_DefinitionContainer, CLASS_NAME_Model, CLASS_NAME_SubCategory } from "../../common/internal/ClassNameDefinitions.js";
-import { ElementChildrenCache } from "../../common/internal/ElementChildrenCache.js";
-import { ModelCategoryElementsCountCache } from "../../common/internal/ModelCategoryElementsCountCache.js";
 import { catchBeSQLiteInterrupts } from "../../common/internal/UseErrorState.js";
 import { getClassesByView, joinId64Arg } from "../../common/internal/Utils.js";
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -24,7 +24,7 @@ import type { Observable } from "rxjs";
 import type { Id64Set, Id64String } from "@itwin/core-bentley";
 import type { ClassGroupingNodeKey, HierarchyNode, HierarchySearchPath, InstancesNodeKey } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
-import type { AlwaysAndNeverDrawnElementInfo } from "../../../common/internal/AlwaysAndNeverDrawnElementInfo.js";
+import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
 import type { ChildrenTree } from "../../../common/internal/Utils.js";
 import type { SearchResultsTree } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
@@ -39,7 +39,7 @@ import type { CategoriesTreeSearchTargets } from "./SearchResultsTree.js";
 export interface CategoriesTreeVisibilityHandlerProps {
   idsCache: CategoriesTreeIdsCache;
   viewport: TreeWidgetViewport;
-  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfo;
+  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfoCache;
   hierarchyConfig: CategoriesTreeHierarchyConfiguration;
 }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -5,6 +5,8 @@
 
 import { defer, EMPTY, forkJoin, from, map, mergeMap, of, reduce, shareReplay, toArray } from "rxjs";
 import { Guid, Id64 } from "@itwin/core-bentley";
+import { ElementChildrenCache } from "../../common/internal/caches/ElementChildrenCache.js";
+import { ModelCategoryElementsCountCache } from "../../common/internal/caches/ModelCategoryElementsCountCache.js";
 import {
   CLASS_NAME_Classification,
   CLASS_NAME_ClassificationSystem,
@@ -16,8 +18,6 @@ import {
   CLASS_NAME_SpatialCategory,
   CLASS_NAME_SubCategory,
 } from "../../common/internal/ClassNameDefinitions.js";
-import { ElementChildrenCache } from "../../common/internal/ElementChildrenCache.js";
-import { ModelCategoryElementsCountCache } from "../../common/internal/ModelCategoryElementsCountCache.js";
 import { catchBeSQLiteInterrupts } from "../../common/internal/UseErrorState.js";
 import { joinId64Arg } from "../../common/internal/Utils.js";
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -14,7 +14,7 @@ import { ClassificationsTreeVisibilityHelper } from "./ClassificationsTreeVisibi
 import type { Observable } from "rxjs";
 import type { Id64Set, Id64String } from "@itwin/core-bentley";
 import type { HierarchyNode } from "@itwin/presentation-hierarchies";
-import type { AlwaysAndNeverDrawnElementInfo } from "../../../common/internal/AlwaysAndNeverDrawnElementInfo.js";
+import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
 import type { ChildrenTree } from "../../../common/internal/Utils.js";
 import type { BaseIdsCache, TreeSpecificVisibilityHandler } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
@@ -27,7 +27,7 @@ import type { ClassificationsTreeSearchTargets } from "./SearchResultsTree.js";
 export interface ClassificationsTreeVisibilityHandlerProps {
   idsCache: ClassificationsTreeIdsCache;
   viewport: TreeWidgetViewport;
-  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfo;
+  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfoCache;
 }
 
 /**

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -30,13 +30,13 @@ import {
 } from "rxjs";
 import { Guid, Id64 } from "@itwin/core-bentley";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { catchBeSQLiteInterrupts } from "./UseErrorState.js";
-import { getClassesByView, getIdsFromChildrenTree, getOptimalBatchSize, releaseMainThreadOnItemsCount, setDifference, updateChildrenTree } from "./Utils.js";
+import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { getClassesByView, getIdsFromChildrenTree, getOptimalBatchSize, releaseMainThreadOnItemsCount, setDifference, updateChildrenTree } from "../Utils.js";
 
 import type { Observable, Subscription } from "rxjs";
 import type { GuidString, Id64Arg, Id64Array, Id64String } from "@itwin/core-bentley";
-import type { TreeWidgetViewport } from "../TreeWidgetViewport.js";
-import type { ChildrenTree } from "./Utils.js";
+import type { TreeWidgetViewport } from "../../TreeWidgetViewport.js";
+import type { ChildrenTree } from "../Utils.js";
 
 /** @internal */
 export const SET_CHANGE_DEBOUNCE_TIME = 20;
@@ -86,14 +86,14 @@ export type MapEntry = { isInAlwaysOrNeverDrawnSet: true; categoryId: Id64String
 
 type CachedNodesMap = ChildrenTree<MapEntry>;
 
-interface AlwaysAndNeverDrawnElementInfoProps {
+interface AlwaysAndNeverDrawnElementInfoCacheProps {
   viewport: TreeWidgetViewport;
   elementClassName?: string;
   componentId?: GuidString;
 }
 
 /** @internal */
-export class AlwaysAndNeverDrawnElementInfo implements Disposable {
+export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   #subscriptions: Subscription[];
   #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: CachedNodesMap };
   #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: CachedNodesMap };
@@ -106,7 +106,7 @@ export class AlwaysAndNeverDrawnElementInfo implements Disposable {
   #suppressors: Observable<number>;
   #suppress = new Subject<boolean>();
 
-  constructor(props: AlwaysAndNeverDrawnElementInfoProps) {
+  constructor(props: AlwaysAndNeverDrawnElementInfoCacheProps) {
     this.#viewport = props.viewport;
     this.#alwaysDrawn = { cacheEntryObs: this.createCacheEntryObservable("always") };
     this.#neverDrawn = { cacheEntryObs: this.createCacheEntryObservable("never") };

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementChildrenCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementChildrenCache.ts
@@ -5,13 +5,13 @@
 
 import { defaultIfEmpty, defer, EMPTY, firstValueFrom, from, map, mergeMap, reduce, tap } from "rxjs";
 import { Guid, Id64 } from "@itwin/core-bentley";
-import { catchBeSQLiteInterrupts } from "./UseErrorState.js";
-import { getOptimalBatchSize } from "./Utils.js";
+import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { getOptimalBatchSize } from "../Utils.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString, Id64Arg, Id64Array, Id64String } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import type { ChildrenTree } from "./Utils.js";
+import type { ChildrenTree } from "../Utils.js";
 
 type ChildElementsMap = Map<Id64String, { children: Id64Array | undefined }>;
 type ChildElementsLoadingMap = Map<Id64String, Promise<void>>;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModelCategoryElementsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModelCategoryElementsCountCache.ts
@@ -5,13 +5,13 @@
 
 import { bufferCount, bufferTime, defer, filter, from, map, mergeAll, mergeMap, reduce, ReplaySubject, Subject, take, toArray } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
-import { catchBeSQLiteInterrupts } from "./UseErrorState.js";
-import { releaseMainThreadOnItemsCount } from "./Utils.js";
+import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { releaseMainThreadOnItemsCount } from "../Utils.js";
 
 import type { Observable, Subscription } from "rxjs";
 import type { GuidString, Id64Set, Id64String } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import type { CategoryId, ModelId } from "./Types.js";
+import type { CategoryId, ModelId } from "../Types.js";
 
 type ModelCategoryKey = `${ModelId}-${CategoryId}`;
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
@@ -8,7 +8,7 @@ import { defaultIfEmpty, EMPTY, filter, firstValueFrom, from, fromEventPattern, 
 import { assert } from "@itwin/core-bentley";
 import { HierarchyNode, HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { HierarchyVisibilityOverrideHandler } from "../../UseHierarchyVisibility.js";
-import { AlwaysAndNeverDrawnElementInfo } from "../AlwaysAndNeverDrawnElementInfo.js";
+import { AlwaysAndNeverDrawnElementInfoCache } from "../caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import { toVoidPromise } from "../Rxjs.js";
 import { createVisibilityStatus } from "../Tooltip.js";
 import { createVisibilityChangeEventListener } from "../VisibilityChangeEventListener.js";
@@ -33,7 +33,7 @@ export interface CreateSearchResultsTreeProps<TCache> {
 
 /** @internal */
 export interface CreateTreeSpecificVisibilityHandlerProps<TCache> {
-  info: AlwaysAndNeverDrawnElementInfo;
+  info: AlwaysAndNeverDrawnElementInfoCache;
   getCache: () => TCache;
   viewport: TreeWidgetViewport;
   overrideHandler: HierarchyVisibilityOverrideHandler;
@@ -114,7 +114,7 @@ function createVisibilityHandlerFactory<TCache, TSearchTargets>(
 export interface HierarchyVisibilityHandlerImplProps<TSearchTargets> {
   viewport: TreeWidgetViewport;
   getTreeSpecificVisibilityHandler: (
-    info: AlwaysAndNeverDrawnElementInfo,
+    info: AlwaysAndNeverDrawnElementInfoCache,
     overrideHandler: HierarchyVisibilityOverrideHandler,
   ) => TreeSpecificVisibilityHandler<TSearchTargets> & Disposable;
   getSearchResultsTree: () => Promise<SearchResultsTree<TSearchTargets>> | undefined;
@@ -132,7 +132,7 @@ export interface HierarchyVisibilityHandlerImplProps<TSearchTargets> {
 export class HierarchyVisibilityHandlerImpl<TSearchTargets> implements HierarchyVisibilityHandler, Disposable {
   readonly #props: HierarchyVisibilityHandlerImplProps<TSearchTargets>;
   readonly #eventListener: IVisibilityChangeEventListener;
-  readonly #alwaysAndNeverDrawnElements: AlwaysAndNeverDrawnElementInfo;
+  readonly #alwaysAndNeverDrawnElements: AlwaysAndNeverDrawnElementInfoCache;
   #treeSpecificVisibilityHandler: TreeSpecificVisibilityHandler<TSearchTargets> & Disposable;
   #changeRequest = new Subject<{ key: HierarchyNodeKey; depth: number }>();
   #searchResultsTree: Promise<SearchResultsTree<TSearchTargets>> | undefined;
@@ -149,7 +149,7 @@ export class HierarchyVisibilityHandlerImpl<TSearchTargets> implements Hierarchy
       },
     });
     this.#searchResultsTree = this.#props.getSearchResultsTree();
-    this.#alwaysAndNeverDrawnElements = new AlwaysAndNeverDrawnElementInfo({
+    this.#alwaysAndNeverDrawnElements = new AlwaysAndNeverDrawnElementInfoCache({
       viewport: this.#props.viewport,
       componentId: props.componentId,
     });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -42,7 +42,7 @@ import type { Id64Arg, Id64Array, Id64Set, Id64String } from "@itwin/core-bentle
 import type { ClassGroupingNodeKey, HierarchyNode, InstancesNodeKey } from "@itwin/presentation-hierarchies";
 import type { TreeWidgetViewport } from "../../TreeWidgetViewport.js";
 import type { HierarchyVisibilityHandlerOverridableMethod, HierarchyVisibilityOverrideHandler, VisibilityStatus } from "../../UseHierarchyVisibility.js";
-import type { AlwaysAndNeverDrawnElementInfo } from "../AlwaysAndNeverDrawnElementInfo.js";
+import type { AlwaysAndNeverDrawnElementInfoCache } from "../caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ModelId } from "../Types.js";
 import type { ChildrenTree } from "../Utils.js";
 import type { GetVisibilityFromAlwaysAndNeverDrawnElementsProps } from "../VisibilityUtils.js";
@@ -104,7 +104,7 @@ export interface TreeSpecificVisibilityHandler<TSearchTargets> {
 /** @internal */
 export interface BaseVisibilityHelperProps {
   viewport: TreeWidgetViewport;
-  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfo;
+  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfoCache;
   overrideHandler?: HierarchyVisibilityOverrideHandler;
   overrides?: BaseTreeVisibilityHandlerOverrides;
   baseIdsCache: BaseIdsCache;
@@ -118,7 +118,7 @@ export interface BaseVisibilityHelperProps {
  */
 export class BaseVisibilityHelper implements Disposable {
   readonly #props: BaseVisibilityHelperProps;
-  readonly #alwaysAndNeverDrawnElements: AlwaysAndNeverDrawnElementInfo;
+  readonly #alwaysAndNeverDrawnElements: AlwaysAndNeverDrawnElementInfoCache;
   #elementChangeQueue = new Subject<Observable<void>>();
   #subscriptions: Subscription[] = [];
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
@@ -6,6 +6,8 @@
 import { defer, EMPTY, filter, forkJoin, from, map, mergeAll, mergeMap, of, reduce, shareReplay, toArray } from "rxjs";
 import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { IModel } from "@itwin/core-common";
+import { ElementChildrenCache } from "../../common/internal/caches/ElementChildrenCache.js";
+import { ModelCategoryElementsCountCache } from "../../common/internal/caches/ModelCategoryElementsCountCache.js";
 import {
   CLASS_NAME_GeometricModel3d,
   CLASS_NAME_InformationPartitionElement,
@@ -14,8 +16,6 @@ import {
   CLASS_NAME_SubCategory,
   CLASS_NAME_Subject,
 } from "../../common/internal/ClassNameDefinitions.js";
-import { ElementChildrenCache } from "../../common/internal/ElementChildrenCache.js";
-import { ModelCategoryElementsCountCache } from "../../common/internal/ModelCategoryElementsCountCache.js";
 import { catchBeSQLiteInterrupts } from "../../common/internal/UseErrorState.js";
 import { pushToMap } from "../../common/internal/Utils.js";
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -17,7 +17,7 @@ import type { Observable } from "rxjs";
 import type { Id64Arg, Id64Set, Id64String } from "@itwin/core-bentley";
 import type { ClassGroupingNodeKey, GroupingHierarchyNode, HierarchyNode, HierarchySearchPath, InstancesNodeKey } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
-import type { AlwaysAndNeverDrawnElementInfo } from "../../../common/internal/AlwaysAndNeverDrawnElementInfo.js";
+import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
 import type { ChildrenTree } from "../../../common/internal/Utils.js";
 import type { SearchResultsTree } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
@@ -54,7 +54,7 @@ export interface ModelsTreeVisibilityHandlerOverrides extends BaseTreeVisibility
 export interface ModelsTreeVisibilityHandlerProps {
   idsCache: ModelsTreeIdsCache;
   viewport: TreeWidgetViewport;
-  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfo;
+  alwaysAndNeverDrawnElementInfo: AlwaysAndNeverDrawnElementInfoCache;
   overrideHandler: HierarchyVisibilityOverrideHandler;
   overrides?: ModelsTreeVisibilityHandlerOverrides;
 }


### PR DESCRIPTION
Moved caches under common folder. This is part of [#1421](https://github.com/iTwin/viewer-components-react/issues/1421).
Also renamed `AlwaysAndNeverDrawnElementInfo` -> `AlwaysAndNeverDrawnElementInfoCache`