### PR TITLE
Fix flaky learning snippet extractions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,5 @@ jobs:
 
       - run: pnpm install
 
-      - run: pnpm exec lage docs --grouped
-        name: Build docs
-
-      - run: pnpm exec lage check-extractions --grouped
-        name: Validate snippets in markdowns
+      - name: Check code snippets
+        run: pnpm check-extractions

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "bump": "beachball bump",
     "prettier": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "update-extractions": "npm run docs:all && lage update-extractions",
-    "check-extractions": "npm run docs:all && lage check-extractions",
+    "gather-docs": "node ./scripts/gatherDocs.js",
+    "update-extractions": "npm run docs:all && npm run gather-docs && lage update-extractions",
+    "check-extractions": "npm run docs:all && npm run gather-docs && lage check-extractions",
     "benchmark:tree-widget": "pnpm run -C ./apps/performance-tests benchmark:tree-widget"
   },
   "devDependencies": {

--- a/scripts/gatherDocs.js
+++ b/scripts/gatherDocs.js
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 const { execSync } = require("child_process");
 const cpx = require("cpx2");
+const fs = require("fs");
+const path = require("path");
 
 function safeJsonParse(data) {
   try {
@@ -25,11 +27,14 @@ const allWorkspacePackages = safeJsonParse(execSync("pnpm list -r --depth -1 --o
 // get info about root package
 const [{ name: workspaceRootName, path: workspaceRootPath }] = JSON.parse(execSync("pnpm list -w --only-projects --json", { encoding: "utf-8" }));
 
+const targetDir = path.join(workspaceRootPath, "build");
+fs.mkdirSync(targetDir, { recursive: true });
+
 // filter out root package
 const workspacePackages = allWorkspacePackages.filter(({ name }) => name !== workspaceRootName);
 console.log(workspacePackages);
 
 for (const package of workspacePackages) {
   // copy docs build from each package to the root
-  cpx.copySync(`${package.path}/build/**`, `${workspaceRootPath}/build`);
+  cpx.copySync(`${package.path}/build/**`, targetDir);
 }

--- a/scripts/updateExtractions.js
+++ b/scripts/updateExtractions.js
@@ -12,6 +12,7 @@ const argv = yargs(process.argv).argv;
 
 // parse args
 const isCheck = "check" in argv;
+const gatherDocs = "gatherDocs" in argv;
 const targets = argv.targets;
 if (!targets) {
   console.error(
@@ -24,8 +25,13 @@ if (!targets) {
 const [{ path: workspaceRootPath }] = JSON.parse(execFileSync("pnpm", ["list", "-w", "--only-projects", "--json"], { shell: true, encoding: "utf-8" }));
 
 // gather extractions from different packages into the workspace root
-console.log(`Gathering extractions from different packages...`);
-execFileSync("node", [path.join(workspaceRootPath, "scripts", "gatherDocs.js")], { stdio: "inherit", cwd: workspaceRootPath });
+if (gatherDocs) {
+  console.log(`Gathering extractions from different packages...`);
+  execFileSync("node", [path.join(workspaceRootPath, "scripts", "gatherDocs.js")], {
+    stdio: "inherit",
+    cwd: workspaceRootPath,
+  });
+}
 
 // set up constants
 const extractionsDir = path.join(workspaceRootPath, "build/docs/extract");


### PR DESCRIPTION
Example failure: https://github.com/iTwin/viewer-components-react/actions/runs/24184999137/job/70587550444
```
@itwin/property-grid-react check-extractions … queued
@itwin/property-grid-react check-extractions ➔ start
@itwin/property-grid-react check-extractions :  Running pnpm run check-extractions, pid: 4929
@itwin/property-grid-react check-extractions :  
@itwin/property-grid-react check-extractions :  > @itwin/property-grid-react@1.19.6 check-extractions /home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/property-grid
@itwin/property-grid-react check-extractions :  > node ../../../scripts/updateExtractions.js --targets=./README.md --check
@itwin/property-grid-react check-extractions :  
@itwin/property-grid-react check-extractions :  Gathering extractions from different packages...
@itwin/property-grid-react check-extractions :  [
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: 'learning-snippets',
@itwin/property-grid-react check-extractions :      version: '0.0.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/apps/learning-snippets',
@itwin/property-grid-react check-extractions :      private: true
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: 'vcr-performance-tests',
@itwin/property-grid-react check-extractions :      version: '0.0.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/apps/performance-tests',
@itwin/property-grid-react check-extractions :      private: true
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: 'test-viewer',
@itwin/property-grid-react check-extractions :      version: '0.1.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/apps/test-viewer',
@itwin/property-grid-react check-extractions :      private: true
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/ec3-widget-react',
@itwin/property-grid-react check-extractions :      version: '0.10.1',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/ec3-widget',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/geo-tools-react',
@itwin/property-grid-react check-extractions :      version: '6.0.1',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/geo-tools',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/grouping-mapping-widget',
@itwin/property-grid-react check-extractions :      version: '0.37.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/grouping-mapping-widget',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/map-layers',
@itwin/property-grid-react check-extractions :      version: '6.2.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/map-layers',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/measure-tools-react',
@itwin/property-grid-react check-extractions :      version: '0.32.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/measure-tools',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/one-click-lca-react',
@itwin/property-grid-react check-extractions :      version: '0.8.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/one-click-lca-widget',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/property-grid-react',
@itwin/property-grid-react check-extractions :      version: '1.19.6',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/property-grid',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/quantity-formatting-react',
@itwin/property-grid-react check-extractions :      version: '0.1.4',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/quantity-formatting',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/reports-config-widget-react',
@itwin/property-grid-react check-extractions :      version: '0.9.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/reports-config-widget',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: 'test-utilities',
@itwin/property-grid-react check-extractions :      version: '0.0.0',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/test-utilities',
@itwin/property-grid-react check-extractions :      private: true
@itwin/property-grid-react check-extractions :    },
@itwin/property-grid-react check-extractions :    {
@itwin/property-grid-react check-extractions :      name: '@itwin/tree-widget-react',
@itwin/property-grid-react check-extractions :      version: '3.17.9',
@itwin/property-grid-react check-extractions :      path: '/home/runner/work/viewer-components-react/viewer-components-react/packages/itwin/tree-widget',
@itwin/property-grid-react check-extractions :      private: false
@itwin/property-grid-react check-extractions :    }
@itwin/property-grid-react check-extractions :  ]
@itwin/property-grid-react check-extractions :  Processing target "./README.md"...
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ComponentWithTelemetryWrapperImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ComponentWithTelemetryWrapper
@itwin/property-grid-react check-extractions :  Updated extraction "[PropertyGrid.ComponentWithTelemetryWrapperImports, PropertyGrid.ComponentWithTelemetryWrapper]" at line 353 in file "./README.md".
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ComponentWithTelemetryImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ComponentWithTelemetry
@itwin/property-grid-react check-extractions :  Updated extraction "[PropertyGrid.ComponentWithTelemetryImports, PropertyGrid.ComponentWithTelemetry]" at line 327 in file "./README.md".
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.PropertyGridWithSettingsMenuItemImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.PropertyGridWithSettingsMenuItem
@itwin/property-grid-react check-extractions :  Updated extraction "[PropertyGrid.PropertyGridWithSettingsMenuItemImports, PropertyGrid.PropertyGridWithSettingsMenuItem]" at line 265 in file "./README.md".
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ExampleSettingsMenuItemImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ExampleSettingsMenuItem
@itwin/property-grid-react check-extractions :  Updated extraction "[PropertyGrid.ExampleSettingsMenuItemImports, PropertyGrid.ExampleSettingsMenuItem]" at line 240 in file "./README.md".
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.PropertyGridWithContextMenuItemImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.PropertyGridWithContextMenuItem
@itwin/property-grid-react check-extractions :  Updated extraction "[PropertyGrid.PropertyGridWithContextMenuItemImports, PropertyGrid.PropertyGridWithContextMenuItem]" at line 201 in file "./README.md".
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ExampleContextMenuItemImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.ExampleContextMenuItem
@itwin/property-grid-react check-extractions :  Updated extraction "[PropertyGrid.ExampleContextMenuItemImports, PropertyGrid.ExampleContextMenuItem]" at line 174 in file "./README.md".
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.RegisterCustomPropertyGridWidgetImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.RegisterCustomPropertyGridWidget
@itwin/property-grid-react check-extractions :  Updated extraction "[PropertyGrid.RegisterCustomPropertyGridWidgetImports, PropertyGrid.RegisterCustomPropertyGridWidget]" at line 45 in file "./README.md".
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.RegisterPropertyGridWidgetImports
@itwin/property-grid-react check-extractions :  /home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.RegisterPropertyGridWidget
@itwin/property-grid-react check-extractions :  node:fs:440
@itwin/property-grid-react check-extractions :      return binding.readFileUtf8(path, stringToFlags(options.flag));
@itwin/property-grid-react check-extractions :                     ^
@itwin/property-grid-react check-extractions :  
@itwin/property-grid-react check-extractions :  Error: ENOENT: no such file or directory, open '/home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.RegisterPropertyGridWidget'
@itwin/property-grid-react check-extractions :      at Object.readFileSync (node:fs:440:20)
@itwin/property-grid-react check-extractions :      at /home/runner/work/viewer-components-react/viewer-components-react/scripts/updateExtractions.js:125:28
@itwin/property-grid-react check-extractions :      at Array.reduce (<anonymous>)
@itwin/property-grid-react check-extractions :      at /home/runner/work/viewer-components-react/viewer-components-react/scripts/updateExtractions.js:116:8
@itwin/property-grid-react check-extractions :      at Array.forEach (<anonymous>)
@itwin/property-grid-react check-extractions :      at handleTargetFile (/home/runner/work/viewer-components-react/viewer-components-react/scripts/updateExtractions.js:107:14)
@itwin/property-grid-react check-extractions :      at /home/runner/work/viewer-components-react/viewer-components-react/scripts/updateExtractions.js:49:5
@itwin/property-grid-react check-extractions :      at Array.forEach (<anonymous>)
@itwin/property-grid-react check-extractions :      at Object.<anonymous> (/home/runner/work/viewer-components-react/viewer-components-react/scripts/updateExtractions.js:41:20)
@itwin/property-grid-react check-extractions :      at Module._compile (node:internal/modules/cjs/loader:1705:14) {
@itwin/property-grid-react check-extractions :    errno: -2,
@itwin/property-grid-react check-extractions :    code: 'ENOENT',
@itwin/property-grid-react check-extractions :    syscall: 'open',
@itwin/property-grid-react check-extractions :    path: '/home/runner/work/viewer-components-react/viewer-components-react/build/docs/extract/PropertyGrid.RegisterPropertyGridWidget'
@itwin/property-grid-react check-extractions :  }
@itwin/property-grid-react check-extractions :  
@itwin/property-grid-react check-extractions :  Node.js v22.22.2
@itwin/property-grid-react check-extractions :   ELIFECYCLE  Command failed with exit code 1.
@itwin/property-grid-react check-extractions ✖ fail
```

`lage` runs the `check-extractions` script for multiple packages in parallel, and we ended up in situations where:
- Package1 has already gathered extractions and is already injecting them into markdowns,
- Package2 is in the process of gathering extractions.

If Package1 was looking for an extraction file that was at the same time being replaced by Package2 script, we got this error.

The solution is to run `gatherExtractions` script once before starting the checks for all packages.

The problem was that 