### PR TITLE
Tree widget: Slightly improve changing visibility of many categories

### DIFF
--- a/apps/performance-tests/.mocharc.json
+++ b/apps/performance-tests/.mocharc.json
@@ -1,6 +1,6 @@
 {
   "require": ["ignore-styles", "./lib/setup.js"],
-  "timeout": 300000,
+  "timeout": 600000,
   "check-leaks": true,
   "file": "./lib/main.js",
   "reporter": ["./lib/util/TestReporter.cjs"]

--- a/change/@itwin-tree-widget-react-e14925a3-5c38-4177-8f48-304a27a1aff9.json
+++ b/change/@itwin-tree-widget-react-e14925a3-5c38-4177-8f48-304a27a1aff9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Slightly improve changing visibility of many categories",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "35135765+grigasp@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -543,8 +543,8 @@ export class BaseVisibilityHelper implements Disposable {
         return this.changeCategoriesUnderModelVisibilityStatus({ categoryIds, modelId: props.modelId, on });
       }
 
-      const changeCategoriesObs = fromWithRelease({ source: categoryIds, releaseOnCount: 500 }).pipe(
-        bufferCount(getOptimalBatchSize({ totalSize: Id64.sizeOf(categoryIds), maximumBatchSize: 500 })),
+      const changeCategoriesObs = fromWithRelease({ source: categoryIds, releaseOnCount: 5000 }).pipe(
+        bufferCount(getOptimalBatchSize({ totalSize: Id64.sizeOf(categoryIds), maximumBatchSize: 5000 })),
         map((categoryIdsBatch) => this.#props.viewport.changeCategoryDisplay({ categoryIds: categoryIdsBatch, display: on, enableAllSubCategories: false })),
       );
       const categoryModelsObs = from(Id64.iterable(categoryIds)).pipe(


### PR DESCRIPTION
Follow-up of https://github.com/iTwin/viewer-components-react/pull/1605#discussion_r2840096119.

Local testing results:
```jsonc

[
  // 500 batch size
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories",
    "unit": "ms",
    "value": 112229.98
  },
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories (P95 of main thread blocks)",
    "unit": "ms",
    "value": 898,
    "extra": "count: 180\nmax: 976\np95: 898\nmedian: 497.5"
  },
  // 1k batch size
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories",
    "unit": "ms",
    "value": 97391.69
  },
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories (P95 of main thread blocks)",
    "unit": "ms",
    "value": 702,
    "extra": "count: 191\nmax: 806\np95: 702\nmedian: 385"
  },
  // 5k batch size
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories",
    "unit": "ms",
    "value": 95000.64
  },
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories (P95 of main thread blocks)",
    "unit": "ms",
    "value": 698,
    "extra": "count: 200\nmax: 791\np95: 698\nmedian: 351.5"
  },
  // 10k batch size
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories",
    "unit": "ms",
    "value": 104824.41
  },
  {
    "name": "categories tree changing definition container visibility changes visibility for 50k categories (P95 of main thread blocks)",
    "unit": "ms",
    "value": 814,
    "extra": "count: 213\nmax: 931\np95: 814\nmedian: 377"
  }
]
```

I think this shouldn't be merged until iTwin.js Core 5.7 is released.