### PR TITLE
[Tree widget]: Adjust caching behavior on `next`

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -54,6 +54,7 @@
     "e2e-out",
     "**/CHANGELOG.*",
     "**/tsconfig.json",
+    "**/*.tsbuildinfo",
     "**/*.api.md",
     "breakdown-trees",
     "ec3-widget",

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
@@ -338,7 +338,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
 
       setterFunction(newSet, vp);
       queryPausePromise.resolve();
-      // After change, set still contains > 2x the treshold, so there should be 3 new queries executed.
+      // After change, set still contains > 2x the threshold, so there should be 3 new queries executed.
       const firstResult = await firstPromise;
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5); // 2 on the first run, 3 after the change
 

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
@@ -6,6 +6,7 @@
 import { firstValueFrom } from "rxjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ALWAYS_NEVER_BUFFER_THRESHOLD,
   AlwaysAndNeverDrawnElementInfoCache,
   SET_CHANGE_DEBOUNCE_TIME,
 } from "../../../../tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
@@ -282,6 +283,177 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
 
       await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
+    });
+
+    it(`executes number of queries based on buffer threshold for ${setType}Drawn`, async () => {
+      // For this test no need to check if debounce time is working
+      vi.useRealTimers();
+
+      const modelId = "0x1";
+      const set = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+
+      using vp = createFakeViewport({
+        [`${setType}Drawn`]: set,
+      });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
+      await firstValueFrom(info.getElementsTree({ setType, modelId }));
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
+      const setterFunction = (ids: Set<Id64String>) => {
+        if (setType === "always") {
+          vp.setAlwaysDrawn({ elementIds: ids });
+          return;
+        }
+        vp.setNeverDrawn({ elementIds: ids });
+      };
+      const newSet = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+      setterFunction(newSet);
+      await firstValueFrom(info.getElementsTree({ setType, modelId }));
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5); // 2 previous + 3 new
+    });
+
+    it(`cancels scheduled queries when ${setType}Drawn changes without suppression`, async () => {
+      // For this test no need to check if debounce time is working
+      vi.useRealTimers();
+
+      const modelId = "0x1";
+      const set = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+
+      const setterFunction = (ids: Set<Id64String>) => {
+        if (setType === "always") {
+          vp.setAlwaysDrawn({ elementIds: ids });
+          return;
+        }
+        vp.setNeverDrawn({ elementIds: ids });
+      };
+      let resolvablePromise: undefined | ((_?: unknown) => void);
+      let queryExecutedResolvablePromise: undefined | ((_?: unknown) => void);
+      const queryExecutedPromise = new Promise((resolve) => {
+        queryExecutedResolvablePromise = resolve;
+      });
+      using vp = createFakeViewport({
+        [`${setType}Drawn`]: set,
+        queryHandler: vi
+          .fn()
+          .mockImplementationOnce(async () => {
+            queryExecutedResolvablePromise?.();
+            await new Promise((resolve) => {
+              resolvablePromise = resolve;
+            }); // wait to ensure debounce time has passed and query is scheduled
+            return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x3" }];
+          })
+          .mockImplementation(() => {
+            return [{ rootCategoryId: "0x5", categoryId: "0x5", modelId: "0x1", elementsPath: "0x4" }];
+          }),
+      });
+
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
+      const firstPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
+      await queryExecutedPromise;
+      const newSet = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+      setterFunction(newSet);
+      resolvablePromise?.();
+      const firstResult = await firstPromise;
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
+
+      const secondResult = await firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
+      const expectedResult = new Set(["0x4"]);
+      expect(secondResult).toEqual(expectedResult);
+      expect(firstResult).toEqual(expectedResult);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
+    });
+
+    it(`updates latestCacheEntryValue depending on when ${setType}Drawn changes`, async () => {
+      // For this test no need to check if debounce time is working
+      vi.useRealTimers();
+
+      const modelId = "0x1";
+      const set = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+
+      let resolvablePromise: undefined | ((_?: unknown) => void);
+      let queryExecutedResolvablePromise: undefined | ((_?: unknown) => void);
+      const queryExecutedPromise = new Promise((resolve) => {
+        queryExecutedResolvablePromise = resolve;
+      });
+
+      const vp = createFakeViewport({
+        [`${setType}Drawn`]: set,
+        queryHandler: vi
+          .fn()
+          .mockImplementationOnce(async () => {
+            queryExecutedResolvablePromise?.();
+            await new Promise((resolve) => {
+              resolvablePromise = resolve;
+            });
+            return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x3" }];
+          })
+          .mockImplementation((...args) => {
+            const config = args[2];
+            if (config.restartToken.endsWith("-0")) {
+              return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x4" }];
+            }
+            if (config.restartToken.endsWith("-1")) {
+              return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x5" }];
+            }
+            return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x6" }];
+          }),
+      });
+
+      const info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
+      // first request: results depends on change
+      const firstPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
+      await queryExecutedPromise;
+      info.suppressChangeEvents();
+      // second request: results will be generated for the current state
+      const secondPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
+      info.resumeChangeEvents();
+
+      const setterFunction = (ids: Set<Id64String>) => {
+        if (setType === "always") {
+          vp.setAlwaysDrawn({ elementIds: ids });
+          return;
+        }
+        vp.setNeverDrawn({ elementIds: ids });
+      };
+      const newSet = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+      setterFunction(newSet);
+      info.suppressChangeEvents();
+      // third request: since suppression happened after change event, latestCacheEntryValue contains the new values
+      const thirdPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
+      resolvablePromise?.();
+      const secondResult = await secondPromise;
+      info.resumeChangeEvents();
+      const firstResult = await firstPromise;
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
+      const expectedResultAfterChange = new Set(["0x4", "0x5"]);
+      const expectedResultBeforeChange = new Set(["0x3", "0x5", "0x6"]);
+      expect(firstResult).toEqual(expectedResultAfterChange);
+      expect(secondResult).toEqual(expectedResultBeforeChange);
+      expect(await thirdPromise).toEqual(expectedResultAfterChange);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
     });
 
     it(`requeries when suppression is removed and ${setType}Drawn changes`, async () => {

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
@@ -175,6 +175,48 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
     });
 
