### PR TITLE
[Tree widget]: optimistically update child nodes visibility state

### DIFF
--- a/change/@itwin-tree-widget-react-6e15ce9a-b906-4d93-b980-6805801ca1ed.json
+++ b/change/@itwin-tree-widget-react-6e15ce9a-b906-4d93-b980-6805801ca1ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Visibility trees: make child nodes visibility state be updated optimistically.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/test/trees/common/UseHierarchyVisibility.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/UseHierarchyVisibility.test.ts
@@ -147,10 +147,10 @@ describe("useHierarchyVisibility", () => {
     });
 
     act(() => {
-      // expect visibility state to be optimistically updated to 'visible'
+      // expect visibility state to be optimistically updated to 'hidden'
       expect(visibilityHandler.getVisibilityStatus).toHaveBeenCalledOnce();
       const state = result.current.getVisibilityButtonState(node);
-      expect(state).toEqual({ state: "visible", tooltip: "visibilityTooltips.status.determining" });
+      expect(state).toEqual({ state: "hidden", tooltip: "visibilityTooltips.status.determining" });
     });
 
     await waitFor(() => {
@@ -161,5 +161,60 @@ describe("useHierarchyVisibility", () => {
     });
 
     expect(visibilityHandler.getVisibilityStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("optimistically updates children visibility when changing parent visibility", async () => {
+    const grandchild = createTreeNode({ id: "grandchild-1" });
+    const child = createTreeNode({ id: "child-1", children: [grandchild] });
+    const parent = createTreeNode({ id: "parent-1", children: [child] });
+
+    const { result } = renderHook(useHierarchyVisibility, { initialProps });
+
+    visibilityHandler.getVisibilityStatus.mockResolvedValue({ state: "visible" });
+
+    act(() => {
+      result.current.getVisibilityButtonState(parent);
+      result.current.getVisibilityButtonState(child);
+      result.current.getVisibilityButtonState(grandchild);
+    });
+
+    await waitFor(() => {
+      expect(visibilityHandler.getVisibilityStatus).toHaveBeenCalledTimes(3);
+      expect(result.current.getVisibilityButtonState(parent)).toEqual({ state: "visible", tooltip: "visibilityTooltips.status.visible" });
+      expect(result.current.getVisibilityButtonState(child)).toEqual({ state: "visible", tooltip: "visibilityTooltips.status.visible" });
+      expect(result.current.getVisibilityButtonState(grandchild)).toEqual({ state: "visible", tooltip: "visibilityTooltips.status.visible" });
+    });
+
+    // Toggle parent from visible to hidden
+    act(() => {
+      result.current.onVisibilityButtonClick(parent, "visible");
+    });
+
+    // All descendants should be optimistically set to "hidden"
+    act(() => {
+      expect(result.current.getVisibilityButtonState(parent)).toEqual({ state: "hidden", tooltip: "visibilityTooltips.status.determining" });
+      expect(result.current.getVisibilityButtonState(child)).toEqual({ state: "hidden", tooltip: "visibilityTooltips.status.determining" });
+      expect(result.current.getVisibilityButtonState(grandchild)).toEqual({ state: "hidden", tooltip: "visibilityTooltips.status.determining" });
+    });
+
+    // Simulate handler reporting actual visibility after change
+    visibilityHandler.getVisibilityStatus.mockResolvedValue({ state: "hidden" });
+
+    act(() => {
+      onVisibilityChange.raiseEvent();
+    });
+
+    act(() => {
+      result.current.getVisibilityButtonState(parent);
+      result.current.getVisibilityButtonState(child);
+      result.current.getVisibilityButtonState(grandchild);
+    });
+
+    // After reconciliation, all nodes should reflect the actual handler state
+    await waitFor(() => {
+      expect(result.current.getVisibilityButtonState(parent)).toEqual({ state: "hidden", tooltip: "visibilityTooltips.status.hidden" });
+      expect(result.current.getVisibilityButtonState(child)).toEqual({ state: "hidden", tooltip: "visibilityTooltips.status.hidden" });
+      expect(result.current.getVisibilityButtonState(grandchild)).toEqual({ state: "hidden", tooltip: "visibilityTooltips.status.hidden" });
+    });
   });
 });

--- a/packages/itwin/tree-widget/src/test/trees/common/UseHierarchyVisibility.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/UseHierarchyVisibility.test.ts
@@ -172,14 +172,7 @@ describe("useHierarchyVisibility", () => {
 
     visibilityHandler.getVisibilityStatus.mockResolvedValue({ state: "visible" });
 
-    act(() => {
-      result.current.getVisibilityButtonState(parent);
-      result.current.getVisibilityButtonState(child);
-      result.current.getVisibilityButtonState(grandchild);
-    });
-
     await waitFor(() => {
-      expect(visibilityHandler.getVisibilityStatus).toHaveBeenCalledTimes(3);
       expect(result.current.getVisibilityButtonState(parent)).toEqual({ state: "visible", tooltip: "visibilityTooltips.status.visible" });
       expect(result.current.getVisibilityButtonState(child)).toEqual({ state: "visible", tooltip: "visibilityTooltips.status.visible" });
       expect(result.current.getVisibilityButtonState(grandchild)).toEqual({ state: "visible", tooltip: "visibilityTooltips.status.visible" });
@@ -202,12 +195,6 @@ describe("useHierarchyVisibility", () => {
 
     act(() => {
       onVisibilityChange.raiseEvent();
-    });
-
-    act(() => {
-      result.current.getVisibilityButtonState(parent);
-      result.current.getVisibilityButtonState(child);
-      result.current.getVisibilityButtonState(grandchild);
     });
 
     // After reconciliation, all nodes should reflect the actual handler state

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
@@ -10,7 +10,6 @@ import { createTooltip } from "./internal/Tooltip.js";
 import { useErrorState } from "./internal/UseErrorState.js";
 import { useTelemetryContext } from "./UseTelemetryContext.js";
 
-import type { MutableRefObject } from "react";
 import type { Observable } from "rxjs";
 import type { BeEvent } from "@itwin/core-bentley";
 import type { HierarchyNode, TreeNode } from "@itwin/presentation-hierarchies-react";
@@ -44,20 +43,18 @@ interface UseHierarchyVisibilityProps {
   visibilityHandlerFactory: () => HierarchyVisibilityHandler;
 }
 
-type VisibilityStatusMap = MutableRefObject<
-  Map<
-    string,
-    {
-      node: TreeNode;
-      status: TreeItemVisibilityButtonState;
-      needsRefresh: boolean;
-    }
-  >
+type VisibilityStatusMap = Map<
+  string,
+  {
+    node: TreeNode;
+    status: TreeItemVisibilityButtonState;
+    needsRefresh: boolean;
+  }
 >;
 
 /** @internal */
 export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarchyVisibilityProps): VisibilityContext & { triggerRefresh: () => void } {
-  const visibilityStatusMap: VisibilityStatusMap = useRef(new Map());
+  const visibilityStatusMap = useRef<VisibilityStatusMap>(new Map());
   const [state, setState] = useState<VisibilityContext & { triggerRefresh: () => void }>({
     getVisibilityButtonState: () => ({ isLoading: true }),
     onVisibilityButtonClick: () => {},
@@ -87,7 +84,7 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
     const triggerCheckboxUpdate = () => {
       setState((prev) => ({
         ...prev,
-        getVisibilityButtonState: createStateGetter(visibilityStatusMap, calculateNodeStatus),
+        getVisibilityButtonState: createStateGetter(visibilityStatusMap.current, calculateNodeStatus),
       }));
     };
 
@@ -126,7 +123,6 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
 
     const changeVisibility: VisibilityContext["onVisibilityButtonClick"] = (node, visibilityState) => {
       onFeatureUsed({ featureId: "visibility-change", reportInteraction: true });
-      // visible should become hidden, partial and hidden should become visible TODO: redo for clarity
       const { on, newState } = visibilityState === "visible" ? { on: false, newState: "hidden" as const } : { on: true, newState: "visible" as const };
       void (async () => {
         try {
@@ -143,7 +139,7 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
         node,
         newState,
         tooltip,
-        map: visibilityStatusMap,
+        map: visibilityStatusMap.current,
       });
       if (!entry) {
         return;
@@ -159,7 +155,7 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
 
     setState({
       onVisibilityButtonClick: changeVisibility,
-      getVisibilityButtonState: createStateGetter(visibilityStatusMap, calculateNodeStatus),
+      getVisibilityButtonState: createStateGetter(visibilityStatusMap.current, calculateNodeStatus),
       triggerRefresh: () => {
         resetCache();
         triggerCheckboxUpdate();
@@ -194,7 +190,7 @@ function setChildrenStateRecursively({
 }) {
   if (Array.isArray(node.children)) {
     for (const child of node.children) {
-      const childEntry = map.current.get(child.id);
+      const childEntry = map.get(child.id);
       if (childEntry) {
         childEntry.status = {
           ...childEntry.status,
@@ -215,7 +211,7 @@ function setChildrenStateRecursively({
 
 function createStateGetter(map: VisibilityStatusMap, calculateVisibility: (node: TreeNode) => void): VisibilityContext["getVisibilityButtonState"] {
   return (node) => {
-    const entry = map.current.get(node.id);
+    const entry = map.get(node.id);
     if (entry === undefined) {
       calculateVisibility(node);
       return { isLoading: true };

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
@@ -44,9 +44,20 @@ interface UseHierarchyVisibilityProps {
   visibilityHandlerFactory: () => HierarchyVisibilityHandler;
 }
 
+type VisibilityStatusMap = MutableRefObject<
+  Map<
+    string,
+    {
+      node: TreeNode;
+      status: TreeItemVisibilityButtonState;
+      needsRefresh: boolean;
+    }
+  >
+>;
+
 /** @internal */
 export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarchyVisibilityProps): VisibilityContext & { triggerRefresh: () => void } {
-  const visibilityStatusMap = useRef(new Map<string, { node: TreeNode; status: TreeItemVisibilityButtonState; needsRefresh: boolean }>());
+  const visibilityStatusMap: VisibilityStatusMap = useRef(new Map());
   const [state, setState] = useState<VisibilityContext & { triggerRefresh: () => void }>({
     getVisibilityButtonState: () => ({ isLoading: true }),
     onVisibilityButtonClick: () => {},
@@ -116,21 +127,29 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
     const changeVisibility: VisibilityContext["onVisibilityButtonClick"] = (node, visibilityState) => {
       onFeatureUsed({ featureId: "visibility-change", reportInteraction: true });
       // visible should become hidden, partial and hidden should become visible TODO: redo for clarity
-      const on = visibilityState === "visible" ? false : true;
+      const { on, newState } = visibilityState === "visible" ? { on: false, newState: "hidden" as const } : { on: true, newState: "visible" as const };
       void (async () => {
         try {
           await handler.changeVisibility(node.nodeData, on);
         } catch {}
       })();
+      const tooltip = createTooltip("determining", translate);
       const entry = visibilityStatusMap.current.get(node.id);
+      setChildrenStateRecursively({
+        node,
+        newState,
+        tooltip,
+        map: visibilityStatusMap,
+      });
       if (!entry) {
         return;
       }
       entry.status = {
         ...entry.status,
-        state: visibilityState,
-        tooltip: createTooltip("determining", translate),
+        state: newState,
+        tooltip,
       };
+      entry.needsRefresh = true;
       triggerCheckboxUpdate();
     };
 
@@ -158,10 +177,39 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
   return state;
 }
 
-function createStateGetter(
-  map: MutableRefObject<Map<string, { node: TreeNode; status: TreeItemVisibilityButtonState; needsRefresh: boolean }>>,
-  calculateVisibility: (node: TreeNode) => void,
-): VisibilityContext["getVisibilityButtonState"] {
+function setChildrenStateRecursively({
+  node,
+  newState,
+  tooltip,
+  map,
+}: {
+  node: TreeNode;
+  newState: "visible" | "hidden";
+  tooltip: string;
+  map: MutableRefObject<Map<string, { node: TreeNode; status: TreeItemVisibilityButtonState; needsRefresh: boolean }>>;
+}) {
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const childEntry = map.current.get(child.id);
+      if (childEntry) {
+        childEntry.status = {
+          ...childEntry.status,
+          state: newState,
+          tooltip,
+        };
+        childEntry.needsRefresh = true;
+      }
+      setChildrenStateRecursively({
+        node: child,
+        newState,
+        tooltip,
+        map,
+      });
+    }
+  }
+}
+
+function createStateGetter(map: VisibilityStatusMap, calculateVisibility: (node: TreeNode) => void): VisibilityContext["getVisibilityButtonState"] {
   return (node) => {
     const entry = map.current.get(node.id);
     if (entry === undefined) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/UseHierarchyVisibility.ts
@@ -131,7 +131,11 @@ export function useHierarchyVisibility({ visibilityHandlerFactory }: UseHierarch
       void (async () => {
         try {
           await handler.changeVisibility(node.nodeData, on);
-        } catch {}
+        } catch (error) {
+          setErrorState(error);
+          resetCache();
+          triggerCheckboxUpdate();
+        }
       })();
       const tooltip = createTooltip("determining", translate);
       const entry = visibilityStatusMap.current.get(node.id);
@@ -186,7 +190,7 @@ function setChildrenStateRecursively({
   node: TreeNode;
   newState: "visible" | "hidden";
   tooltip: string;
-  map: MutableRefObject<Map<string, { node: TreeNode; status: TreeItemVisibilityButtonState; needsRefresh: boolean }>>;
+  map: VisibilityStatusMap;
 }) {
   if (Array.isArray(node.children)) {
     for (const child of node.children) {


### PR DESCRIPTION
While looking at https://github.com/iTwin/viewer-components-react/issues/1649, realized that child nodes state can be optimistically updated. Adjusted.

This PR builds on `UseHierarchyVisibility` changes made in https://github.com/iTwin/viewer-components-react/pull/1650