### PR TITLE
[Tree widget]: Simplify getVisibilityFromAlwaysAndNeverDrawnElementsImpl

### DIFF
--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/VisibilityUtils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/VisibilityUtils.ts
@@ -113,17 +113,14 @@ export function getVisibilityFromAlwaysAndNeverDrawnElementsImpl(props: {
   defaultStatus: NonPartialVisibilityStatus;
 }): VisibilityStatus {
   const { numberOfElementsInOppositeSet, totalCount, defaultStatus } = props;
-  if (totalCount === 0) {
+  if (totalCount === 0 || numberOfElementsInOppositeSet === 0) {
     return defaultStatus;
   }
   if (numberOfElementsInOppositeSet === totalCount) {
     return defaultStatus.state === "hidden" ? createVisibilityStatus("visible") : createVisibilityStatus("hidden");
   }
 
-  if (numberOfElementsInOppositeSet > 0) {
-    return createVisibilityStatus("partial");
-  }
-  return defaultStatus;
+  return createVisibilityStatus("partial");
 }
 
 /**

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -203,11 +203,7 @@ export class BaseVisibilityHelper implements Disposable {
    * - Category selector visibility in the viewport.
    * - Sub-categories visibility in the viewport.
    */
-  public getSubCategoriesVisibilityStatus(props: {
-    subCategoryIds: Id64Arg;
-    categoryId: Id64String;
-    returnOnEmpty?: VisibilityStatus | "empty";
-  }): Observable<VisibilityStatus> {
+  public getSubCategoriesVisibilityStatus(props: { subCategoryIds: Id64Arg; categoryId: Id64String }): Observable<VisibilityStatus> {
     if (Id64.sizeOf(props.subCategoryIds) === 0) {
       return EMPTY;
     }


### PR DESCRIPTION
Removed unused `returnOnEmpty` prop from `getSubCategoriesVisibilityStatus` and simplified `getVisibilityFromAlwaysAndNeverDrawnElementsImpl`