+    it.only(`finishes pending request when suppression is activated for ${setType}Drawn after event fires but before debounce time has passed`, async () => {
+      const modelId = "0x1";
+      const categoryId = "0x2";
+      const elementId = "0x3";
+      const set = new Set([elementId]);
+      const queryHandler = vi
+        .fn()
+        .mockReturnValueOnce([{ rootCategoryId: categoryId, modelId, categoryId, elementsPath: elementId }])
+        .mockReturnValueOnce([{ rootCategoryId: categoryId, modelId, categoryId, elementsPath: "0x4" }]);
+
+      using vp = createFakeViewport({
+        [`${setType}Drawn`]: set,
+        queryHandler,
+      });
+
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
+      await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
+      const result1 = await firstValueFrom(info.getElementsTree({ setType, modelId }));
+      const expectedResult: ChildrenTree<MapEntry> = new Map();
+      expectedResult.set(categoryId, { children: new Map([[elementId, { categoryId, isInAlwaysOrNeverDrawnSet: true }]]), isInAlwaysOrNeverDrawnSet: false });
+      expect(result1).toEqual(expectedResult);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+      const setterFunction = (ids: Set<Id64String>) => {
+        if (setType === "always") {
+          vp.setAlwaysDrawn({ elementIds: ids });
+          return;
+        }
+        vp.setNeverDrawn({ elementIds: ids });
+      };
+      setterFunction(new Set(["0x4"]));
+      info.suppressChangeEvents();
+      const promiseResult2 = firstValueFrom(info.getElementsTree({ setType, modelId }));
+      await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
+      const result2 = await promiseResult2;
+      expectedResult.set(categoryId, { children: new Map([["0x4", { categoryId, isInAlwaysOrNeverDrawnSet: true }]]), isInAlwaysOrNeverDrawnSet: false });
+      info.resumeChangeEvents();
+      const result3 = await firstValueFrom(info.getElementsTree({ setType, modelId }));
+      expect(result2).toEqual(expectedResult);
+      expect(result3).toEqual(expectedResult);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
+    });
+
     it(`does not requery when suppress is activated and deactivated for ${setType}Drawn`, async () => {
       const modelId = "0x1";
       const categoryId = "0x2";

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
@@ -330,13 +330,6 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
           .map((_, i) => `0x${i}`),
       );
 
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
       let resolvablePromise: undefined | ((_?: unknown) => void);
       let queryExecutedResolvablePromise: undefined | ((_?: unknown) => void);
       const queryExecutedPromise = new Promise((resolve) => {
@@ -366,6 +359,14 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
           .fill(0)
           .map((_, i) => `0x${i}`),
       );
+
+      const setterFunction = (ids: Set<Id64String>) => {
+        if (setType === "always") {
+          vp.setAlwaysDrawn({ elementIds: ids });
+          return;
+        }
+        vp.setNeverDrawn({ elementIds: ids });
+      };
       setterFunction(newSet);
       resolvablePromise?.();
       const firstResult = await firstPromise;
@@ -395,7 +396,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
         queryExecutedResolvablePromise = resolve;
       });
 
-      const vp = createFakeViewport({
+      using vp = createFakeViewport({
         [`${setType}Drawn`]: set,
         queryHandler: vi
           .fn()
@@ -418,7 +419,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
           }),
       });
 
-      const info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       // first request: results depends on change
       const firstPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
       await queryExecutedPromise;

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
@@ -10,9 +10,11 @@ import {
   AlwaysAndNeverDrawnElementInfoCache,
   SET_CHANGE_DEBOUNCE_TIME,
 } from "../../../../tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
+import { createResolvablePromise } from "../../../TestUtils.js";
 import { createFakeViewport } from "../../Common.js";
 
 import type { Id64String } from "@itwin/core-bentley";
