### PR TITLE
[Tree widget]: Add element model categories cache

### DIFF
--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -103,10 +103,10 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
         toArray(),
       );
     }),
-    getModelCategoryIds: sinon.stub<[Id64String], Observable<Id64Array>>().callsFake((modelId) => {
-      return of(props?.modelCategories?.get(modelId) ?? []);
+    getModelCategoryIds: sinon.stub<[Id64String], Observable<Id64Set>>().callsFake((modelId) => {
+      return of(new Set(props?.modelCategories?.get(modelId) ?? []));
     }),
-    getAllCategories: sinon.stub<[], Observable<Id64Set>>().callsFake(() => {
+    getAllCategoriesOfElements: sinon.stub<[], Observable<Id64Set>>().callsFake(() => {
       const result = new Set<Id64String>();
       props?.modelCategories?.forEach((categories) => categories.forEach((category) => result.add(category)));
       return of(result);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -561,7 +561,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     const modelIds: Id64Array = parentNode.extendedData?.isCategoryOfSubModel
       ? parseIdsSelectorResult(parentNode.extendedData?.modelIds)
       : await firstValueFrom(
-          this.#idsCache.getCategoriesElementModels(categoryIds).pipe(
+          this.#idsCache.getCategoriesElementModels({ categoryIds }).pipe(
             mergeMap(({ models }) => models ?? []),
             distinct(),
             toArray(),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -64,7 +64,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       getChildElementsTree: (props) => this.getChildElementsTree(props),
       getAllChildElementsCount: (props) => this.getAllChildElementsCount(props),
       getCategories: (props) => this.getCategories(props),
-      getAllCategories: () => this.getAllCategories(),
+      getAllCategoriesOfElements: () => this.getAllCategoriesOfElements(),
       getElementsCount: (props) => this.getElementsCount(props),
       getModels: (props) => this.getModels(props),
       getSubCategories: (props) => this.getSubCategories(props),
@@ -464,8 +464,8 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
     );
   }
 
-  private getAllCategories(): ReturnType<BaseIdsCache["getAllCategories"]> {
-    return this.#props.idsCache.getAllCategories();
+  private getAllCategoriesOfElements(): ReturnType<BaseIdsCache["getAllCategoriesOfElements"]> {
+    return this.#props.idsCache.getAllCategoriesOfElements();
   }
 
   private getElementsCount(props: Parameters<BaseIdsCache["getElementsCount"]>[0]): ReturnType<BaseIdsCache["getElementsCount"]> {
@@ -473,7 +473,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
   }
 
   private getModels(props: Parameters<BaseIdsCache["getModels"]>[0]): ReturnType<BaseIdsCache["getModels"]> {
-    return this.#props.idsCache.getCategoriesElementModels(props.categoryIds, true);
+    return this.#props.idsCache.getCategoriesElementModels({ categoryIds: props.categoryIds, includeSubModels: true });
   }
 
   private getChildElementsTree(props: Parameters<BaseIdsCache["getChildElementsTree"]>[0]): ReturnType<BaseIdsCache["getChildElementsTree"]> {
@@ -515,7 +515,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       );
     }
 
-    return this.#props.idsCache.getCategoriesElementModels(props.categoryIds).pipe(
+    return this.#props.idsCache.getCategoriesElementModels({ categoryIds: props.categoryIds }).pipe(
       mergeMap(({ id, models }) => {
         if (!models) {
           return of({ id, subModels: undefined });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -138,13 +138,13 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
   /** Turns on category and its' related models. Does not turn on other categories contained in those models.*/
   private enableCategoryWithoutEnablingOtherCategories(categoryId: Id64String): Observable<void> {
     this.#props.viewport.changeCategoryDisplay({ categoryIds: categoryId, display: true });
-    return this.#props.idsCache.getCategoriesElementModels(categoryId, true).pipe(
+    return this.#props.idsCache.getCategoriesElementModels({ categoryIds: categoryId, includeSubModels: true }).pipe(
       mergeMap(({ models }) => from(models ?? [])),
       mergeMap((modelId) => {
         this.#props.viewport.setPerModelCategoryOverride({ modelIds: modelId, categoryIds: categoryId, override: "none" });
         return this.#props.viewport.viewsModel(modelId)
           ? EMPTY
-          : this.#props.idsCache.getCategoriesOfElementModel(modelId).pipe(
+          : this.#props.idsCache.getModelCategoryIds(modelId).pipe(
               map((allModelCategories) => {
                 // Add 'Hide' override to categories that were hidden before model is turned on
                 allModelCategories?.forEach((modelCategoryId) => {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -49,7 +49,7 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
       getAllChildElementsCount: (props) => this.getAllChildElementsCount(props),
       getChildElementsTree: (props) => this.getChildElementsTree(props),
       getCategories: (props) => this.getCategories(props),
-      getAllCategories: () => this.getAllCategories(),
+      getAllCategoriesOfElements: () => this.getAllCategoriesOfElements(),
       getElementsCount: (props) => this.getElementsCount(props),
       getModels: (props) => this.getModels(props),
       getSubCategories: (props) => this.getSubCategories(props),
@@ -326,8 +326,8 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
     );
   }
 
-  private getAllCategories(): ReturnType<BaseIdsCache["getAllCategories"]> {
-    return this.#props.idsCache.getAllCategories();
+  private getAllCategoriesOfElements(): ReturnType<BaseIdsCache["getAllCategoriesOfElements"]> {
+    return this.#props.idsCache.getAllCategoriesOfElements();
   }
 
   private getElementsCount(props: Parameters<BaseIdsCache["getElementsCount"]>[0]): ReturnType<BaseIdsCache["getElementsCount"]> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
@@ -1,0 +1,160 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { defer, forkJoin, from, map, mergeMap, reduce, shareReplay } from "rxjs";
+import { Guid, Id64 } from "@itwin/core-bentley";
+import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+
+import type { Observable } from "rxjs";
+import type { GuidString, Id64Arg, Id64Array, Id64Set, Id64String } from "@itwin/core-bentley";
+import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
+import type { CategoryId, ModelId } from "../Types.js";
+import type { ModeledElementsCache } from "./ModeledElementsCache.js";
+
+interface ElementModelCategoriesCacheProps {
+  queryExecutor: LimitingECSqlQueryExecutor;
+  componentId?: GuidString;
+  elementClassName: string;
+  type: "2d" | "3d";
+  modelClassName: string;
+  modeledElementsCache: ModeledElementsCache;
+}
+
+/** @internal */
+export class ElementModelCategoriesCache {
+  #queryExecutor: LimitingECSqlQueryExecutor;
+  #componentId: GuidString;
+  #componentName: string;
+  #elementClassName: string;
+  #type: "2d" | "3d";
+  #modelClassName: string;
+  #modeledElementsCache: ModeledElementsCache;
+  #modelsCategoriesInfo:
+    | Observable<Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>>
+    | undefined;
+
+  constructor(props: ElementModelCategoriesCacheProps) {
+    this.#queryExecutor = props.queryExecutor;
+    this.#elementClassName = props.elementClassName;
+    this.#modelClassName = props.modelClassName;
+    this.#modeledElementsCache = props.modeledElementsCache;
+    this.#type = props.type;
+    this.#componentId = props.componentId ?? Guid.createValue();
+    this.#componentName = `ElementModelCategoriesCache${this.#type}`;
+  }
+
+  private queryElementModelCategories(): Observable<{
+    modelId: Id64String;
+    categoryId: Id64String;
+    isTopMostElementCategory: boolean;
+  }> {
+    return defer(() => {
+      const query = `
+          SELECT * FROM (
+            SELECT
+              this.Model.Id modelId,
+              this.Category.Id categoryId,
+              MAX(IIF(this.Parent.Id IS NULL, 1, 0)) isTopMostElementCategory
+            FROM ${this.#modelClassName} m
+            JOIN ${this.#elementClassName} this ON m.ECInstanceId = this.Model.Id
+            WHERE m.IsPrivate = false
+            GROUP BY modelId, categoryId
+          )
+        `;
+      return this.#queryExecutor.createQueryReader(
+        { ecsql: query },
+        { rowFormat: "ECSqlPropertyNames", limit: "unbounded", restartToken: `${this.#componentName}/${this.#componentId}/element-models-and-categories` },
+      );
+    }).pipe(
+      catchBeSQLiteInterrupts,
+      map((row) => {
+        return { modelId: row.modelId, categoryId: row.categoryId, isTopMostElementCategory: !!row.isTopMostElementCategory };
+      }),
+    );
+  }
+
+  private getElementModelCategories() {
+    this.#modelsCategoriesInfo ??= forkJoin({
+      modelCategories: this.queryElementModelCategories().pipe(
+        reduce((acc, queriedCategory) => {
+          let modelEntry = acc.get(queriedCategory.modelId);
+          if (modelEntry === undefined) {
+            modelEntry = { categoriesOfTopMostElements: new Set(), allCategories: new Set() };
+            acc.set(queriedCategory.modelId, modelEntry);
+          }
+          modelEntry.allCategories.add(queriedCategory.categoryId);
+          if (queriedCategory.isTopMostElementCategory) {
+            modelEntry.categoriesOfTopMostElements.add(queriedCategory.categoryId);
+          }
+          return acc;
+        }, new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId> }>()),
+      ),
+      allSubModels: this.#modeledElementsCache.getModeledElementsInfo().pipe(map(({ allSubModels }) => allSubModels)),
+    }).pipe(
+      map(({ modelCategories, allSubModels }) => {
+        const result = new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>();
+        modelCategories.forEach(({ categoriesOfTopMostElements, allCategories }, modelId) => {
+          const isSubModel = allSubModels.has(modelId);
+          result.set(modelId, {
+            categoriesOfTopMostElements,
+            allCategories,
+            isSubModel,
+          });
+        });
+        return result;
+      }),
+      shareReplay(),
+    );
+    return this.#modelsCategoriesInfo;
+  }
+
+  public getCategoriesElementModels(props: {
+    categoryIds: Id64Arg;
+    includeSubModels?: boolean;
+  }): Observable<{ id: CategoryId; models: Array<ModelId> | undefined }> {
+    const { categoryIds, includeSubModels } = props;
+    return this.getElementModelCategories().pipe(
+      mergeMap((modelCategories) =>
+        from(Id64.iterable(categoryIds)).pipe(
+          map((categoryId) => {
+            const categoryModels = new Array<ModelId>();
+            modelCategories.forEach(({ allCategories, isSubModel }, modelId) => {
+              if ((includeSubModels || !isSubModel) && allCategories.has(categoryId)) {
+                categoryModels.push(modelId);
+              }
+            });
+            return { id: categoryId, models: categoryModels.length > 0 ? categoryModels : undefined };
+          }),
+        ),
+      ),
+    );
+  }
+
+  public getModelCategoryIds(modelId: Id64String): Observable<Id64Set> {
+    return this.getElementModelCategories().pipe(map((modelCategories) => modelCategories.get(modelId)?.allCategories ?? new Set()));
+  }
+
+  public getModelsOfTopMostElementCategory(categoryId: Id64String): Observable<Id64Array> {
+    return this.getElementModelCategories().pipe(
+      mergeMap((modelCategories) => modelCategories.entries()),
+      reduce((acc, [modelId, { categoriesOfTopMostElements, isSubModel }]) => {
+        if (!isSubModel && categoriesOfTopMostElements.has(categoryId)) {
+          acc.push(modelId);
+        }
+        return acc;
+      }, new Array<ModelId>()),
+    );
+  }
+
+  public getAllCategoriesOfElements(): Observable<Id64Set> {
+    return this.getElementModelCategories().pipe(
+      mergeMap((modelCategories) => modelCategories.values()),
+      reduce((acc, { allCategories }) => {
+        allCategories.forEach((categoryId) => acc.add(categoryId));
+        return acc;
+      }, new Set<CategoryId>()),
+    );
+  }
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
@@ -99,6 +99,9 @@ export class ModeledElementsCache {
   }
 
   public getCategoriesModeledElements({ modelId, categoryIds }: { modelId: Id64String; categoryIds: Id64Arg }): Observable<Id64Array> {
+    if (Id64.sizeOf(categoryIds) === 0) {
+      return of([]);
+    }
     return this.getModeledElementsInfo().pipe(
       mergeMap(({ modelWithCategoryModeledElements }) => {
         const result = new Array<ElementId>();

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -80,7 +80,7 @@ export interface BaseIdsCache {
   getSubModels: (
     props: { modelIds: Id64Arg; categoryId?: Id64String } | { categoryIds: Id64Arg; modelId: Id64String | undefined },
   ) => Observable<{ id: Id64String; subModels: Id64Arg | undefined }>;
-  getAllCategories: () => Observable<Id64Set>;
+  getAllCategoriesOfElements: () => Observable<Id64Set>;
   getChildElementsTree: (props: { elementIds: Id64Arg }) => Observable<ChildrenTree>;
   getAllChildElementsCount: (props: { elementIds: Id64Arg }) => Observable<Map<Id64String, number>>;
 }
@@ -141,7 +141,7 @@ export class BaseVisibilityHelper implements Disposable {
    * - Clears never drawn list;
    * - Removes all per-model category overrides. */
   public removeAlwaysDrawnExclusive(): Observable<void> {
-    return from(this.#props.baseIdsCache.getAllCategories()).pipe(
+    return from(this.#props.baseIdsCache.getAllCategoriesOfElements()).pipe(
       map((categories) => {
         if (categories.size) {
           this.#props.viewport.changeCategoryDisplay({ categoryIds: categories, display: false, enableAllSubCategories: false });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -83,7 +83,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
       getSubCategories: (props) => this.getSubCategories(props),
       getSubModels: (props) => this.getSubModels(props),
       hasSubModel: (props) => this.#props.idsCache.hasSubModel(props),
-      getAllCategories: () => this.getAllCategories(),
+      getAllCategoriesOfElements: () => this.getAllCategoriesOfElements(),
     };
     this.#visibilityHelper = new ModelsTreeVisibilityHelper({
       viewport: this.#props.viewport,
@@ -442,8 +442,8 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
     return this.#props.idsCache.getChildElementsTree({ elementIds: props.elementIds });
   }
 
-  private getAllCategories(): ReturnType<BaseIdsCache["getAllCategories"]> {
-    return this.#props.idsCache.getAllCategories();
+  private getAllCategoriesOfElements(): ReturnType<BaseIdsCache["getAllCategoriesOfElements"]> {
+    return this.#props.idsCache.getAllCategoriesOfElements();
   }
 
   private getAllChildElementsCount(props: Parameters<BaseIdsCache["getAllChildElementsCount"]>[0]): ReturnType<BaseIdsCache["getAllChildElementsCount"]> {


### PR DESCRIPTION
`ModelsTreeIdsCache`, `CategoriesTreeIdsCache` and `ClassificationsTreeIdsCache` used almost the same implementation to query and store data about element model categories. Moved them to `ElementModelCategoriesCache`, which is now used by them.