+import type { TreeWidgetViewport } from "../../../../tree-widget-react.js";
 import type { MapEntry } from "../../../../tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { ChildrenTree } from "../../../../tree-widget-react/components/trees/common/internal/Utils.js";
 
@@ -26,7 +28,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
     vi.useRealTimers();
   });
 
-  function runTests(setType: "always" | "never") {
+  function runTests(setType: "always" | "never", setterFunction: (ids: Set<Id64String>, vp: TreeWidgetViewport) => void) {
     it(`subscribes to ${setType}Drawn list changes and unsubscribes on dispose`, async () => {
       using vp = createFakeViewport();
       const event = setType === "always" ? vp.onAlwaysDrawnChanged : vp.onNeverDrawnChanged;
@@ -135,14 +137,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       expect(result).toEqual(expectedResult);
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
 
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
-      setterFunction(new Set(["0x4"]));
+      setterFunction(new Set(["0x4"]), vp);
 
       const resultPromise2 = firstValueFrom(info.getElementsTree({ setType, modelId }));
       await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
@@ -163,14 +158,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       await firstValueFrom(info.getElementsTree({ setType, modelId: "0x2" }));
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
       const resultPromise2 = firstValueFrom(info.getElementsTree({ setType, modelId: "0x2" }));
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
-      setterFunction(new Set(["0x2"]));
+      setterFunction(new Set(["0x2"]), vp);
       await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
       await resultPromise2;
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
@@ -198,14 +186,9 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       expectedResult.set(categoryId, { children: new Map([[elementId, { categoryId, isInAlwaysOrNeverDrawnSet: true }]]), isInAlwaysOrNeverDrawnSet: false });
       expect(result1).toEqual(expectedResult);
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
-      setterFunction(new Set(["0x4"]));
+
+      setterFunction(new Set(["0x4"]), vp);
+
       info.suppressChangeEvents();
       const promiseResult2 = firstValueFrom(info.getElementsTree({ setType, modelId }));
       await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
@@ -267,14 +250,8 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       expect(result1).toEqual(expectedResult);
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
       info.suppressChangeEvents();
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
-      setterFunction(new Set(["0x4"]));
+
+      setterFunction(new Set(["0x4"]), vp);
       await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
       await firstValueFrom(info.getElementsTree({ setType, modelId }));
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
@@ -290,6 +267,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       vi.useRealTimers();
 
       const modelId = "0x1";
+      // Always drawn cache makes multiple queries if number of elements in always/never drawn set is above a threshold,
       const set = new Set(
         Array(ALWAYS_NEVER_BUFFER_THRESHOLD + 1)
           .fill(0)
@@ -301,20 +279,15 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       });
       using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       await firstValueFrom(info.getElementsTree({ setType, modelId }));
+      // First time the set is just above the threshold, so there should be 2 queries
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
       const newSet = new Set(
         Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
           .fill(0)
           .map((_, i) => `0x${i}`),
       );
-      setterFunction(newSet);
+      setterFunction(newSet, vp);
+      // Second set contains more than twice the threshold, so there should be 3 new queries
       await firstValueFrom(info.getElementsTree({ setType, modelId }));
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5); // 2 previous + 3 new
     });
@@ -324,26 +297,23 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       vi.useRealTimers();
 
       const modelId = "0x1";
+      // Set contains > 2x the threshold to ensure 3 queries are scheduled
       const set = new Set(
         Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
           .fill(0)
           .map((_, i) => `0x${i}`),
       );
 
-      let resolvablePromise: undefined | ((_?: unknown) => void);
-      let queryExecutedResolvablePromise: undefined | ((_?: unknown) => void);
-      const queryExecutedPromise = new Promise((resolve) => {
-        queryExecutedResolvablePromise = resolve;
-      });
+      const queryStartedPromise = createResolvablePromise<void>();
+      const queryPausePromise = createResolvablePromise<void>();
       using vp = createFakeViewport({
         [`${setType}Drawn`]: set,
         queryHandler: vi
           .fn()
           .mockImplementationOnce(async () => {
-            queryExecutedResolvablePromise?.();
-            await new Promise((resolve) => {
-              resolvablePromise = resolve;
-            }); // wait to ensure debounce time has passed and query is scheduled
+            queryStartedPromise.resolve();
+            await queryPausePromise.promise;
+
             return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x3" }];
           })
           .mockImplementation(() => {
@@ -353,25 +323,26 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
 
       using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
       const firstPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
-      await queryExecutedPromise;
+      await queryStartedPromise.promise;
+      // Before making the changes make sure that the first query has started,
+      // Since cache is executing two queries at the same time, 2 queries should have been started by now
+      // In total 3 queries should be executed to process the initial set
+      // Since first query is paused, expect that the third one is not called
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
+
       const newSet = new Set(
         Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
           .fill(0)
           .map((_, i) => `0x${i}`),
       );
 
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
-      setterFunction(newSet);
-      resolvablePromise?.();
+      setterFunction(newSet, vp);
+      queryPausePromise.resolve();
+      // After change, set still contains > 2x the treshold, so there should be 3 new queries executed.
       const firstResult = await firstPromise;
-      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5); // 2 on the first run, 3 after the change
 
+      // Second request should not make any new requests
       const secondResult = await firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
       const expectedResult = new Set(["0x4"]);
       expect(secondResult).toEqual(expectedResult);
@@ -379,40 +350,35 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
     });
 
-    it(`updates latestCacheEntryValue depending on when ${setType}Drawn changes`, async () => {
+    it(`returns latest values when suppress is not active and ${setType}Drawn changes during query execution`, async () => {
       // For this test no need to check if debounce time is working
       vi.useRealTimers();
 
       const modelId = "0x1";
+      // Should make 3 queries for the initial set
       const set = new Set(
         Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
           .fill(0)
           .map((_, i) => `0x${i}`),
       );
 
-      let resolvablePromise: undefined | ((_?: unknown) => void);
-      let queryExecutedResolvablePromise: undefined | ((_?: unknown) => void);
-      const queryExecutedPromise = new Promise((resolve) => {
-        queryExecutedResolvablePromise = resolve;
-      });
-
+      const queryStartedPromise = createResolvablePromise<void>();
+      const queryPausePromise = createResolvablePromise<void>();
       using vp = createFakeViewport({
         [`${setType}Drawn`]: set,
         queryHandler: vi
           .fn()
           .mockImplementationOnce(async () => {
-            queryExecutedResolvablePromise?.();
-            await new Promise((resolve) => {
-              resolvablePromise = resolve;
-            });
+            queryStartedPromise.resolve();
+            await queryPausePromise.promise;
             return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x3" }];
           })
           .mockImplementation((...args) => {
-            const config = args[2];
-            if (config.restartToken.endsWith("-0")) {
+            const restartToken = args[2].restartToken as string;
+            if (restartToken.endsWith("-0")) {
               return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x4" }];
             }
-            if (config.restartToken.endsWith("-1")) {
+            if (restartToken.endsWith("-1")) {
               return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x5" }];
             }
             return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x6" }];
@@ -420,41 +386,81 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       });
 
       using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
-      // first request: results depends on change
-      const firstPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
-      await queryExecutedPromise;
-      info.suppressChangeEvents();
-      // second request: results will be generated for the current state
-      const secondPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
-      info.resumeChangeEvents();
+      const resultPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
+      await queryStartedPromise.promise;
+      // At first there should have been 2 queries started,
+      // Since the first query is paused, the 3rd query should not have been called
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
 
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
       const newSet = new Set(
         Array(ALWAYS_NEVER_BUFFER_THRESHOLD + 1)
           .fill(0)
           .map((_, i) => `0x${i}`),
       );
-      setterFunction(newSet);
+      setterFunction(newSet, vp);
+      queryPausePromise.resolve();
+      const result = await resultPromise;
+      // Set has changed during execution, since the new set contains more than the threshold,
+      // There should be 2 new queries executed
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(4); // 2 on first run, 2 after the change
+      expect(result).toEqual(new Set(["0x4", "0x5"]));
+    });
+
+    it(`returns values that were at the time of the call when suppress is active and ${setType}Drawn changes during query execution`, async () => {
+      // For this test no need to check if debounce time is working
+      vi.useRealTimers();
+
+      const modelId = "0x1";
+      // There should be 3 queries for the initial set
+      const set = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 2 + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+
+      const queryStartedPromise = createResolvablePromise<void>();
+      const queryPausePromise = createResolvablePromise<void>();
+      using vp = createFakeViewport({
+        [`${setType}Drawn`]: set,
+        queryHandler: vi
+          .fn()
+          .mockImplementationOnce(async () => {
+            queryStartedPromise.resolve();
+            await queryPausePromise.promise;
+            return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x3" }];
+          })
+          .mockImplementation((...args) => {
+            const restartToken = args[2].restartToken as string;
+            if (restartToken.endsWith("-0")) {
+              return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x4" }];
+            }
+            if (restartToken.endsWith("-1")) {
+              return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x5" }];
+            }
+            return [{ rootCategoryId: "0x2", categoryId: "0x2", modelId: "0x1", elementsPath: "0x6" }];
+          }),
+      });
+
+      using info = new AlwaysAndNeverDrawnElementInfoCache({ viewport: vp });
+      await queryStartedPromise.promise;
       info.suppressChangeEvents();
-      // third request: since suppression happened after change event, latestCacheEntryValue contains the new values
-      const thirdPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
-      resolvablePromise?.();
-      const secondResult = await secondPromise;
+      // Request is made when suppress is active, so changes to always/never drawn set should not affect the result
+      const resultPromise = firstValueFrom(info.getAlwaysOrNeverDrawnElements({ setType, modelId }));
       info.resumeChangeEvents();
-      const firstResult = await firstPromise;
-      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
-      const expectedResultAfterChange = new Set(["0x4", "0x5"]);
-      const expectedResultBeforeChange = new Set(["0x3", "0x5", "0x6"]);
-      expect(firstResult).toEqual(expectedResultAfterChange);
-      expect(secondResult).toEqual(expectedResultBeforeChange);
-      expect(await thirdPromise).toEqual(expectedResultAfterChange);
-      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(5);
+
+      // New set requires 3 queries
+      const newSet = new Set(
+        Array(ALWAYS_NEVER_BUFFER_THRESHOLD * 3 + 1)
+          .fill(0)
+          .map((_, i) => `0x${i}`),
+      );
+      setterFunction(newSet, vp);
+      queryPausePromise.resolve();
+      const result = await resultPromise;
+      // Changed values have not been requested yet. The initial set required 3 queries,
+      // results can be checked: 0x3 - first query, 0x5 - second query, 0x6 - third query.
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(3);
+      expect(result).toEqual(new Set(["0x3", "0x5", "0x6"]));
     });
 
     it(`requeries when suppression is removed and ${setType}Drawn changes`, async () => {
@@ -468,14 +474,8 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       await firstValueFrom(info.getElementsTree({ setType, modelId: "0x2" }));
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
       info.suppressChangeEvents();
-      const setterFunction = (ids: Set<Id64String>) => {
-        if (setType === "always") {
-          vp.setAlwaysDrawn({ elementIds: ids });
-          return;
-        }
-        vp.setNeverDrawn({ elementIds: ids });
-      };
-      setterFunction(new Set(["0x2"]));
+
+      setterFunction(new Set(["0x2"]), vp);
       info.resumeChangeEvents();
       const resultPromise2 = firstValueFrom(info.getElementsTree({ setType, modelId: "0x2" }));
       await vi.advanceTimersByTimeAsync(SET_CHANGE_DEBOUNCE_TIME);
@@ -561,10 +561,16 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
   }
 
   describe("always drawn", () => {
-    runTests("always");
+    const setterFunction = (ids: Set<Id64String>, vp: TreeWidgetViewport) => {
+      vp.setAlwaysDrawn({ elementIds: ids });
+    };
+    runTests("always", setterFunction);
   });
 
   describe("never drawn", () => {
-    runTests("never");
+    const setterFunction = (ids: Set<Id64String>, vp: TreeWidgetViewport) => {
+      vp.setNeverDrawn({ elementIds: ids });
+    };
+    runTests("never", setterFunction);
   });
 });

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/AlwaysAndNeverDrawnElementInfoCache.test.ts
@@ -175,7 +175,7 @@ describe("AlwaysAndNeverDrawnElementInfoCache", () => {
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
     });
 
-    it.only(`finishes pending request when suppression is activated for ${setType}Drawn after event fires but before debounce time has passed`, async () => {
+    it(`finishes pending request when suppression is activated for ${setType}Drawn after event fires but before debounce time has passed`, async () => {
       const modelId = "0x1";
       const categoryId = "0x2";
       const elementId = "0x3";

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -116,15 +116,17 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   constructor(props: AlwaysAndNeverDrawnElementInfoCacheProps) {
     this.#viewport = props.viewport;
     const partialLatestAlwaysDrawnCacheEntry = { isUsed: false, invalidateValue: new Subject<void>() };
+    // Entry value is created only for typescript types, it will be thrown away when createUpToDateCacheEntryValue is called
     const latestAlwaysDrawnCacheEntryValue = this.createLatestCacheEntryValue({ setType: "always", latestCacheEntry: partialLatestAlwaysDrawnCacheEntry });
     this.#alwaysDrawn = {
-      upToDateCacheEntryValue: this.createUpToDateCacheEntryValue({ setType: "always", latestCacheEntryValue: latestAlwaysDrawnCacheEntryValue }),
+      upToDateCacheEntryValue: this.createUpToDateCacheEntryValue("always"),
       latestCacheEntry: { ...partialLatestAlwaysDrawnCacheEntry, value: latestAlwaysDrawnCacheEntryValue },
     };
     const partialLatestNeverDrawnCacheEntry = { isUsed: false, invalidateValue: new Subject<void>() };
+    // Entry value is created only for typescript types, it will be thrown away when createUpToDateCacheEntryValue is called
     const latestNeverDrawnCacheEntryValue = this.createLatestCacheEntryValue({ setType: "never", latestCacheEntry: partialLatestNeverDrawnCacheEntry });
     this.#neverDrawn = {
-      upToDateCacheEntryValue: this.createUpToDateCacheEntryValue({ setType: "never", latestCacheEntryValue: latestNeverDrawnCacheEntryValue }),
+      upToDateCacheEntryValue: this.createUpToDateCacheEntryValue("never"),
       latestCacheEntry: { ...partialLatestNeverDrawnCacheEntry, value: latestNeverDrawnCacheEntryValue },
     };
     this.#suppressors = this.#suppress.pipe(
@@ -204,13 +206,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
     return result;
   }
 
-  private createUpToDateCacheEntryValue({
-    setType,
-    latestCacheEntryValue,
-  }: {
-    setType: SetType;
-    latestCacheEntryValue: Observable<CachedNodesMap>;
-  }): Observable<CachedNodesMap> {
+  private createUpToDateCacheEntryValue(setType: SetType): Observable<CachedNodesMap> {
     const event = setType === "always" ? this.#viewport.onAlwaysDrawnChanged : this.#viewport.onNeverDrawnChanged;
     const resultSubject = new BehaviorSubject<CachedNodesMap | undefined>(undefined);
     // Observable listens to viewport always/never drawn set change events.
@@ -237,13 +233,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
           take(1),
         ),
       ),
-      map((_, idx) => {
-        // Initial latest cache entry value is created at the constructor
-        // Should reuse the same observable until the first event is raised, when it is raised `idx` will be larger than 0
-        // And a new latestCacheEntry.value will be created and assigned
-        if (idx === 0) {
-          return latestCacheEntryValue;
-        }
+      map(() => {
         const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
         // Make sure to set new latestCacheEntry value
         const queryObservable = this.createLatestCacheEntryValue({ setType, latestCacheEntry: cache.latestCacheEntry });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -218,7 +218,11 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
           // previous latestCacheEntry is not used, invalidate it
           invalidateCache.next();
         }
-        const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(takeUntil(invalidateCache), shareReplay());
+        const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(
+          takeUntil(invalidateCache),
+          takeUntil(this.#disposeSubject),
+          shareReplay(),
+        );
 
         // Make sure latestCacheEntry is set to a new observable if change happened before suppression
         cache.latestCacheEntryValue = queryObservable;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -87,12 +87,23 @@ interface AlwaysAndNeverDrawnElementInfoCacheProps {
   elementClassName?: string;
   componentId?: GuidString;
 }
+interface LatestCacheEntry {
+  value: Observable<CachedNodesMap>;
+  isUsed: boolean;
+  invalidateValue: Subject<void>;
+}
 
 /** @internal */
 export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   #subscriptions: Subscription[];
-  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap>; latestCacheEntryValueUsed?: boolean };
-  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap>; latestCacheEntryValueUsed?: boolean };
+  #alwaysDrawn: {
+    upToDateCacheEntryValue: Observable<CachedNodesMap>;
+    latestCacheEntry: LatestCacheEntry;
+  };
+  #neverDrawn: {
+    upToDateCacheEntryValue: Observable<CachedNodesMap>;
+    latestCacheEntry: LatestCacheEntry;
+  };
   #disposeSubject = new Subject<void>();
   readonly #viewport: TreeWidgetViewport;
   readonly #elementClassName: string;
@@ -104,14 +115,24 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
 
   constructor(props: AlwaysAndNeverDrawnElementInfoCacheProps) {
     this.#viewport = props.viewport;
-    this.#alwaysDrawn = { cacheEntryObs: this.createCacheEntryObservable("always") };
-    this.#neverDrawn = { cacheEntryObs: this.createCacheEntryObservable("never") };
+    const partialLatestAlwaysDrawnCacheEntry = { isUsed: false, invalidateValue: new Subject<void>() };
+    const latestAlwaysDrawnCacheEntryValue = this.createLatestCacheEntryValue({ setType: "always", latestCacheEntry: partialLatestAlwaysDrawnCacheEntry });
+    this.#alwaysDrawn = {
+      upToDateCacheEntryValue: this.createUpToDateCacheEntryValue({ setType: "always", latestCacheEntryValue: latestAlwaysDrawnCacheEntryValue }),
+      latestCacheEntry: { ...partialLatestAlwaysDrawnCacheEntry, value: latestAlwaysDrawnCacheEntryValue },
+    };
+    const partialLatestNeverDrawnCacheEntry = { isUsed: false, invalidateValue: new Subject<void>() };
+    const latestNeverDrawnCacheEntryValue = this.createLatestCacheEntryValue({ setType: "never", latestCacheEntry: partialLatestNeverDrawnCacheEntry });
+    this.#neverDrawn = {
+      upToDateCacheEntryValue: this.createUpToDateCacheEntryValue({ setType: "never", latestCacheEntryValue: latestNeverDrawnCacheEntryValue }),
+      latestCacheEntry: { ...partialLatestNeverDrawnCacheEntry, value: latestNeverDrawnCacheEntryValue },
+    };
     this.#suppressors = this.#suppress.pipe(
       scan((acc, suppress) => acc + (suppress ? 1 : -1), 0),
       startWith(0),
       shareReplay(1),
     );
-    this.#subscriptions = [this.#alwaysDrawn.cacheEntryObs.subscribe(), this.#neverDrawn.cacheEntryObs.subscribe()];
+    this.#subscriptions = [this.#alwaysDrawn.upToDateCacheEntryValue.subscribe(), this.#neverDrawn.upToDateCacheEntryValue.subscribe()];
     this.#componentId = props.componentId ?? Guid.createValue();
     this.#componentName = "AlwaysAndNeverDrawnElementInfo";
     this.#elementClassName = props.elementClassName ? props.elementClassName : getClassesByView(this.#viewport.viewType === "2d" ? "2d" : "3d").elementClass;
@@ -145,10 +166,10 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       take(1),
       mergeMap((suppressionCount) => {
         if (suppressionCount > 0) {
-          cache.latestCacheEntryValueUsed = true;
-          return cache.latestCacheEntryValue!.pipe(map(getElements));
+          cache.latestCacheEntry.isUsed = true;
+          return cache.latestCacheEntry.value.pipe(map(getElements));
         }
-        return cache.cacheEntryObs.pipe(map(getElements));
+        return cache.upToDateCacheEntryValue.pipe(map(getElements));
       }),
     );
   }
@@ -183,10 +204,14 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
     return result;
   }
 
-  private createCacheEntryObservable(setType: SetType): Observable<CachedNodesMap> {
+  private createUpToDateCacheEntryValue({
+    setType,
+    latestCacheEntryValue,
+  }: {
+    setType: SetType;
+    latestCacheEntryValue: Observable<CachedNodesMap>;
+  }): Observable<CachedNodesMap> {
     const event = setType === "always" ? this.#viewport.onAlwaysDrawnChanged : this.#viewport.onNeverDrawnChanged;
-    const getIds = setType === "always" ? () => this.#viewport.alwaysDrawn : () => this.#viewport.neverDrawn;
-    const invalidateCache = new Subject<void>();
     const resultSubject = new BehaviorSubject<CachedNodesMap | undefined>(undefined);
     // Observable listens to viewport always/never drawn set change events.
     const sharedObs = fromEventPattern(
@@ -212,21 +237,14 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
           take(1),
         ),
       ),
-      map(() => {
-        const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
-        if (!cache.latestCacheEntryValueUsed) {
-          // previous latestCacheEntry is not used, invalidate it
-          invalidateCache.next();
+      map((_, idx) => {
+        if (idx === 0) {
+          return latestCacheEntryValue;
         }
-        const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(
-          takeUntil(invalidateCache),
-          takeUntil(this.#disposeSubject),
-          shareReplay(),
-        );
-
-        // Make sure latestCacheEntry is set to a new observable if change happened before suppression
-        cache.latestCacheEntryValue = queryObservable;
-        cache.latestCacheEntryValueUsed = false;
+        const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
+        // Make sure to set new latestCacheEntry value
+        const queryObservable = this.createLatestCacheEntryValue({ setType, latestCacheEntry: cache.latestCacheEntry });
+        cache.latestCacheEntry.value = queryObservable;
         return queryObservable;
       }),
       debounceTime(SET_CHANGE_DEBOUNCE_TIME),
@@ -247,6 +265,28 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       first((x): x is CachedNodesMap => !!x),
     );
     return obs;
+  }
+
+  private createLatestCacheEntryValue({
+    setType,
+    latestCacheEntry,
+  }: {
+    setType: SetType;
+    latestCacheEntry: Omit<LatestCacheEntry, "value">;
+  }): Observable<CachedNodesMap> {
+    if (!latestCacheEntry.isUsed) {
+      // previous latestCacheEntry is not used, invalidate it
+      latestCacheEntry.invalidateValue.next();
+    }
+    const set = setType === "always" ? this.#viewport.alwaysDrawn : this.#viewport.neverDrawn;
+    const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(set, setType).pipe(
+      takeUntil(latestCacheEntry.invalidateValue),
+      takeUntil(this.#disposeSubject),
+      shareReplay(),
+    );
+
+    latestCacheEntry.isUsed = false;
+    return queryObservable;
   }
 
   public [Symbol.dispose](): void {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -90,8 +90,8 @@ interface AlwaysAndNeverDrawnElementInfoCacheProps {
 /** @internal */
 export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   #subscriptions: Subscription[];
-  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: CachedNodesMap };
-  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: CachedNodesMap };
+  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
+  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
   #disposeSubject = new Subject<void>();
   readonly #viewport: TreeWidgetViewport;
   readonly #elementClassName: string;
@@ -145,7 +145,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       : this.#suppressors.pipe(
           take(1),
           mergeMap((suppressionCount) =>
-            suppressionCount > 0 ? of(cache.latestCacheEntryValue).pipe(map(getElements)) : cache.cacheEntryObs.pipe(map(getElements)),
+            suppressionCount > 0 ? cache.latestCacheEntryValue!.pipe(map(getElements)) : cache.cacheEntryObs.pipe(map(getElements)),
           ),
         );
   }
@@ -194,6 +194,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       map(() => undefined),
       share(),
     );
+
     const obs = sharedObs.pipe(
       // Fire the observable once at the beginning
       startWith(undefined),
@@ -208,24 +209,21 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
           take(1),
         ),
       ),
+      map(() => {
+        // Make sure latestCacheEntry is set to a new observable if change happened before suppression
+        const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
+        cache.latestCacheEntryValue = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(shareReplay());
+        return cache.latestCacheEntryValue;
+      }),
       debounceTime(SET_CHANGE_DEBOUNCE_TIME),
       // Cancel pending request if dispose() is called.
       takeUntil(this.#disposeSubject),
       // If multiple requests are sent at once, preserve only the result of the newest.
-      switchMap(() =>
+      switchMap((queryObservable) =>
         // Race between the event and the query.
         // In cases where event is raised before query returns, the query result is discarded.
-        race(
-          sharedObs,
-          defer(() => this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType)),
-        ),
+        race(sharedObs, queryObservable),
       ),
-      tap((cacheEntry) => {
-        if (cacheEntry !== undefined) {
-          const value = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
-          value.latestCacheEntryValue = cacheEntry;
-        }
-      }),
       // Share the result by using a subject which always emits the saved result.
       share({
         connector: () => resultSubject,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -238,6 +238,9 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
         ),
       ),
       map((_, idx) => {
+        // Initial latest cache entry value is created at the constructor
+        // Should reuse the same observable until the first event is raised, when it is raised `idx` will be larger than 0
+        // And a new latestCacheEntry.value will be created and assigned
         if (idx === 0) {
           return latestCacheEntryValue;
         }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -41,7 +41,8 @@ import type { ChildrenTree } from "../Utils.js";
 
 /** @internal */
 export const SET_CHANGE_DEBOUNCE_TIME = 20;
-const ALWAYS_NEVER_BUFFER_THRESHOLD = 5000;
+/** @internal */
+export const ALWAYS_NEVER_BUFFER_THRESHOLD = 5000;
 
 type SetType = "always" | "never";
 
@@ -90,8 +91,8 @@ interface AlwaysAndNeverDrawnElementInfoCacheProps {
 /** @internal */
 export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   #subscriptions: Subscription[];
-  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
-  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
+  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap>; latestCacheEntryValueUsed?: boolean };
+  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap>; latestCacheEntryValueUsed?: boolean };
   #disposeSubject = new Subject<void>();
   readonly #viewport: TreeWidgetViewport;
   readonly #elementClassName: string;
@@ -140,14 +141,16 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       return this.getChildrenTree({ currentChildrenTree: rootTreeNodes, pathToElements, currentIdsIndex: 0 });
     };
 
-    return !cache.latestCacheEntryValue
-      ? cache.cacheEntryObs.pipe(map(getElements))
-      : this.#suppressors.pipe(
-          take(1),
-          mergeMap((suppressionCount) =>
-            suppressionCount > 0 ? cache.latestCacheEntryValue!.pipe(map(getElements)) : cache.cacheEntryObs.pipe(map(getElements)),
-          ),
-        );
+    return this.#suppressors.pipe(
+      take(1),
+      mergeMap((suppressionCount) => {
+        if (suppressionCount > 0) {
+          cache.latestCacheEntryValueUsed = true;
+          return cache.latestCacheEntryValue!.pipe(map(getElements));
+        }
+        return cache.cacheEntryObs.pipe(map(getElements));
+      }),
+    );
   }
 
   private getChildrenTree({
@@ -183,7 +186,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   private createCacheEntryObservable(setType: SetType): Observable<CachedNodesMap> {
     const event = setType === "always" ? this.#viewport.onAlwaysDrawnChanged : this.#viewport.onNeverDrawnChanged;
     const getIds = setType === "always" ? () => this.#viewport.alwaysDrawn : () => this.#viewport.neverDrawn;
-
+    const invalidateCache = new Subject<void>();
     const resultSubject = new BehaviorSubject<CachedNodesMap | undefined>(undefined);
     // Observable listens to viewport always/never drawn set change events.
     const sharedObs = fromEventPattern(
@@ -210,10 +213,16 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
         ),
       ),
       map(() => {
-        // Make sure latestCacheEntry is set to a new observable if change happened before suppression
         const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
-        const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(shareReplay());
+        if (!cache.latestCacheEntryValueUsed) {
+          // previous latestCacheEntry is not used, invalidate it
+          invalidateCache.next();
+        }
+        const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(takeUntil(invalidateCache), shareReplay());
+
+        // Make sure latestCacheEntry is set to a new observable if change happened before suppression
         cache.latestCacheEntryValue = queryObservable;
+        cache.latestCacheEntryValueUsed = false;
         return queryObservable;
       }),
       debounceTime(SET_CHANGE_DEBOUNCE_TIME),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -212,8 +212,9 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       map(() => {
         // Make sure latestCacheEntry is set to a new observable if change happened before suppression
         const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
-        cache.latestCacheEntryValue = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(shareReplay());
-        return cache.latestCacheEntryValue;
+        const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(shareReplay());
+        cache.latestCacheEntryValue = queryObservable;
+        return queryObservable;
       }),
       debounceTime(SET_CHANGE_DEBOUNCE_TIME),
       // Cancel pending request if dispose() is called.


### PR DESCRIPTION
When trying to better split up performance tests noticed an issue with how always/never drawn elements are queried.
The bug can be reproduced with the added test.