### PR TITLE
[Tree widget]: Split up performance tests on `next`

### DIFF
--- a/apps/performance-tests/eslint.config.js
+++ b/apps/performance-tests/eslint.config.js
@@ -3,26 +3,31 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-const iTwinPlugin = require("@itwin/eslint-plugin");
-const eslintConfigPrettier = require("eslint-config-prettier");
-const unusedImports = require("eslint-plugin-unused-imports");
+import eslintConfigPrettier from "eslint-config-prettier";
+import unusedImports from "eslint-plugin-unused-imports";
+import { defineConfig } from "eslint/config";
+import iTwinPlugin from "@itwin/eslint-plugin";
 
-module.exports = [
+export default defineConfig([
   {
-    files: ["**/*.{ts,cts}"],
+    ignores: ["lib/**", "vitest.config.ts"],
+  },
+  {
+    files: ["**/*.{ts,tsx,cts}"],
     ...iTwinPlugin.configs.iTwinjsRecommendedConfig,
   },
   {
     plugins: {
       "unused-imports": unusedImports,
     },
-    files: ["**/*.{ts,cts}"],
+    files: ["**/*.{ts,tsx,cts}"],
     rules: {
       "no-duplicate-imports": "off",
       "no-console": "off",
       "import/no-duplicates": "error",
       "object-curly-spacing": ["error", "always"],
       "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/consistent-type-exports": "error",
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "unused-imports/no-unused-imports": "error",
@@ -31,4 +36,4 @@ module.exports = [
     },
   },
   eslintConfigPrettier,
-];
+]);

--- a/apps/performance-tests/src/setup.ts
+++ b/apps/performance-tests/src/setup.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
   });
   ECSchemaRpcImpl.register();
   await Datasets.initialize("./datasets");
-});
+}, 30_000);
 
 afterAll(async () => {
   await terminatePresentationTesting();

--- a/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
@@ -6,7 +6,7 @@
 import { describe, expect } from "vitest";
 import { SnapshotDb } from "@itwin/core-backend";
 import { assert } from "@itwin/core-bentley";
-import { createIModelHierarchyProvider, HierarchySearchTree } from "@itwin/presentation-hierarchies";
+import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 import { Props } from "@itwin/presentation-shared";
 import { SharedTreeContextProvider, useCategoriesTree } from "@itwin/tree-widget-react";
 import {
@@ -33,44 +33,67 @@ import {
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+import type { HierarchyDefinition, HierarchyNode, HierarchyProvider, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import type { HierarchyVisibilityHandler } from "@itwin/tree-widget-react";
 import type { IModelAccess } from "./StatelessHierarchyProvider.js";
 import type { TreeWidgetTestingViewport } from "./VisibilityUtilities.js";
 
 describe("categories tree", () => {
-  run<{ iModelConnection: IModelConnection; imodelAccess: IModelAccess; viewport: TreeWidgetTestingViewport }>({
-    testName: "creates initial filtered view for 50k items",
+  run<{
+    iModelConnection: IModelConnection;
+    imodelAccess: IModelAccess;
+    viewport: TreeWidgetTestingViewport;
+    searchPaths: HierarchySearchTree[] | undefined;
+    hierarchyDefinition: HierarchyDefinition | undefined;
+  }>({
+    testName: "50k subCategories search",
     setup: async () => {
       const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k subcategories"));
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
       const viewport = await createViewport({ iModelConnection });
-      return { iModelConnection, imodelAccess, viewport };
+      return {
+        iModelConnection,
+        imodelAccess,
+        viewport,
+        searchPaths: undefined as HierarchySearchTree[] | undefined,
+        hierarchyDefinition: undefined as HierarchyDefinition | undefined,
+      };
     },
     cleanup: (props) => props.iModelConnection.close(),
-    test: async ({ viewport, imodelAccess }) => {
-      using hook = renderUseCategoriesTreeHook({
-        activeView: viewport,
-        hierarchyConfig: defaultCategoriesTreeHierarchyConfiguration,
-        searchText: "sc",
-        searchLimit: "unbounded",
-      });
-      const hierarchyDefinition = await act(async () => hook.result.current.treeProps.getHierarchyDefinition({ imodelAccess }));
-      const searchPaths = await act(async () => hook.result.current.treeProps.getSearchPaths!({ imodelAccess, abortSignal: new AbortController().signal }));
-      expect(countSearchTargets(searchPaths!)).to.eq(50000);
-
-      using provider = new StatelessHierarchyProvider({
-        imodelAccess,
-        getHierarchyFactory: () => hierarchyDefinition,
-        search: { paths: searchPaths! },
-      });
-      const result = await provider.loadHierarchy({ shouldExpand: (node) => node.children && !!node.autoExpand });
-      expect(result).to.eq(
-        1 + // root definition container
-          50 + // categories
-          50 * 1000, // subcategories
-      ); // 50051 total
-    },
+    testSteps: [
+      {
+        name: "get search paths",
+        callBack: async (ctx) => {
+          using hook = renderUseCategoriesTreeHook({
+            activeView: ctx.viewport,
+            hierarchyConfig: defaultCategoriesTreeHierarchyConfiguration,
+            searchText: "sc",
+            searchLimit: "unbounded",
+          });
+          ctx.hierarchyDefinition = await act(async () => hook.result.current.treeProps.getHierarchyDefinition({ imodelAccess: ctx.imodelAccess }));
+          ctx.searchPaths = await act(async () =>
+            hook.result.current.treeProps.getSearchPaths!({ imodelAccess: ctx.imodelAccess, abortSignal: new AbortController().signal }),
+          );
+          expect(countSearchTargets(ctx.searchPaths!)).to.eq(50000);
+        },
+      },
+      {
+        name: "load hierarchy from search paths",
+        callBack: async ({ imodelAccess, hierarchyDefinition, searchPaths }) => {
+          using provider = new StatelessHierarchyProvider({
+            imodelAccess,
+            getHierarchyFactory: () => hierarchyDefinition!,
+            search: { paths: searchPaths! },
+          });
+          const result = await provider.loadHierarchy({ shouldExpand: (node) => node.children && !!node.autoExpand });
+          expect(result).to.eq(
+            1 + // root definition container
+              50 + // categories
+              50 * 1000, // sub-categories
+          ); // 50051 total
+        },
+      },
+    ],
   });
 
   run<{
@@ -83,7 +106,7 @@ describe("categories tree", () => {
     iModelConnection: IModelConnection;
     hierarchyNodes: HierarchyNode[];
   }>({
-    testName: "changing definition container visibility changes visibility for 50k subCategories",
+    testName: "50k subCategories",
     setup: async () => {
       const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k subcategories"));
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
@@ -110,13 +133,6 @@ describe("categories tree", () => {
         }),
         imodelAccess,
       });
-      const hierarchyNodes = await collectNodes({ provider });
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
 
       expect(visibilityTargets.definitionContainers.length).toBe(1);
       return {
@@ -127,7 +143,7 @@ describe("categories tree", () => {
         handler,
         definitionContainer: visibilityTargets.definitionContainers[0],
         iModelConnection,
-        hierarchyNodes,
+        hierarchyNodes: [],
       };
     },
     cleanup: async (props) => {
@@ -139,15 +155,42 @@ describe("categories tree", () => {
         await props.iModelConnection.close();
       }
     },
-    test: async ({ viewport, handler, hierarchyNodes, definitionContainer }) => {
-      await handler.changeVisibility(createDefinitionContainerHierarchyNode(definitionContainer), true);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-    },
+    testSteps: [
+      {
+        name: "collect nodes",
+        callBack: async (ctx) => {
+          ctx.hierarchyNodes = await collectNodes({ provider: ctx.provider });
+        },
+      },
+      {
+        name: "validate initial visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "change visibility",
+        callBack: async ({ handler, definitionContainer }) => {
+          await handler.changeVisibility(createDefinitionContainerHierarchyNode(definitionContainer), true);
+        },
+      },
+      {
+        name: "validate changed visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
+        },
+      },
+    ],
   });
 
   run<{
@@ -160,7 +203,7 @@ describe("categories tree", () => {
     iModelConnection: IModelConnection;
     hierarchyNodes: HierarchyNode[];
   }>({
-    testName: "changing definition container visibility changes visibility for 50k categories",
+    testName: "50k categories",
     setup: async () => {
       const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k categories"));
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
@@ -187,13 +230,6 @@ describe("categories tree", () => {
         }),
         imodelAccess,
       });
-      const hierarchyNodes = await collectNodes({ provider });
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
       const categoriesDefinitionContainers = new Set<Id64String>();
       visibilityTargets.categories.forEach((categoryId) => {
         categoriesDefinitionContainers.add(iModel.elements.getElementProps(categoryId).model);
@@ -203,7 +239,7 @@ describe("categories tree", () => {
       );
       expect(rootDefinitionContainer).toBeDefined();
       assert(rootDefinitionContainer !== undefined);
-      return { iModel, imodelAccess, viewport, provider, handler, rootDefinitionContainer, iModelConnection, hierarchyNodes };
+      return { iModel, imodelAccess, viewport, provider, handler, rootDefinitionContainer, iModelConnection, hierarchyNodes: [] };
     },
     cleanup: async (props) => {
       props.iModel.close();
@@ -214,15 +250,42 @@ describe("categories tree", () => {
         await props.iModelConnection.close();
       }
     },
-    test: async ({ viewport, handler, hierarchyNodes, rootDefinitionContainer }) => {
-      await handler.changeVisibility(createDefinitionContainerHierarchyNode(rootDefinitionContainer), true);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-    },
+    testSteps: [
+      {
+        name: "collect nodes",
+        callBack: async (ctx) => {
+          ctx.hierarchyNodes = await collectNodes({ provider: ctx.provider });
+        },
+      },
+      {
+        name: "validate initial visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "change visibility",
+        callBack: async ({ handler, rootDefinitionContainer }) => {
+          await handler.changeVisibility(createDefinitionContainerHierarchyNode(rootDefinitionContainer), true);
+        },
+      },
+      {
+        name: "validate changed visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
+        },
+      },
+    ],
   });
 });
 

--- a/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect } from "vitest";
-import { SnapshotDb } from "@itwin/core-backend";
 import { assert } from "@itwin/core-bentley";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
-import { Props } from "@itwin/presentation-shared";
 import { SharedTreeContextProvider, useCategoriesTree } from "@itwin/tree-widget-react";
 import {
   BaseIdsCache,
@@ -31,9 +29,11 @@ import {
   validateHierarchyVisibility,
 } from "./VisibilityUtilities.js";
 
+import type { SnapshotDb } from "@itwin/core-backend";
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition, HierarchyNode, HierarchyProvider, HierarchySearchTree } from "@itwin/presentation-hierarchies";
+import type { Props } from "@itwin/presentation-shared";
 import type { HierarchyVisibilityHandler } from "@itwin/tree-widget-react";
 import type { IModelAccess } from "./StatelessHierarchyProvider.js";
 import type { TreeWidgetTestingViewport } from "./VisibilityUtilities.js";

--- a/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
@@ -68,7 +68,7 @@ describe("categories tree", () => {
         await iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "get search paths",
         callBack: async (ctx) => {
@@ -163,7 +163,7 @@ describe("categories tree", () => {
         await props.iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "collect nodes",
         callBack: async (ctx) => {
@@ -258,7 +258,7 @@ describe("categories tree", () => {
         await props.iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "collect nodes",
         callBack: async (ctx) => {

--- a/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/CategoriesTree.test.tsx
@@ -40,6 +40,7 @@ import type { TreeWidgetTestingViewport } from "./VisibilityUtilities.js";
 
 describe("categories tree", () => {
   run<{
+    iModel: SnapshotDb;
     iModelConnection: IModelConnection;
     imodelAccess: IModelAccess;
     viewport: TreeWidgetTestingViewport;
@@ -52,6 +53,7 @@ describe("categories tree", () => {
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
       const viewport = await createViewport({ iModelConnection });
       return {
+        iModel,
         iModelConnection,
         imodelAccess,
         viewport,
@@ -59,7 +61,13 @@ describe("categories tree", () => {
         hierarchyDefinition: undefined as HierarchyDefinition | undefined,
       };
     },
-    cleanup: (props) => props.iModelConnection.close(),
+    cleanup: async ({ iModelConnection, iModel, viewport }) => {
+      iModel.close();
+      viewport[Symbol.dispose]();
+      if (!iModelConnection.isClosed) {
+        await iModelConnection.close();
+      }
+    },
     testSteps: [
       {
         name: "get search paths",

--- a/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
@@ -39,6 +39,7 @@ describe("classifications tree", () => {
   const rootClassificationSystemCode = "50k classifications";
 
   run<{
+    iModel: SnapshotDb;
     iModelConnection: IModelConnection;
     imodelAccess: IModelAccess;
     viewport: TreeWidgetTestingViewport;
@@ -51,6 +52,7 @@ describe("classifications tree", () => {
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
       const viewport = await createViewport({ iModelConnection });
       return {
+        iModel,
         iModelConnection,
         imodelAccess,
         viewport,
@@ -58,9 +60,12 @@ describe("classifications tree", () => {
         hierarchyDefinition: undefined as HierarchyDefinition | undefined,
       };
     },
-    cleanup: (props) => {
-      props.viewport[Symbol.dispose]();
-      props.iModelConnection.close();
+    cleanup: async ({ iModelConnection, iModel, viewport }) => {
+      iModel.close();
+      viewport[Symbol.dispose]();
+      if (!iModelConnection.isClosed) {
+        await iModelConnection.close();
+      }
     },
     testSteps: [
       {

--- a/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
@@ -5,78 +5,214 @@
 
 import { describe, expect } from "vitest";
 import { SnapshotDb } from "@itwin/core-backend";
-import { BaseIdsCache, ClassificationsTreeDefinition, ClassificationsTreeIdsCache } from "@itwin/tree-widget-react/internal";
+import { Id64String } from "@itwin/core-bentley";
+import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
+import { ClassificationsTreeNode, HierarchyVisibilityHandler, SharedTreeContextProvider, useClassificationsTree } from "@itwin/tree-widget-react";
+import {
+  BaseIdsCache,
+  ClassificationsTreeDefinition,
+  ClassificationsTreeIdsCache,
+  createClassificationsTreeVisibilityHandler,
+} from "@itwin/tree-widget-react/internal";
+import { act, renderHook } from "@testing-library/react";
 import { Datasets } from "../util/Datasets.js";
-import { run } from "../util/TestUtilities.js";
+import { run, TestIModelConnection } from "../util/TestUtilities.js";
+import { countSearchTargets } from "./SearchUtils.js";
 import { StatelessHierarchyProvider } from "./StatelessHierarchyProvider.js";
+import {
+  collectNodes,
+  createClassificationTableHierarchyNode,
+  createTestDataForInitialDisplay,
+  createViewport,
+  getVisibilityTargets,
+  setupInitialDisplayState,
+  validateHierarchyVisibility,
+} from "./VisibilityUtilities.js";
 
-import type { HierarchyDefinition } from "@itwin/presentation-hierarchies";
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { HierarchyDefinition, HierarchyNode, HierarchyProvider, HierarchySearchTree } from "@itwin/presentation-hierarchies";
+import type { Props } from "@itwin/presentation-shared";
 import type { IModelAccess } from "./StatelessHierarchyProvider.js";
+import type { TreeWidgetTestingViewport } from "./VisibilityUtilities.js";
 
 describe("classifications tree", () => {
   const rootClassificationSystemCode = "50k classifications";
 
-  runClassificationsPerformanceTest({
-    testName: "loads initial view for iModel with 50k classifications",
-    hierarchyConfig: { rootClassificationSystemCode },
-    loadHierarchyProps: { shouldExpand: (node) => node.children && !!node.autoExpand },
-    validateResult: (result) => {
-      expect(result).toBe(50);
-    },
-  });
-
-  runClassificationsPerformanceTest({
-    testName: "loads first branch for iModel with 50k classifications",
-    hierarchyConfig: { rootClassificationSystemCode },
-    loadHierarchyProps: { shouldExpand: (node, index) => node.children && index === 0 },
-    validateResult: (result) => {
-      expect(result).toBe(50 /* tables */ + 1000 /* classifications */ + 2 /* classification + spatial category */);
-    },
-  });
-});
-
-function runClassificationsPerformanceTest({
-  testName,
-  hierarchyConfig,
-  loadHierarchyProps,
-  validateResult,
-  only,
-}: {
-  testName: string;
-  hierarchyConfig: ConstructorParameters<typeof ClassificationsTreeDefinition>[0]["hierarchyConfig"];
-  loadHierarchyProps?: Parameters<StatelessHierarchyProvider["loadHierarchy"]>[0];
-  validateResult?: (result: number) => Promise<void> | void;
-  only?: boolean;
-}) {
-  return run<{
-    imodel: SnapshotDb;
+  run<{
+    iModelConnection: IModelConnection;
     imodelAccess: IModelAccess;
-    hierarchyDefinition: HierarchyDefinition;
+    viewport: TreeWidgetTestingViewport;
+    searchPaths: HierarchySearchTree[] | undefined;
+    hierarchyDefinition: HierarchyDefinition | undefined;
   }>({
-    testName,
-    only,
+    testName: "50k classifications search",
     setup: async () => {
-      const imodel = SnapshotDb.openFile(Datasets.getIModelPath("50k classifications"));
-      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(imodel, "unbounded");
+      const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k classifications"));
+      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
+      const viewport = await createViewport({ iModelConnection });
+      return {
+        iModelConnection,
+        imodelAccess,
+        viewport,
+        searchPaths: undefined as HierarchySearchTree[] | undefined,
+        hierarchyDefinition: undefined as HierarchyDefinition | undefined,
+      };
+    },
+    cleanup: (props) => {
+      props.viewport[Symbol.dispose]();
+      props.iModelConnection.close();
+    },
+    testSteps: [
+      {
+        name: "get search paths",
+        callBack: async (ctx) => {
+          using hook = renderUseClassificationsTreeHook({
+            activeView: ctx.viewport,
+            hierarchyConfig: { rootClassificationSystemCode },
+            searchText: "Classification",
+            searchLimit: "unbounded",
+          });
+          ctx.hierarchyDefinition = await act(async () => hook.result.current.treeProps.getHierarchyDefinition({ imodelAccess: ctx.imodelAccess }));
+          ctx.searchPaths = await act(async () =>
+            hook.result.current.treeProps.getSearchPaths!({
+              imodelAccess: ctx.imodelAccess,
+              abortSignal: new AbortController().signal,
+            }),
+          );
+          expect(countSearchTargets(ctx.searchPaths!)).to.eq(50000);
+        },
+      },
+      {
+        name: "load hierarchy from search paths",
+        callBack: async ({ imodelAccess, hierarchyDefinition, searchPaths }) => {
+          using provider = new StatelessHierarchyProvider({
+            imodelAccess,
+            getHierarchyFactory: () => hierarchyDefinition!,
+            search: { paths: searchPaths! },
+          });
+          const result = await provider.loadHierarchy({
+            shouldExpand: (node) => node.children && !!node.autoExpand,
+          });
+          // 50 classification tables should be loaded, each with 1000 classifications
+          expect(result).toBe(
+            50 + // classification tables
+              25 * 1000 + // classifications
+              25 * 1000, // child classifications
+          );
+        },
+      },
+    ],
+  });
+
+  run<{
+    iModel: SnapshotDb;
+    imodelAccess: IModelAccess;
+    viewport: TreeWidgetTestingViewport;
+    handler: HierarchyVisibilityHandler & Disposable;
+    provider: HierarchyProvider & Disposable;
+    firstClassificationTable: Id64String;
+    iModelConnection: IModelConnection;
+    hierarchyNodes: HierarchyNode[];
+  }>({
+    testName: "50k classifications",
+    setup: async () => {
+      const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k classifications"));
+      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
+      const visibilityTargets = await getVisibilityTargets(imodelAccess, rootClassificationSystemCode);
+      const testData = createTestDataForInitialDisplay({ visibilityTargets, visible: false });
+
+      const viewport = await createViewport({
+        iModelConnection,
+        testData,
+      });
+      setupInitialDisplayState({
+        viewport,
+        ...testData,
+      });
+      const hierarchyConfig = { rootClassificationSystemCode };
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: "BisCore:GeometricElement3d", type: "3d" });
       const idsCache = new ClassificationsTreeIdsCache({
         queryExecutor: imodelAccess,
         hierarchyConfig,
         baseIdsCache,
       });
-      const hierarchyDefinition = new ClassificationsTreeDefinition({ imodelAccess, getIdsCache: () => idsCache, hierarchyConfig });
-      return { imodel, imodelAccess, hierarchyDefinition };
-    },
-    cleanup: (props) => {
-      props.imodel.close();
-    },
-    test: async ({ imodelAccess, hierarchyDefinition }) => {
-      using provider = new StatelessHierarchyProvider({
+      const handler = createClassificationsTreeVisibilityHandler({ imodelAccess, idsCache, viewport });
+      const provider = createIModelHierarchyProvider({
+        hierarchyDefinition: new ClassificationsTreeDefinition({
+          getIdsCache: () => idsCache,
+          imodelAccess,
+          hierarchyConfig,
+        }),
         imodelAccess,
-        getHierarchyFactory: () => hierarchyDefinition,
       });
-      const result = await provider.loadHierarchy(loadHierarchyProps);
-      await validateResult?.(result);
+      expect(visibilityTargets.classificationTables.length).toBeGreaterThanOrEqual(1);
+      const firstClassificationTable = visibilityTargets.classificationTables[0];
+      return { iModel, imodelAccess, viewport, handler, provider, firstClassificationTable, iModelConnection, hierarchyNodes: [] };
     },
+    cleanup: async (props) => {
+      props.iModel.close();
+      props.viewport[Symbol.dispose]();
+      props.handler[Symbol.dispose]();
+      props.provider[Symbol.dispose]();
+      if (!props.iModelConnection.isClosed) {
+        await props.iModelConnection.close();
+      }
+    },
+    testSteps: [
+      {
+        name: "collect nodes",
+        callBack: async (ctx) => {
+          // Collect only classification tables and classifications
+          ctx.hierarchyNodes = await collectNodes({
+            provider: ctx.provider,
+            ignoreChildren: (node) => ClassificationsTreeNode.isClassificationNode(node) && node.parentKeys.length === 2,
+          });
+        },
+      },
+      {
+        name: "validate initial visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "change visibility",
+        callBack: async ({ handler, firstClassificationTable }) => {
+          await handler.changeVisibility(createClassificationTableHierarchyNode(firstClassificationTable), true);
+        },
+      },
+      {
+        name: "validate changed visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport, firstClassificationTable }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: {
+              default: "all-hidden",
+              instances: {
+                [firstClassificationTable]: "visible",
+              },
+              parentIds: {
+                [firstClassificationTable]: "visible",
+              },
+            },
+          });
+        },
+      },
+    ],
   });
+});
+
+function renderUseClassificationsTreeHook(props: Props<typeof useClassificationsTree>) {
+  const result = renderHook((hookProps) => useClassificationsTree(hookProps), {
+    initialProps: props,
+    wrapper: ({ children }) => <SharedTreeContextProvider>{children}</SharedTreeContextProvider>,
+  });
+  return { ...result, [Symbol.dispose]: () => result.unmount() };
 }

--- a/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect } from "vitest";
-import { SnapshotDb } from "@itwin/core-backend";
-import { Id64String } from "@itwin/core-bentley";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
-import { ClassificationsTreeNode, HierarchyVisibilityHandler, SharedTreeContextProvider, useClassificationsTree } from "@itwin/tree-widget-react";
+import { ClassificationsTreeNode, SharedTreeContextProvider, useClassificationsTree } from "@itwin/tree-widget-react";
 import {
   BaseIdsCache,
   ClassificationsTreeDefinition,
@@ -29,9 +27,12 @@ import {
   validateHierarchyVisibility,
 } from "./VisibilityUtilities.js";
 
+import type { SnapshotDb } from "@itwin/core-backend";
+import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition, HierarchyNode, HierarchyProvider, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
+import type { HierarchyVisibilityHandler } from "@itwin/tree-widget-react";
 import type { IModelAccess } from "./StatelessHierarchyProvider.js";
 import type { TreeWidgetTestingViewport } from "./VisibilityUtilities.js";
 

--- a/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
@@ -68,7 +68,7 @@ describe("classifications tree", () => {
         await iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "get search paths",
         callBack: async (ctx) => {
@@ -164,7 +164,7 @@ describe("classifications tree", () => {
         await props.iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "collect nodes",
         callBack: async (ctx) => {

--- a/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
@@ -78,7 +78,7 @@ describe("models tree", () => {
         await iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "get search paths",
         callBack: async (ctx) => {
@@ -170,7 +170,7 @@ describe("models tree", () => {
         await iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "collect nodes",
         callBack: async (ctx) => {
@@ -286,7 +286,7 @@ describe("models tree", () => {
         await props.iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "collect nodes",
         callBack: async (ctx) => {
@@ -463,7 +463,7 @@ describe("models tree", () => {
         await props.iModelConnection.close();
       }
     },
-    testSteps: [
+    steps: [
       {
         name: "collect nodes",
         callBack: async (ctx) => {

--- a/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, expect } from "vitest";
-import { SnapshotDb } from "@itwin/core-backend";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 import { ModelsTreeNode, SharedTreeContextProvider, useModelsTree } from "@itwin/tree-widget-react";
 import {
@@ -31,6 +30,7 @@ import {
   validateHierarchyVisibility,
 } from "./VisibilityUtilities.js";
 
+import type { SnapshotDb } from "@itwin/core-backend";
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchyDefinition, HierarchyNode, HierarchyProvider, HierarchySearchTree } from "@itwin/presentation-hierarchies";

--- a/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
@@ -41,6 +41,7 @@ import type { TreeWidgetTestingViewport } from "./VisibilityUtilities.js";
 
 describe("models tree", () => {
   run<{
+    iModel: SnapshotDb;
     iModelConnection: IModelConnection;
     imodelAccess: IModelAccess;
     viewport: TreeWidgetTestingViewport;
@@ -61,6 +62,7 @@ describe("models tree", () => {
         targetItems.push({ id: row.ECInstanceId, className: "Generic:PhysicalObject" });
       }
       return {
+        iModel,
         iModelConnection,
         imodelAccess,
         targetItems,
@@ -69,7 +71,13 @@ describe("models tree", () => {
         hierarchyDefinition: undefined as HierarchyDefinition | undefined,
       };
     },
-    cleanup: (props) => props.iModelConnection.close(),
+    cleanup: async ({ iModelConnection, viewport, iModel }) => {
+      iModel.close();
+      viewport[Symbol.dispose]();
+      if (!iModelConnection.isClosed) {
+        await iModelConnection.close();
+      }
+    },
     testSteps: [
       {
         name: "get search paths",
@@ -153,13 +161,13 @@ describe("models tree", () => {
       const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
       return { iModel, imodelAccess, viewport, provider, handler, elementsModel, iModelConnection, hierarchyNodes: [] };
     },
-    cleanup: async (props) => {
-      props.iModel.close();
-      props.viewport[Symbol.dispose]();
-      props.handler[Symbol.dispose]();
-      props.provider[Symbol.dispose]();
-      if (!props.iModelConnection.isClosed) {
-        await props.iModelConnection.close();
+    cleanup: async ({ iModel, viewport, handler, provider, iModelConnection }) => {
+      iModel.close();
+      viewport[Symbol.dispose]();
+      handler[Symbol.dispose]();
+      provider[Symbol.dispose]();
+      if (!iModelConnection.isClosed) {
+        await iModelConnection.close();
       }
     },
     testSteps: [
@@ -338,9 +346,11 @@ describe("models tree", () => {
         },
       },
       {
-        name: "make everything visible 2",
-        callBack: ({ viewport, resetInitialVisibilityState }) => {
+        name: "make everything visible and clear always/never drawn sets",
+        callBack: ({ resetInitialVisibilityState, viewport }) => {
           resetInitialVisibilityState({ shouldBeVisible: true });
+          viewport.clearAlwaysDrawn();
+          viewport.clearNeverDrawn();
         },
         ignoreMeasurement: true,
       },

--- a/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
@@ -6,7 +6,7 @@
 import { describe, expect } from "vitest";
 import { SnapshotDb } from "@itwin/core-backend";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
-import { SharedTreeContextProvider, useModelsTree } from "@itwin/tree-widget-react";
+import { ModelsTreeNode, SharedTreeContextProvider, useModelsTree } from "@itwin/tree-widget-react";
 import {
   BaseIdsCache,
   createModelsTreeVisibilityHandler,
@@ -33,15 +33,22 @@ import {
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
+import type { HierarchyDefinition, HierarchyNode, HierarchyProvider, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import type { ECSqlQueryDef, InstanceKey, Props } from "@itwin/presentation-shared";
 import type { HierarchyVisibilityHandler } from "@itwin/tree-widget-react";
 import type { IModelAccess } from "./StatelessHierarchyProvider.js";
 import type { TreeWidgetTestingViewport } from "./VisibilityUtilities.js";
 
 describe("models tree", () => {
-  run<{ iModelConnection: IModelConnection; imodelAccess: IModelAccess; viewport: TreeWidgetTestingViewport; targetItems: Array<InstanceKey> }>({
-    testName: "creates initial filtered view for 50k target items",
+  run<{
+    iModelConnection: IModelConnection;
+    imodelAccess: IModelAccess;
+    viewport: TreeWidgetTestingViewport;
+    targetItems: Array<InstanceKey>;
+    searchPaths: HierarchySearchTree[] | undefined;
+    hierarchyDefinition: HierarchyDefinition | undefined;
+  }>({
+    testName: "50k 3D elements search",
     setup: async () => {
       const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k 3D elements"));
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
@@ -53,37 +60,55 @@ describe("models tree", () => {
       for await (const row of imodelAccess.createQueryReader(query, { limit: "unbounded" })) {
         targetItems.push({ id: row.ECInstanceId, className: "Generic:PhysicalObject" });
       }
-      return { iModelConnection, imodelAccess, targetItems, viewport };
+      return {
+        iModelConnection,
+        imodelAccess,
+        targetItems,
+        viewport,
+        searchPaths: undefined as HierarchySearchTree[] | undefined,
+        hierarchyDefinition: undefined as HierarchyDefinition | undefined,
+      };
     },
     cleanup: (props) => props.iModelConnection.close(),
-    test: async ({ imodelAccess, targetItems, viewport }) => {
-      using hook = renderUseModelsTreeHook({
-        activeView: viewport,
-        hierarchyConfig: defaultModelsTreeHierarchyConfiguration,
-        getSearchPaths: async ({ createInstanceKeyPaths }) => createInstanceKeyPaths({ targetItems }),
-        searchLimit: "unbounded",
-      });
-      const hierarchyDefinition = await act(async () => hook.result.current.treeProps.getHierarchyDefinition({ imodelAccess }));
-      const searchPaths = await act(async () => hook.result.current.treeProps.getSearchPaths!({ imodelAccess, abortSignal: new AbortController().signal }));
-      expect(countSearchTargets(searchPaths!)).to.eq(50000);
-
-      using provider = new StatelessHierarchyProvider({
-        imodelAccess,
-        getHierarchyFactory: () => hierarchyDefinition,
-        search: { paths: searchPaths! },
-      });
-      const result = await provider.loadHierarchy({ shouldExpand: (node) => node.children && !!node.autoExpand });
-      expect(result).to.eq(
-        1 + // root subject
-          1 + // model
-          1 + // category
-          1 + // root elements' class grouping node
-          1000 * 2 + // root elements + class grouping nodes under them
-          16 * 1000 * 2 + // elements under root elements + class grouping nodes under them
-          16 * 1000 * 2 +
-          1000, // indirect child elements
-      ); // 67004 total
-    },
+    testSteps: [
+      {
+        name: "get search paths",
+        callBack: async (ctx) => {
+          using hook = renderUseModelsTreeHook({
+            activeView: ctx.viewport,
+            hierarchyConfig: defaultModelsTreeHierarchyConfiguration,
+            getSearchPaths: async ({ createInstanceKeyPaths }) => createInstanceKeyPaths({ targetItems: ctx.targetItems }),
+            searchLimit: "unbounded",
+          });
+          ctx.hierarchyDefinition = await act(async () => hook.result.current.treeProps.getHierarchyDefinition({ imodelAccess: ctx.imodelAccess }));
+          ctx.searchPaths = await act(async () =>
+            hook.result.current.treeProps.getSearchPaths!({ imodelAccess: ctx.imodelAccess, abortSignal: new AbortController().signal }),
+          );
+          expect(countSearchTargets(ctx.searchPaths!)).to.eq(50000);
+        },
+      },
+      {
+        name: "load hierarchy from search paths",
+        callBack: async ({ imodelAccess, hierarchyDefinition, searchPaths }) => {
+          using provider = new StatelessHierarchyProvider({
+            imodelAccess,
+            getHierarchyFactory: () => hierarchyDefinition!,
+            search: { paths: searchPaths! },
+          });
+          const result = await provider.loadHierarchy({ shouldExpand: (node) => node.children && !!node.autoExpand });
+          expect(result).to.eq(
+            1 + // root subject
+              1 + // model
+              1 + // category
+              1 + // root elements' class grouping node
+              1000 * 2 + // root elements + class grouping nodes under them
+              16 * 1000 * 2 + // elements under root elements + class grouping nodes under them
+              16 * 1000 * 2 +
+              1000, // indirect child elements
+          ); // 67004 total
+        },
+      },
+    ],
   });
   run<{
     iModel: SnapshotDb;
@@ -95,7 +120,7 @@ describe("models tree", () => {
     iModelConnection: IModelConnection;
     hierarchyNodes: HierarchyNode[];
   }>({
-    testName: "validates categories visibility for imodel with 50k categories",
+    testName: "50k categories",
     setup: async () => {
       const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k categories"));
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
@@ -125,15 +150,8 @@ describe("models tree", () => {
         hierarchyDefinition: new ModelsTreeDefinition({ idsCache, imodelAccess, hierarchyConfig: defaultModelsTreeHierarchyConfiguration }),
         imodelAccess,
       });
-      const hierarchyNodes = await collectNodes({ provider, ignoreChildren: (node) => !!node.extendedData?.isCategory });
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
       const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
-      return { iModel, imodelAccess, viewport, provider, handler, elementsModel, iModelConnection, hierarchyNodes };
+      return { iModel, imodelAccess, viewport, provider, handler, elementsModel, iModelConnection, hierarchyNodes: [] };
     },
     cleanup: async (props) => {
       props.iModel.close();
@@ -144,323 +162,236 @@ describe("models tree", () => {
         await props.iModelConnection.close();
       }
     },
-    test: async ({ viewport, handler, hierarchyNodes, elementsModel }) => {
-      // Add one element to always draw set to trigger additional queries
-      viewport.setAlwaysDrawn({ elementIds: new Set([elementsModel]) });
-      viewport.renderFrame();
-      await handler.changeVisibility(createModelHierarchyNode(elementsModel), true);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-    },
-  });
-
-  run<{
-    iModel: SnapshotDb;
-    imodelAccess: IModelAccess;
-    viewport: TreeWidgetTestingViewport;
-    handler: HierarchyVisibilityHandler & Disposable;
-    provider: HierarchyProvider & Disposable;
-    elementsModel: Id64String;
-    iModelConnection: IModelConnection;
-    hierarchyNodes: HierarchyNode[];
-  }>({
-    testName: "changing model visibility changes visibility for 50k elements",
-    setup: async () => {
-      const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k 3D elements"));
-      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
-      const visibilityTargets = await getVisibilityTargets(imodelAccess);
-      const testData = createTestDataForInitialDisplay({ visibilityTargets, visible: false });
-
-      const viewport = await createViewport({
-        iModelConnection,
-        testData,
-      });
-      setupInitialDisplayState({
-        viewport,
-        ...testData,
-      });
-      const baseIdsCache = new BaseIdsCache({
-        elementClassName: defaultModelsTreeHierarchyConfiguration.elementClassSpecification,
-        type: "3d",
-        queryExecutor: imodelAccess,
-      });
-      const idsCache = new ModelsTreeIdsCache({
-        queryExecutor: imodelAccess,
-        hierarchyConfig: defaultModelsTreeHierarchyConfiguration,
-        baseIdsCache,
-      });
-      const handler = createModelsTreeVisibilityHandler({ idsCache, viewport, imodelAccess });
-      const provider = createIModelHierarchyProvider({
-        hierarchyDefinition: new ModelsTreeDefinition({ idsCache, imodelAccess, hierarchyConfig: defaultModelsTreeHierarchyConfiguration }),
-        imodelAccess,
-      });
-      const hierarchyNodes = await collectNodes({ provider });
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
-      const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
-      return { iModel, imodelAccess, viewport, provider, handler, elementsModel, iModelConnection, hierarchyNodes };
-    },
-    cleanup: async (props) => {
-      props.iModel.close();
-      props.viewport[Symbol.dispose]();
-      props.handler[Symbol.dispose]();
-      props.provider[Symbol.dispose]();
-      if (!props.iModelConnection.isClosed) {
-        await props.iModelConnection.close();
-      }
-    },
-    test: async ({ viewport, handler, hierarchyNodes, elementsModel }) => {
-      await handler.changeVisibility(createModelHierarchyNode(elementsModel), true);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-    },
-  });
-
-  run<{
-    iModel: SnapshotDb;
-    imodelAccess: IModelAccess;
-    viewport: TreeWidgetTestingViewport;
-    handler: HierarchyVisibilityHandler & Disposable;
-    provider: HierarchyProvider & Disposable;
-    elementsCategory: Id64String;
-    elementsModel: Id64String;
-    iModelConnection: IModelConnection;
-    hierarchyNodes: HierarchyNode[];
-  }>({
-    testName: "changing category visibility changes visibility for 50k elements",
-    setup: async () => {
-      const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k 3D elements"));
-      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
-      const visibilityTargets = await getVisibilityTargets(imodelAccess);
-      const testData = createTestDataForInitialDisplay({ visibilityTargets, visible: true });
-
-      const viewport = await createViewport({
-        iModelConnection,
-        testData,
-      });
-      setupInitialDisplayState({
-        viewport,
-        ...testData,
-      });
-      const baseIdsCache = new BaseIdsCache({
-        elementClassName: defaultModelsTreeHierarchyConfiguration.elementClassSpecification,
-        type: "3d",
-        queryExecutor: imodelAccess,
-      });
-      const idsCache = new ModelsTreeIdsCache({
-        queryExecutor: imodelAccess,
-        hierarchyConfig: defaultModelsTreeHierarchyConfiguration,
-        baseIdsCache,
-      });
-      const handler = createModelsTreeVisibilityHandler({ idsCache, viewport, imodelAccess });
-      const provider = createIModelHierarchyProvider({
-        hierarchyDefinition: new ModelsTreeDefinition({ idsCache, imodelAccess, hierarchyConfig: defaultModelsTreeHierarchyConfiguration }),
-        imodelAccess,
-      });
-      const hierarchyNodes = await collectNodes({ provider });
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-      const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
-      expect(visibilityTargets.categories.length).toBe(1);
-      const elementsCategory = visibilityTargets.categories[0];
-      return { iModel, imodelAccess, viewport, provider, handler, elementsCategory, elementsModel, iModelConnection, hierarchyNodes };
-    },
-    cleanup: async (props) => {
-      props.iModel.close();
-      props.viewport[Symbol.dispose]();
-      props.handler[Symbol.dispose]();
-      props.provider[Symbol.dispose]();
-      if (!props.iModelConnection.isClosed) {
-        await props.iModelConnection.close();
-      }
-    },
-    test: async ({ viewport, handler, hierarchyNodes, elementsCategory, elementsModel }) => {
-      await handler.changeVisibility(createCategoryHierarchyNode(elementsCategory, elementsModel, true), false);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
-    },
-  });
-
-  run<{
-    iModel: SnapshotDb;
-    imodelAccess: IModelAccess;
-    viewport: TreeWidgetTestingViewport;
-    handler: HierarchyVisibilityHandler & Disposable;
-    provider: HierarchyProvider & Disposable;
-    elementsCategory: Id64String;
-    elementsModel: Id64String;
-    iModelConnection: IModelConnection;
-    hierarchyNodes: HierarchyNode[];
-  }>({
-    testName: "changing per-model-category override changes visibility for 50k elements",
-    setup: async () => {
-      const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k 3D elements"));
-      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
-      const visibilityTargets = await getVisibilityTargets(imodelAccess);
-      const testData = createTestDataForInitialDisplay({ visibilityTargets, visible: false });
-
-      const viewport = await createViewport({
-        iModelConnection,
-        testData,
-      });
-      setupInitialDisplayState({
-        viewport,
-        ...testData,
-      });
-      const baseIdsCache = new BaseIdsCache({
-        elementClassName: defaultModelsTreeHierarchyConfiguration.elementClassSpecification,
-        type: "3d",
-        queryExecutor: imodelAccess,
-      });
-      const idsCache = new ModelsTreeIdsCache({
-        queryExecutor: imodelAccess,
-        hierarchyConfig: defaultModelsTreeHierarchyConfiguration,
-        baseIdsCache,
-      });
-      const handler = createModelsTreeVisibilityHandler({ idsCache, viewport, imodelAccess });
-      const provider = createIModelHierarchyProvider({
-        hierarchyDefinition: new ModelsTreeDefinition({ idsCache, imodelAccess, hierarchyConfig: defaultModelsTreeHierarchyConfiguration }),
-        imodelAccess,
-      });
-      const hierarchyNodes = await collectNodes({ provider });
-
-      const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
-      expect(visibilityTargets.categories.length).toBe(1);
-      const elementsCategory = visibilityTargets.categories[0];
-
-      await handler.changeVisibility(createModelHierarchyNode(elementsModel), true);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-      return { iModel, imodelAccess, viewport, provider, handler, elementsCategory, elementsModel, iModelConnection, hierarchyNodes };
-    },
-    cleanup: async (props) => {
-      props.iModel.close();
-      props.viewport[Symbol.dispose]();
-      props.handler[Symbol.dispose]();
-      props.provider[Symbol.dispose]();
-      if (!props.iModelConnection.isClosed) {
-        await props.iModelConnection.close();
-      }
-    },
-    test: async ({ viewport, handler, hierarchyNodes, elementsCategory, elementsModel }) => {
-      viewport.setPerModelCategoryOverride({ modelIds: elementsModel, categoryIds: elementsCategory, override: "hide" });
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
-    },
-  });
-
-  run<{
-    iModel: SnapshotDb;
-    imodelAccess: IModelAccess;
-    viewport: TreeWidgetTestingViewport;
-    handler: HierarchyVisibilityHandler & Disposable;
-    provider: HierarchyProvider & Disposable;
-    node: { modelId: Id64String; categoryId: Id64String; elementId: Id64String; subjectId: Id64String };
-    iModelConnection: IModelConnection;
-    hierarchyNodes: HierarchyNode[];
-  }>({
-    testName: "changing element visibility changes only parent nodes visibility with 50k elements",
-    setup: async () => {
-      const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k 3D elements"));
-      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
-      const visibilityTargets = await getVisibilityTargets(imodelAccess);
-      const testData = createTestDataForInitialDisplay({ visibilityTargets, visible: false });
-
-      const viewport = await createViewport({
-        iModelConnection,
-        testData,
-      });
-      setupInitialDisplayState({
-        viewport,
-        ...testData,
-      });
-      const baseIdsCache = new BaseIdsCache({
-        elementClassName: defaultModelsTreeHierarchyConfiguration.elementClassSpecification,
-        type: "3d",
-        queryExecutor: imodelAccess,
-      });
-      const idsCache = new ModelsTreeIdsCache({
-        queryExecutor: imodelAccess,
-        hierarchyConfig: defaultModelsTreeHierarchyConfiguration,
-        baseIdsCache,
-      });
-      const handler = createModelsTreeVisibilityHandler({ idsCache, viewport, imodelAccess });
-      const provider = createIModelHierarchyProvider({
-        hierarchyDefinition: new ModelsTreeDefinition({ idsCache, imodelAccess, hierarchyConfig: defaultModelsTreeHierarchyConfiguration }),
-        imodelAccess,
-      });
-      const hierarchyNodes = await collectNodes({ provider });
-
-      const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
-      expect(visibilityTargets.categories.length).toBe(1);
-      const elementsCategory = visibilityTargets.categories[0];
-      const node = { modelId: elementsModel, elementId: visibilityTargets.elements[0], categoryId: elementsCategory, subjectId: "0x1" };
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
-
-      return { iModel, imodelAccess, viewport, provider, handler, node, iModelConnection, hierarchyNodes };
-    },
-    cleanup: async (props) => {
-      props.iModel.close();
-      props.viewport[Symbol.dispose]();
-      props.handler[Symbol.dispose]();
-      props.provider[Symbol.dispose]();
-      if (!props.iModelConnection.isClosed) {
-        await props.iModelConnection.close();
-      }
-    },
-    test: async ({ viewport, handler, hierarchyNodes, node }) => {
-      await handler.changeVisibility(createElementHierarchyNode(node), true);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: {
-          default: "all-hidden",
-          instances: {
-            [node.modelId]: "partial",
-            [node.subjectId]: "partial",
-            [node.categoryId]: "partial",
-            [node.elementId]: "visible",
-          },
-          parentIds: {
-            [node.elementId]: "visible",
-          },
+    testSteps: [
+      {
+        name: "collect nodes",
+        callBack: async (ctx) => {
+          ctx.hierarchyNodes = await collectNodes({ provider: ctx.provider, ignoreChildren: (node) => ModelsTreeNode.isCategoryNode(node) });
         },
+      },
+      {
+        name: "validate initial visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "change visibility",
+        callBack: async ({ viewport, handler, elementsModel }) => {
+          // Add one element to always draw set to trigger additional queries
+          viewport.setAlwaysDrawn({ elementIds: new Set([elementsModel]) });
+          await handler.changeVisibility(createModelHierarchyNode(elementsModel), true);
+        },
+      },
+      {
+        name: "validate changed visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
+        },
+      },
+    ],
+  });
+
+  run<{
+    iModel: SnapshotDb;
+    imodelAccess: IModelAccess;
+    viewport: TreeWidgetTestingViewport;
+    handler: HierarchyVisibilityHandler & Disposable;
+    provider: HierarchyProvider & Disposable;
+    elementsModel: Id64String;
+    elementsCategory: Id64String;
+    elementNodeData: { modelId: Id64String; categoryId: Id64String; elementId: Id64String; subjectId: Id64String };
+    iModelConnection: IModelConnection;
+    hierarchyNodes: HierarchyNode[];
+    resetInitialVisibilityState: ({ shouldBeVisible }: { shouldBeVisible?: boolean }) => void;
+  }>({
+    testName: "50k 3D elements",
+    setup: async () => {
+      const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k 3D elements"));
+      const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
+      const visibilityTargets = await getVisibilityTargets(imodelAccess);
+      const hiddenTestData = createTestDataForInitialDisplay({ visibilityTargets, visible: false });
+      const visibleTestData = createTestDataForInitialDisplay({ visibilityTargets, visible: true });
+
+      const viewport = await createViewport({
+        iModelConnection,
+        testData: hiddenTestData,
       });
+      setupInitialDisplayState({
+        viewport,
+        ...hiddenTestData,
+      });
+      const baseIdsCache = new BaseIdsCache({
+        elementClassName: defaultModelsTreeHierarchyConfiguration.elementClassSpecification,
+        type: "3d",
+        queryExecutor: imodelAccess,
+      });
+      const idsCache = new ModelsTreeIdsCache({
+        queryExecutor: imodelAccess,
+        hierarchyConfig: defaultModelsTreeHierarchyConfiguration,
+        baseIdsCache,
+      });
+      const handler = createModelsTreeVisibilityHandler({ idsCache, viewport, imodelAccess });
+      const provider = createIModelHierarchyProvider({
+        hierarchyDefinition: new ModelsTreeDefinition({ idsCache, imodelAccess, hierarchyConfig: defaultModelsTreeHierarchyConfiguration }),
+        imodelAccess,
+      });
+      const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
+      expect(visibilityTargets.categories.length).toBe(1);
+      const elementsCategory = visibilityTargets.categories[0];
+      const elementNodeData = { modelId: elementsModel, elementId: visibilityTargets.elements[0], categoryId: elementsCategory, subjectId: "0x1" };
+      return {
+        iModel,
+        imodelAccess,
+        viewport,
+        provider,
+        handler,
+        elementsModel,
+        elementsCategory,
+        elementNodeData,
+        iModelConnection,
+        hierarchyNodes: [],
+        resetInitialVisibilityState: ({ shouldBeVisible }: { shouldBeVisible?: boolean }) => {
+          setupInitialDisplayState({
+            viewport,
+            ...(shouldBeVisible ? visibleTestData : hiddenTestData),
+          });
+        },
+      };
     },
+    cleanup: async (props) => {
+      props.iModel.close();
+      props.viewport[Symbol.dispose]();
+      props.handler[Symbol.dispose]();
+      props.provider[Symbol.dispose]();
+      if (!props.iModelConnection.isClosed) {
+        await props.iModelConnection.close();
+      }
+    },
+    testSteps: [
+      {
+        name: "collect nodes",
+        callBack: async (ctx) => {
+          ctx.hierarchyNodes = await collectNodes({ provider: ctx.provider });
+        },
+      },
+      {
+        name: "validate initial visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "change model visibility",
+        callBack: async ({ handler, elementsModel }) => {
+          await handler.changeVisibility(createModelHierarchyNode(elementsModel), true);
+        },
+      },
+      {
+        name: "validate changed model visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
+        },
+      },
+      {
+        name: "make everything visible",
+        callBack: async ({ resetInitialVisibilityState }) => {
+          resetInitialVisibilityState({ shouldBeVisible: true });
+        },
+        ignoreMeasurement: true,
+      },
+      {
+        name: "change category node visibility",
+        callBack: async ({ handler, elementsCategory, elementsModel }) => {
+          await handler.changeVisibility(createCategoryHierarchyNode(elementsCategory, elementsModel, true), false);
+        },
+      },
+      {
+        name: "validate changed category visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "make everything visible 2",
+        callBack: ({ viewport, resetInitialVisibilityState }) => {
+          resetInitialVisibilityState({ shouldBeVisible: true });
+        },
+        ignoreMeasurement: true,
+      },
+      {
+        name: "validate per-model category override",
+        callBack: async ({ hierarchyNodes, handler, viewport, elementsModel, elementsCategory }) => {
+          viewport.setPerModelCategoryOverride({ modelIds: elementsModel, categoryIds: elementsCategory, override: "hide" });
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "reset to everything hidden",
+        callBack: ({ resetInitialVisibilityState }) => {
+          resetInitialVisibilityState({ shouldBeVisible: false });
+        },
+        ignoreMeasurement: true,
+      },
+      {
+        name: "change element visibility",
+        callBack: async ({ handler, elementNodeData }) => {
+          await handler.changeVisibility(createElementHierarchyNode(elementNodeData), true);
+        },
+      },
+      {
+        name: "validate changed element visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport, elementNodeData }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: {
+              default: "all-hidden",
+              instances: {
+                [elementNodeData.modelId]: "partial",
+                [elementNodeData.subjectId]: "partial",
+                [elementNodeData.categoryId]: "partial",
+                [elementNodeData.elementId]: "visible",
+              },
+              parentIds: {
+                [elementNodeData.elementId]: "visible",
+              },
+            },
+          });
+        },
+      },
+    ],
   });
 
   run<{
@@ -473,7 +404,7 @@ describe("models tree", () => {
     iModelConnection: IModelConnection;
     hierarchyNodes: HierarchyNode[];
   }>({
-    testName: "changing element visibility changes only parent nodes visibility with 50k child elements with different categories",
+    testName: "50k 3D child elements with different categories",
     setup: async () => {
       const { iModelConnection, iModel } = TestIModelConnection.openFile(Datasets.getIModelPath("50k 3D child elements with different categories"));
       const imodelAccess = StatelessHierarchyProvider.createIModelAccess(iModel, "unbounded");
@@ -505,20 +436,13 @@ describe("models tree", () => {
         hierarchyDefinition: new ModelsTreeDefinition({ idsCache, imodelAccess, hierarchyConfig: defaultModelsTreeHierarchyConfiguration }),
         imodelAccess,
       });
-      const hierarchyNodes = await collectNodes({ provider });
 
       const elementsModel = iModel.elements.getElementProps(visibilityTargets.elements[0]).model;
       expect(visibilityTargets.categories.length).to.be.eq(3);
       const elementsCategory = visibilityTargets.categories[0];
       const node = { modelId: elementsModel, elementId: visibilityTargets.elements[0], categoryId: elementsCategory, subjectId: "0x1" };
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
 
-      return { iModel, imodelAccess, viewport, provider, handler, node, iModelConnection, hierarchyNodes };
+      return { iModel, imodelAccess, viewport, provider, handler, node, iModelConnection, hierarchyNodes: [] };
     },
     cleanup: async (props) => {
       props.iModel.close();
@@ -529,26 +453,53 @@ describe("models tree", () => {
         await props.iModelConnection.close();
       }
     },
-    test: async ({ viewport, handler, hierarchyNodes, node }) => {
-      await handler.changeVisibility(createElementHierarchyNode(node), true);
-      await validateHierarchyVisibility({
-        hierarchyNodes,
-        handler,
-        viewport,
-        expectations: {
-          default: "all-hidden",
-          instances: {
-            [node.modelId]: "partial",
-            [node.subjectId]: "partial",
-            [node.categoryId]: "partial",
-            [node.elementId]: "visible",
-          },
-          parentIds: {
-            [node.elementId]: "visible",
-          },
+    testSteps: [
+      {
+        name: "collect nodes",
+        callBack: async (ctx) => {
+          ctx.hierarchyNodes = await collectNodes({ provider: ctx.provider });
         },
-      });
-    },
+      },
+      {
+        name: "validate initial visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        },
+      },
+      {
+        name: "change visibility",
+        callBack: async ({ handler, node }) => {
+          await handler.changeVisibility(createElementHierarchyNode(node), true);
+        },
+      },
+      {
+        name: "validate changed visibility",
+        callBack: async ({ hierarchyNodes, handler, viewport, node }) => {
+          await validateHierarchyVisibility({
+            hierarchyNodes,
+            handler,
+            viewport,
+            expectations: {
+              default: "all-hidden",
+              instances: {
+                [node.modelId]: "partial",
+                [node.subjectId]: "partial",
+                [node.categoryId]: "partial",
+                [node.elementId]: "visible",
+              },
+              parentIds: {
+                [node.elementId]: "visible",
+              },
+            },
+          });
+        },
+      },
+    ],
   });
 });
 

--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -44,10 +44,12 @@ export interface ValidateNodeProps {
     | "all-hidden"
     | ({
         default: "all-visible" | "all-hidden";
-      } & (
-        | { instances: { [id: string]: Visibility }; parentIds?: { [id: string]: Visibility } }
-        | { instances?: { [id: string]: Visibility }; parentIds: { [id: string]: Visibility } }
-      ));
+      } &
+        // instances: if node has this instanceId then it should have the specified visibility.
+        // parentIds: if node has parent with this parentId then it should have the specified visibility.
+        (| { instances: { [id: string]: Visibility }; parentIds?: { [id: string]: Visibility } }
+          | { instances?: { [id: string]: Visibility }; parentIds: { [id: string]: Visibility } }
+        ));
 }
 
 async function validateNodeVisibility({ node, handler, expectations }: ValidateNodeProps & { node: HierarchyNode }) {

--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -42,11 +42,12 @@ export interface ValidateNodeProps {
   expectations:
     | "all-visible"
     | "all-hidden"
-    | {
+    | ({
         default: "all-visible" | "all-hidden";
-        instances: { [id: string]: Visibility };
-        parentIds?: { [id: string]: Visibility };
-      };
+      } & (
+        | { instances: { [id: string]: Visibility }; parentIds?: { [id: string]: Visibility } }
+        | { instances?: { [id: string]: Visibility }; parentIds: { [id: string]: Visibility } }
+      ));
 }
 
 async function validateNodeVisibility({ node, handler, expectations }: ValidateNodeProps & { node: HierarchyNode }) {
@@ -60,11 +61,13 @@ async function validateNodeVisibility({ node, handler, expectations }: ValidateN
     expect(actualVisibility.state, node.label).toBe(expectations === "all-hidden" ? "hidden" : "visible");
     return;
   }
-  const idInExpectations = ids.find((id) => id in expectations.instances);
-  if (idInExpectations) {
-    const expectedVisibility = expectations.instances[idInExpectations];
-    expect(actualVisibility.state, node.label).toBe(expectedVisibility);
-    return;
+  if (expectations.instances) {
+    const idInExpectations = ids.find((id) => id in expectations.instances!);
+    if (idInExpectations) {
+      const expectedVisibility = expectations.instances[idInExpectations];
+      expect(actualVisibility.state, node.label).toBe(expectedVisibility);
+      return;
+    }
   }
 
   if (expectations.parentIds) {
@@ -371,9 +374,32 @@ export function createDefinitionContainerHierarchyNode(definitionContainerId: Id
   };
 }
 
+export function createClassificationTableHierarchyNode(classificationTableId: Id64String): NonGroupingHierarchyNode {
+  return {
+    key: {
+      type: "instances",
+      instanceKeys: [{ className: "ClassificationSystems.ClassificationTable", id: classificationTableId }],
+    },
+    children: true,
+    label: "",
+    parentKeys: [],
+    extendedData: {
+      type: "ClassificationTable",
+    },
+  };
+}
+
 export async function getVisibilityTargets(
   imodelAccess: IModelAccess,
-): Promise<{ models: Id64Array; categories: Id64Array; subCategories: Id64Array; elements: Id64Array; definitionContainers: Id64Array }> {
+  rootClassificationSystemCode?: string,
+): Promise<{
+  models: Id64Array;
+  categories: Id64Array;
+  subCategories: Id64Array;
+  elements: Id64Array;
+  definitionContainers: Id64Array;
+  classificationTables: Id64Array;
+}> {
   const query: ECSqlQueryDef = {
     ecsql: `
       SELECT
@@ -400,6 +426,19 @@ export async function getVisibilityTargets(
         CAST(IdToHex(ECInstanceId) AS TEXT) AS ECInstanceId,
         'BisCore.DefinitionContainer' as ClassName
       FROM bis.DefinitionContainer
+      ${
+        rootClassificationSystemCode
+          ? `
+            UNION ALL
+            SELECT
+              CAST(IdToHex(this.ECInstanceId) AS TEXT) AS ECInstanceId,
+              'BisCore.ClassificationTable' as ClassName
+            FROM ClassificationSystems.ClassificationTable this
+            JOIN ClassificationSystems.ClassificationSystem system ON system.ECInstanceId = this.Parent.Id
+            WHERE system.CodeValue = '${rootClassificationSystemCode}'
+          `
+          : ""
+      }
     `,
   };
   const categories = new Array<Id64String>();
@@ -407,6 +446,7 @@ export async function getVisibilityTargets(
   const elements = new Array<Id64String>();
   const models = new Array<Id64String>();
   const definitionContainers = new Array<Id64String>();
+  const classificationTables = new Array<Id64String>();
   for await (const row of imodelAccess.createQueryReader(query, { limit: "unbounded" })) {
     if (row.ClassName.toLowerCase().includes("subcategory")) {
       subCategories.push(row.ECInstanceId);
@@ -427,6 +467,9 @@ export async function getVisibilityTargets(
     if (row.ClassName.toLowerCase().includes("container")) {
       definitionContainers.push(row.ECInstanceId);
     }
+    if (row.ClassName.toLowerCase().includes("classificationTable".toLowerCase())) {
+      classificationTables.push(row.ECInstanceId);
+    }
   }
-  return { categories, subCategories, elements, models, definitionContainers };
+  return { categories, subCategories, elements, models, definitionContainers, classificationTables };
 }

--- a/apps/performance-tests/src/util/Datasets.ts
+++ b/apps/performance-tests/src/util/Datasets.ts
@@ -364,14 +364,14 @@ export class Datasets {
             id: tableId,
           },
         });
-        for (let j = 0; j < numElements / classificationTablesCount; ++j) {
+        for (let j = 0; j < numElements / classificationTablesCount / 2; ++j) {
           const classificationId = builder.insertElement({
             classFullName: "ClassificationSystems.Classification",
             model: tableModelId,
             code: builder.createCode(tableModelId, BisCodeSpec.nullCodeSpec, `Classification ${j + 1}`),
           });
 
-          builder.insertElement({
+          const childClassificationId = builder.insertElement({
             classFullName: "ClassificationSystems.Classification",
             model: tableModelId,
             code: builder.createCode(tableModelId, BisCodeSpec.nullCodeSpec, `Child classification ${j + 1}`),
@@ -395,12 +395,12 @@ export class Datasets {
           builder.insertRelationship({
             classFullName: "ClassificationSystems.ElementHasClassifications",
             sourceId: physicalElement.id,
-            targetId: classificationId,
+            targetId: childClassificationId,
           });
           builder.insertRelationship({
             classFullName: "TestClassificationSchema.CategorySymbolizesClassification",
             sourceId: spatialCategory.id,
-            targetId: classificationId,
+            targetId: childClassificationId,
           });
         }
       }

--- a/apps/performance-tests/src/util/TestReporter.ts
+++ b/apps/performance-tests/src/util/TestReporter.ts
@@ -72,10 +72,10 @@ export default class TestReporter implements Reporter {
     const meta = testCase.meta();
     const symbol = state === "passed" ? this.#symbols.passed : state === "failed" ? this.#symbols.failed : this.#symbols.skipped;
     const testFullName = testCase.fullName.replaceAll(">", "").replaceAll("  ", " ");
-    const testSteps = meta.testSteps ?? [];
-    for (let i = 0; i < testSteps.length; ++i) {
-      const step = testSteps[i];
-      const isLastStep = i === testSteps.length - 1;
+    const steps = meta.steps ?? [];
+    for (let i = 0; i < steps.length; ++i) {
+      const step = steps[i];
+      const isLastStep = i === steps.length - 1;
       this.#stepResults.push({
         testFullName,
         stepName: step.name,
@@ -93,7 +93,7 @@ export default class TestReporter implements Reporter {
       }
     }
 
-    const totalDuration = testSteps.reduce<number>((sum, s) => sum + s.duration, 0);
+    const totalDuration = steps.reduce<number>((sum, s) => sum + s.duration, 0);
     this.print(`${symbol} ${testCase.name} (${totalDuration} ms)`);
   }
 

--- a/apps/performance-tests/src/util/TestReporter.ts
+++ b/apps/performance-tests/src/util/TestReporter.ts
@@ -7,12 +7,12 @@ import asTable from "as-table";
 import fs from "fs";
 
 import type { SerializedError, UserConsoleLog } from "vitest";
-import type { Reporter, TestCase, TestModule, TestSuite } from "vitest/node";
+import type { Reporter, TestCase, TestModule, TestRunEndReason, TestSpecification, TestSuite } from "vitest/node";
 import type { Summary } from "./MainThreadBlocksDetector.js";
 
-interface TestInfo {
-  fullName: string;
-  name: string;
+interface TestStepInfo {
+  testFullName: string;
+  stepName: string;
   state: "passed" | "failed" | "skipped" | "pending";
   duration: number;
   blockingSummary: Summary;
@@ -27,13 +27,24 @@ const tableFormatter = asTable.configure({
  * Measures test time and the amounts of time when the main thread was blocked.
  */
 export default class TestReporter implements Reporter {
-  readonly #testInfo: TestInfo[] = [];
+  readonly #stepResults: TestStepInfo[] = [];
   #hasFailures = false;
   #outputPath?: string;
   #indentLevel = 0;
+  #symbols = {
+    passed: "✅",
+    failed: "❌",
+    skipped: "⏩",
+  };
 
   public onInit(): void {
     this.#outputPath = process.env.BENCHMARK_OUTPUT_PATH;
+  }
+
+  public onTestRunStart(specifications: readonly TestSpecification[]): void {
+    if (specifications.length === 0) {
+      this.print(`\n${this.#symbols.failed}  No test files found`);
+    }
   }
 
   public onTestSuiteReady(testSuite: TestSuite): void {
@@ -59,17 +70,22 @@ export default class TestReporter implements Reporter {
     const result = testCase.result();
     const state = result.state;
     const meta = testCase.meta();
+    const symbol = state === "passed" ? this.#symbols.passed : state === "failed" ? this.#symbols.failed : this.#symbols.skipped;
+    const testFullName = testCase.fullName.replaceAll(">", "").replaceAll("  ", " ");
+    const testSteps = meta.testSteps ?? [];
+    for (let i = 0; i < testSteps.length; ++i) {
+      const step = testSteps[i];
+      const isLastStep = i === testSteps.length - 1;
+      this.#stepResults.push({
+        testFullName,
+        stepName: step.name,
+        state: isLastStep ? state : "passed", // if a step fails, steps before should be marked as passed, not failed
+        duration: step.duration,
+        blockingSummary: step.blockingSummary,
+        symbol: isLastStep ? symbol : this.#symbols.passed, // if a step fails, steps before should be marked as passed, not failed
+      });
+    }
 
-    const info: TestInfo = {
-      fullName: testCase.fullName.replaceAll(">", "").replaceAll("  ", " "),
-      name: testCase.name,
-      state,
-      duration: meta.duration ?? 0,
-      blockingSummary: meta.blockingSummary ?? { count: 0 },
-      symbol: state === "passed" ? "✅" : state === "failed" ? "❌" : "⏩",
-    };
-
-    this.#testInfo.push(info);
     if (state === "failed") {
       this.#hasFailures = true;
       if (result.errors.length > 0) {
@@ -77,14 +93,15 @@ export default class TestReporter implements Reporter {
       }
     }
 
-    this.print(`${info.symbol} ${testCase.name} (${info.duration} ms)`);
+    const totalDuration = testSteps.reduce<number>((sum, s) => sum + s.duration, 0);
+    this.print(`${symbol} ${testCase.name} (${totalDuration} ms)`);
   }
 
   public onTestModuleEnd(testModule: TestModule): void {
     const errors = testModule.errors();
     if (errors.length > 0) {
       this.#hasFailures = true;
-      this.print(`\n❌ Module errors in ${testModule.moduleId}:`);
+      this.print(`\n${this.#symbols.failed} Module errors in ${testModule.moduleId}:`);
       this.printErrors(errors);
     }
   }
@@ -101,7 +118,16 @@ export default class TestReporter implements Reporter {
     }
   }
 
-  public onTestRunEnd(): void {
+  public onTestRunEnd(testModules: ReadonlyArray<TestModule>, unhandledErrors: ReadonlyArray<SerializedError>, reason: TestRunEndReason): void {
+    if (unhandledErrors.length > 0) {
+      this.#hasFailures = true;
+      this.print(`\n${this.#symbols.failed} Unhandled errors:`);
+      this.printErrors(unhandledErrors);
+    }
+    if (reason === "failed" && testModules.length === 0) {
+      this.#hasFailures = true;
+      this.print(`\n${this.#symbols.failed} Test run failed: no tests were executed`);
+    }
     this.printResults();
     if (this.#outputPath && !this.#hasFailures) {
       this.saveResults();
@@ -115,7 +141,7 @@ export default class TestReporter implements Reporter {
   }
 
   private printResults() {
-    const results = this.#testInfo.map(({ state, fullName, duration, blockingSummary, symbol }) => {
+    const results = this.#stepResults.map(({ state, testFullName, stepName, duration, blockingSummary, symbol }) => {
       const blockingInfo = Object.entries(blockingSummary)
         .filter(([_, val]) => val !== undefined)
         .map(([key, val]) => `${key}: ${(key === "count" ? val : val?.toFixed(2)) ?? "N/A"}`)
@@ -125,7 +151,7 @@ export default class TestReporter implements Reporter {
 
       return {
         Status: `${symbol} ${state}`,
-        Test: fullName,
+        Test: stepName ? `${testFullName}: ${stepName}` : testFullName,
         Duration: `${duration} ms`,
         Blocks: blockingInfo,
       };
@@ -138,15 +164,16 @@ export default class TestReporter implements Reporter {
 
   /** Saves performance results in a format that is compatible with Github benchmark action. */
   private saveResults() {
-    const data = this.#testInfo.flatMap(({ fullName, duration, blockingSummary }) => {
+    const data = this.#stepResults.flatMap(({ testFullName, stepName, duration, blockingSummary }) => {
+      const name = stepName ? `${testFullName} > ${stepName}` : testFullName;
       const durationEntry = {
-        name: fullName,
+        name,
         unit: "ms",
         value: duration,
       };
 
       const blockingEntry = {
-        name: `${fullName} (P95 of main thread blocks)`,
+        name: `${name} (P95 of main thread blocks)`,
         unit: "ms",
         value: blockingSummary.p95 ?? 0,
         extra: Object.entries(blockingSummary)

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -12,10 +12,15 @@ import type { TaskMeta } from "vitest";
 import type { IModelDb } from "@itwin/core-backend";
 import type { Summary } from "./MainThreadBlocksDetector.js";
 
+interface TestStepEntry {
+  name: string;
+  blockingSummary: Summary;
+  duration: number;
+}
+
 declare module "vitest" {
   interface TaskMeta {
-    blockingSummary?: Summary;
-    duration?: number;
+    testSteps?: Array<TestStepEntry>;
   }
 }
 
@@ -26,8 +31,12 @@ export interface RunOptions<TContext> {
   /** Callback to run before the test that should produce the context required for the test. */
   setup(): TContext | Promise<TContext>;
 
-  /** Test function to run and measure. */
-  test(x: TContext): void | Promise<void>;
+  /** Test steps which are run in order and measured. */
+  testSteps: Array<{
+    name?: string;
+    callBack: (x: TContext) => void | Promise<void>;
+    ignoreMeasurement?: boolean; // if true, the time spent in this step will not be measured and included in the results
+  }>;
 
   /** Callback that cleans up the context produced by the "before" callback. */
   cleanup?: (x: TContext) => void | Promise<void>;
@@ -48,15 +57,25 @@ export function run<T>(props: RunOptions<T>): void {
   const testFunc = async ({ task }: { task: { meta: TaskMeta } }) => {
     const blockHandler = new MainThreadBlocksDetector();
     const value = await props.setup();
-    const start = Date.now();
-    try {
-      blockHandler.start();
-      await props.test(value);
-    } finally {
-      await blockHandler.stop();
-      task.meta.blockingSummary = blockHandler.getSummary();
-      task.meta.duration = Date.now() - start;
-      await props.cleanup?.(value);
+
+    for (const { name, callBack, ignoreMeasurement } of props.testSteps) {
+      const start = Date.now();
+      try {
+        if (!ignoreMeasurement) {
+          blockHandler.start();
+        }
+        await callBack(value);
+      } finally {
+        if (!ignoreMeasurement) {
+          await blockHandler.stop();
+          task.meta.testSteps ??= [];
+          task.meta.testSteps.push({
+            name: name ?? "unknown",
+            blockingSummary: blockHandler.getSummary(),
+            duration: Date.now() - start,
+          });
+        }
+      }
     }
   };
 

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -59,13 +59,10 @@ export function run<T>(props: RunOptions<T>): void {
     try {
       for (const { name, callBack, ignoreMeasurement } of props.steps) {
         console.log(`Step "${name}" in progress...`);
-        await using blockDetector = createThreadBlocksDetector({ ignoreMeasurement, name });
-        try {
-          await callBack(value);
-          console.log(`✅ Step "${name}" done`);
-        } finally {
-          await blockDetector.complete(task);
-        }
+        await using blockDetector = createThreadBlocksDetector({ ignoreMeasurement, name, task });
+        await callBack(value);
+        await blockDetector.complete();
+        console.log(`✅ Step "${name}" done`);
       }
     } finally {
       await props.cleanup?.(value);
@@ -79,8 +76,8 @@ export function run<T>(props: RunOptions<T>): void {
   }
 }
 
-function createThreadBlocksDetector({ ignoreMeasurement, name }: { ignoreMeasurement?: boolean; name: string }): {
-  complete: (task: { meta: TaskMeta }) => Promise<void>;
+function createThreadBlocksDetector({ ignoreMeasurement, name, task }: { ignoreMeasurement?: boolean; name: string; task: { meta: TaskMeta } }): {
+  complete: () => Promise<void>;
 } & AsyncDisposable {
   if (ignoreMeasurement) {
     return { complete: async () => {}, [Symbol.asyncDispose]: async () => {} };
@@ -90,7 +87,10 @@ function createThreadBlocksDetector({ ignoreMeasurement, name }: { ignoreMeasure
   const detector = new MainThreadBlocksDetector();
   detector.start();
   return {
-    complete: async (task: { meta: TaskMeta }) => {
+    complete: async () => {
+      await detector.stop();
+    },
+    [Symbol.asyncDispose]: async () => {
       await detector.stop();
       task.meta.steps ??= [];
       task.meta.steps.push({
@@ -98,9 +98,6 @@ function createThreadBlocksDetector({ ignoreMeasurement, name }: { ignoreMeasure
         blockingSummary: detector.getSummary(),
         duration: Date.now() - start,
       });
-    },
-    [Symbol.asyncDispose]: async () => {
-      await detector.stop();
     },
   };
 }

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -55,25 +55,25 @@ export function run<T>(props: RunOptions<T>): void {
   }
 
   const testFunc = async ({ task }: { task: { meta: TaskMeta } }) => {
-    const blockHandler = new MainThreadBlocksDetector();
     const value = await props.setup();
     try {
       for (const { name, callBack, ignoreMeasurement } of props.steps) {
+        const blockDetector = new MainThreadBlocksDetector();
         console.log(`Step "${name}" in progress...`);
         const start = Date.now();
         try {
           if (!ignoreMeasurement) {
-            blockHandler.start();
+            blockDetector.start();
           }
           await callBack(value);
           console.log(`✅ Step "${name}" done`);
         } finally {
           if (!ignoreMeasurement) {
-            await blockHandler.stop();
+            await blockDetector.stop();
             task.meta.steps ??= [];
             task.meta.steps.push({
               name,
-              blockingSummary: blockHandler.getSummary(),
+              blockingSummary: blockDetector.getSummary(),
               duration: Date.now() - start,
             });
           }

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -58,25 +58,13 @@ export function run<T>(props: RunOptions<T>): void {
     const value = await props.setup();
     try {
       for (const { name, callBack, ignoreMeasurement } of props.steps) {
-        const blockDetector = new MainThreadBlocksDetector();
         console.log(`Step "${name}" in progress...`);
-        const start = Date.now();
+        await using blockDetector = createThreadBlocksDetector({ ignoreMeasurement, name });
         try {
-          if (!ignoreMeasurement) {
-            blockDetector.start();
-          }
           await callBack(value);
           console.log(`✅ Step "${name}" done`);
         } finally {
-          if (!ignoreMeasurement) {
-            await blockDetector.stop();
-            task.meta.steps ??= [];
-            task.meta.steps.push({
-              name,
-              blockingSummary: blockDetector.getSummary(),
-              duration: Date.now() - start,
-            });
-          }
+          await blockDetector.complete(task);
         }
       }
     } finally {
@@ -89,6 +77,32 @@ export function run<T>(props: RunOptions<T>): void {
   } else {
     it(props.testName, testFunc);
   }
+}
+
+function createThreadBlocksDetector({ ignoreMeasurement, name }: { ignoreMeasurement?: boolean; name: string }): {
+  complete: (task: { meta: TaskMeta }) => Promise<void>;
+} & AsyncDisposable {
+  if (ignoreMeasurement) {
+    return { complete: async () => {}, [Symbol.asyncDispose]: async () => {} };
+  }
+
+  const start = Date.now();
+  const detector = new MainThreadBlocksDetector();
+  detector.start();
+  return {
+    complete: async (task: { meta: TaskMeta }) => {
+      await detector.stop();
+      task.meta.steps ??= [];
+      task.meta.steps.push({
+        name,
+        blockingSummary: detector.getSummary(),
+        duration: Date.now() - start,
+      });
+    },
+    [Symbol.asyncDispose]: async () => {
+      await detector.stop();
+    },
+  };
 }
 
 /**

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -57,27 +57,30 @@ export function run<T>(props: RunOptions<T>): void {
   const testFunc = async ({ task }: { task: { meta: TaskMeta } }) => {
     const blockHandler = new MainThreadBlocksDetector();
     const value = await props.setup();
-
-    for (const { name, callBack, ignoreMeasurement } of props.testSteps) {
-      console.log(`Step "${name ?? "unknown"}" in progress...`);
-      const start = Date.now();
-      try {
-        if (!ignoreMeasurement) {
-          blockHandler.start();
-        }
-        await callBack(value);
-        console.log(`✅ Step "${name ?? "unknown"}" done`);
-      } finally {
-        if (!ignoreMeasurement) {
-          await blockHandler.stop();
-          task.meta.testSteps ??= [];
-          task.meta.testSteps.push({
-            name: name ?? "unknown",
-            blockingSummary: blockHandler.getSummary(),
-            duration: Date.now() - start,
-          });
+    try {
+      for (const { name, callBack, ignoreMeasurement } of props.testSteps) {
+        console.log(`Step "${name ?? "unknown"}" in progress...`);
+        const start = Date.now();
+        try {
+          if (!ignoreMeasurement) {
+            blockHandler.start();
+          }
+          await callBack(value);
+          console.log(`✅ Step "${name ?? "unknown"}" done`);
+        } finally {
+          if (!ignoreMeasurement) {
+            await blockHandler.stop();
+            task.meta.testSteps ??= [];
+            task.meta.testSteps.push({
+              name: name ?? "unknown",
+              blockingSummary: blockHandler.getSummary(),
+              duration: Date.now() - start,
+            });
+          }
         }
       }
+    } finally {
+      await props.cleanup?.(value);
     }
   };
 

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -20,7 +20,7 @@ interface TestStepEntry {
 
 declare module "vitest" {
   interface TaskMeta {
-    testSteps?: Array<TestStepEntry>;
+    steps?: Array<TestStepEntry>;
   }
 }
 
@@ -32,7 +32,7 @@ export interface RunOptions<TContext> {
   setup(): TContext | Promise<TContext>;
 
   /** Test steps which are run in order and measured. */
-  testSteps: Array<{
+  steps: Array<{
     name?: string;
     callBack: (x: TContext) => void | Promise<void>;
     ignoreMeasurement?: boolean; // if true, the time spent in this step will not be measured and included in the results
@@ -58,7 +58,7 @@ export function run<T>(props: RunOptions<T>): void {
     const blockHandler = new MainThreadBlocksDetector();
     const value = await props.setup();
     try {
-      for (const { name, callBack, ignoreMeasurement } of props.testSteps) {
+      for (const { name, callBack, ignoreMeasurement } of props.steps) {
         console.log(`Step "${name ?? "unknown"}" in progress...`);
         const start = Date.now();
         try {
@@ -70,8 +70,8 @@ export function run<T>(props: RunOptions<T>): void {
         } finally {
           if (!ignoreMeasurement) {
             await blockHandler.stop();
-            task.meta.testSteps ??= [];
-            task.meta.testSteps.push({
+            task.meta.steps ??= [];
+            task.meta.steps.push({
               name: name ?? "unknown",
               blockingSummary: blockHandler.getSummary(),
               duration: Date.now() - start,

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -59,12 +59,14 @@ export function run<T>(props: RunOptions<T>): void {
     const value = await props.setup();
 
     for (const { name, callBack, ignoreMeasurement } of props.testSteps) {
+      console.log(`Step "${name ?? "unknown"}" in progress...`);
       const start = Date.now();
       try {
         if (!ignoreMeasurement) {
           blockHandler.start();
         }
         await callBack(value);
+        console.log(`✅ Step "${name ?? "unknown"}" done`);
       } finally {
         if (!ignoreMeasurement) {
           await blockHandler.stop();

--- a/apps/performance-tests/src/util/TestUtilities.ts
+++ b/apps/performance-tests/src/util/TestUtilities.ts
@@ -33,7 +33,7 @@ export interface RunOptions<TContext> {
 
   /** Test steps which are run in order and measured. */
   steps: Array<{
-    name?: string;
+    name: string;
     callBack: (x: TContext) => void | Promise<void>;
     ignoreMeasurement?: boolean; // if true, the time spent in this step will not be measured and included in the results
   }>;
@@ -59,20 +59,20 @@ export function run<T>(props: RunOptions<T>): void {
     const value = await props.setup();
     try {
       for (const { name, callBack, ignoreMeasurement } of props.steps) {
-        console.log(`Step "${name ?? "unknown"}" in progress...`);
+        console.log(`Step "${name}" in progress...`);
         const start = Date.now();
         try {
           if (!ignoreMeasurement) {
             blockHandler.start();
           }
           await callBack(value);
-          console.log(`✅ Step "${name ?? "unknown"}" done`);
+          console.log(`✅ Step "${name}" done`);
         } finally {
           if (!ignoreMeasurement) {
             await blockHandler.stop();
             task.meta.steps ??= [];
             task.meta.steps.push({
-              name: name ?? "unknown",
+              name,
               blockingSummary: blockHandler.getSummary(),
               duration: Date.now() - start,
             });

--- a/apps/performance-tests/vitest.config.ts
+++ b/apps/performance-tests/vitest.config.ts
@@ -3,10 +3,43 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import fs from "fs";
+import path from "path";
 import { defineConfig } from "vitest/config";
 import TestReporter from "./src/util/TestReporter.js";
 
+const treeWidgetRoot = path.resolve(__dirname, "../../packages/itwin/tree-widget");
+const treeWidgetSrc = path.resolve(treeWidgetRoot, "src");
+
+function collectDepsFromPackage(...packageDirs: string[]): string[] {
+  const deps = new Set<string>();
+  for (const dir of packageDirs) {
+    const pkg = JSON.parse(fs.readFileSync(path.resolve(dir, "package.json"), "utf-8"));
+    for (const dep of Object.keys(pkg.peerDependencies ?? {})) {
+      deps.add(dep);
+    }
+    for (const dep of Object.keys(pkg.dependencies ?? {})) {
+      deps.add(dep);
+    }
+    for (const dep of Object.keys(pkg.devDependencies ?? {})) {
+      deps.add(dep);
+    }
+  }
+  return [...deps];
+}
+
 export default defineConfig({
+  // Debugging dependencies (in this case tree-widget) is not easy since source maps don't seem to work.
+  // Adding these aliases allows adding breakpoints straight into the source code and it does not need to be built.
+  resolve: {
+    alias: [
+      { find: "@itwin/tree-widget-react/internal", replacement: path.resolve(treeWidgetSrc, "tree-widget-react-internal.ts") },
+      { find: "@itwin/tree-widget-react", replacement: path.resolve(treeWidgetSrc, "tree-widget-react.ts") },
+    ],
+    // Dedupe ensures that shared dependencies (e.g. @itwin/core-frontend) resolve from this app's
+    // node_modules rather than the tree-widget package's node_modules, preventing duplicate package errors.
+    dedupe: collectDepsFromPackage(treeWidgetRoot, __dirname),
+  },
   test: {
     environment: "happy-dom",
     include: ["src/**/*.test.{ts,tsx}"],

--- a/apps/performance-tests/vitest.config.ts
+++ b/apps/performance-tests/vitest.config.ts
@@ -5,9 +5,12 @@
 
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { defineConfig } from "vitest/config";
 import TestReporter from "./src/util/TestReporter.js";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const treeWidgetRoot = path.resolve(__dirname, "../../packages/itwin/tree-widget");
 const treeWidgetSrc = path.resolve(treeWidgetRoot, "src");
 

--- a/packages/itwin/tree-widget/src/tree-widget-react-internal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react-internal.ts
@@ -25,6 +25,7 @@ export { createCategoriesTreeVisibilityHandler } from "./tree-widget-react/compo
 export { ClassificationsTreeDefinition } from "./tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.js";
 export { ClassificationsTreeIdsCache } from "./tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.js";
 export { releaseMainThreadOnItemsCount } from "./tree-widget-react/components/trees/common/internal/Utils.js";
+export { createClassificationsTreeVisibilityHandler } from "./tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.js";
 
 export { BaseIdsCache } from "./tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.js";
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -4,20 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of } from "rxjs";
-import { assert } from "@itwin/core-bentley";
+import { assert, Guid } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
+import { HierarchyVisibilityHandlerImpl } from "../../../common/internal/useTreeHooks/UseCachedVisibility.js";
 import { fromWithRelease, getIdsFromChildrenTree, getParentElementsIdsPath, setDifference, setIntersection } from "../../../common/internal/Utils.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
 import { ClassificationsTreeNodeInternal } from "../ClassificationsTreeNodeInternal.js";
 import { ClassificationsTreeVisibilityHelper } from "./ClassificationsTreeVisibilityHelper.js";
+import { createClassificationsSearchResultsTree } from "./SearchResultsTree.js";
 
 import type { Observable } from "rxjs";
 import type { Id64Set, Id64String } from "@itwin/core-bentley";
-import type { HierarchyNode } from "@itwin/presentation-hierarchies";
+import type { HierarchyNode, HierarchySearchTree } from "@itwin/presentation-hierarchies";
+import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
 import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
 import type { ChildrenTree } from "../../../common/internal/Utils.js";
+import type { SearchResultsTree } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
 import type { TreeSpecificVisibilityHandler } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import type { TreeWidgetViewport } from "../../../common/TreeWidgetViewport.js";
 import type { VisibilityStatus } from "../../../common/UseHierarchyVisibility.js";
@@ -309,4 +313,37 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
       ),
     );
   }
+}
+
+/**
+ * Creates classifications tree visibility handler. Is used by integration and performance tests.
+ * @internal
+ */
+export function createClassificationsTreeVisibilityHandler(props: {
+  viewport: TreeWidgetViewport;
+  idsCache: ClassificationsTreeIdsCache;
+  imodelAccess: ECClassHierarchyInspector;
+  searchPaths?: HierarchySearchTree[];
+}) {
+  return new HierarchyVisibilityHandlerImpl<ClassificationsTreeSearchTargets>({
+    getSearchResultsTree: (): undefined | Promise<SearchResultsTree<ClassificationsTreeSearchTargets>> => {
+      if (!props.searchPaths) {
+        return undefined;
+      }
+      return createClassificationsSearchResultsTree({
+        idsCache: props.idsCache,
+        searchPaths: props.searchPaths,
+        imodelAccess: props.imodelAccess,
+      });
+    },
+    getTreeSpecificVisibilityHandler: (info) => {
+      return new ClassificationsTreeVisibilityHandler({
+        alwaysAndNeverDrawnElementInfo: info,
+        idsCache: props.idsCache,
+        viewport: props.viewport,
+      });
+    },
+    viewport: props.viewport,
+    componentId: Guid.createValue(),
+  });
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -336,11 +336,11 @@ export function createClassificationsTreeVisibilityHandler(props: {
         imodelAccess: props.imodelAccess,
       });
     },
-    getTreeSpecificVisibilityHandler: (info) => {
+    getTreeSpecificVisibilityHandler: ({ info, viewport }) => {
       return new ClassificationsTreeVisibilityHandler({
         alwaysAndNeverDrawnElementInfo: info,
         idsCache: props.idsCache,
-        viewport: props.viewport,
+        viewport,
       });
     },
     viewport: props.viewport,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -41,7 +41,8 @@ import type { ChildrenTree } from "../Utils.js";
 
 /** @internal */
 export const SET_CHANGE_DEBOUNCE_TIME = 20;
-const ALWAYS_NEVER_BUFFER_THRESHOLD = 5000;
+/** @internal */
+export const ALWAYS_NEVER_BUFFER_THRESHOLD = 5000;
 
 type SetType = "always" | "never";
 
@@ -90,8 +91,8 @@ interface AlwaysAndNeverDrawnElementInfoCacheProps {
 /** @internal */
 export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   #subscriptions: Subscription[];
-  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
-  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
+  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap>; latestCacheEntryValueUsed?: boolean };
+  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap>; latestCacheEntryValueUsed?: boolean };
   #disposeSubject = new Subject<void>();
   readonly #viewport: TreeWidgetViewport;
   readonly #elementClassName: string;
@@ -140,14 +141,16 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       return this.getChildrenTree({ currentChildrenTree: rootTreeNodes, pathToElements, currentIdsIndex: 0 });
     };
 
-    return !cache.latestCacheEntryValue
-      ? cache.cacheEntryObs.pipe(map(getElements))
-      : this.#suppressors.pipe(
-          take(1),
-          mergeMap((suppressionCount) =>
-            suppressionCount > 0 ? cache.latestCacheEntryValue!.pipe(map(getElements)) : cache.cacheEntryObs.pipe(map(getElements)),
-          ),
-        );
+    return this.#suppressors.pipe(
+      take(1),
+      mergeMap((suppressionCount) => {
+        if (suppressionCount > 0) {
+          cache.latestCacheEntryValueUsed = true;
+          return cache.latestCacheEntryValue!.pipe(map(getElements));
+        }
+        return cache.cacheEntryObs.pipe(map(getElements));
+      }),
+    );
   }
 
   private getChildrenTree({
@@ -183,7 +186,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   private createCacheEntryObservable(setType: SetType): Observable<CachedNodesMap> {
     const event = setType === "always" ? this.#viewport.onAlwaysDrawnChanged : this.#viewport.onNeverDrawnChanged;
     const getIds = setType === "always" ? () => this.#viewport.alwaysDrawn : () => this.#viewport.neverDrawn;
-
+    const invalidateCache = new Subject<void>();
     const resultSubject = new BehaviorSubject<CachedNodesMap | undefined>(undefined);
     // Observable listens to viewport always/never drawn set change events.
     const sharedObs = fromEventPattern(
@@ -210,10 +213,17 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
         ),
       ),
       map(() => {
-        // Make sure latestCacheEntry is set to a new observable if change happened before suppression
         const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
-        cache.latestCacheEntryValue = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(shareReplay());
-        return cache.latestCacheEntryValue;
+        if (!cache.latestCacheEntryValueUsed) {
+          // previous latestCacheEntry is not used, invalidate it
+          invalidateCache.next();
+        }
+        const queryObservable = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(takeUntil(invalidateCache), shareReplay());
+
+        // Make sure latestCacheEntry is set to a new observable if change happened before suppression
+        cache.latestCacheEntryValue = queryObservable;
+        cache.latestCacheEntryValueUsed = false;
+        return queryObservable;
       }),
       debounceTime(SET_CHANGE_DEBOUNCE_TIME),
       // Cancel pending request if dispose() is called.

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -90,8 +90,8 @@ interface AlwaysAndNeverDrawnElementInfoCacheProps {
 /** @internal */
 export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
   #subscriptions: Subscription[];
-  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: CachedNodesMap };
-  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: CachedNodesMap };
+  #alwaysDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
+  #neverDrawn: { cacheEntryObs: Observable<CachedNodesMap>; latestCacheEntryValue?: Observable<CachedNodesMap> };
   #disposeSubject = new Subject<void>();
   readonly #viewport: TreeWidgetViewport;
   readonly #elementClassName: string;
@@ -145,7 +145,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       : this.#suppressors.pipe(
           take(1),
           mergeMap((suppressionCount) =>
-            suppressionCount > 0 ? of(cache.latestCacheEntryValue).pipe(map(getElements)) : cache.cacheEntryObs.pipe(map(getElements)),
+            suppressionCount > 0 ? cache.latestCacheEntryValue!.pipe(map(getElements)) : cache.cacheEntryObs.pipe(map(getElements)),
           ),
         );
   }
@@ -194,6 +194,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
       map(() => undefined),
       share(),
     );
+
     const obs = sharedObs.pipe(
       // Fire the observable once at the beginning
       startWith(undefined),
@@ -208,24 +209,21 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
           take(1),
         ),
       ),
+      map(() => {
+        // Make sure latestCacheEntry is set to a new observable if change happened before suppression
+        const cache = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
+        cache.latestCacheEntryValue = this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType).pipe(shareReplay());
+        return cache.latestCacheEntryValue;
+      }),
       debounceTime(SET_CHANGE_DEBOUNCE_TIME),
       // Cancel pending request if dispose() is called.
       takeUntil(this.#disposeSubject),
       // If multiple requests are sent at once, preserve only the result of the newest.
-      switchMap(() =>
+      switchMap((queryObservable) =>
         // Race between the event and the query.
         // In cases where event is raised before query returns, the query result is discarded.
-        race(
-          sharedObs,
-          defer(() => this.queryAlwaysOrNeverDrawnElementInfo(getIds(), setType)),
-        ),
+        race(sharedObs, queryObservable),
       ),
-      tap((cacheEntry) => {
-        if (cacheEntry !== undefined) {
-          const value = setType === "always" ? this.#alwaysDrawn : this.#neverDrawn;
-          value.latestCacheEntryValue = cacheEntry;
-        }
-      }),
       // Share the result by using a subject which always emits the saved result.
       share({
         connector: () => resultSubject,


### PR DESCRIPTION
Decided to split up performance tests into these parts:
- For search tests:
  - Get search paths
  - Load hierarchy from search paths
- For non-search tests:
  - Gather nodes
  - Validate initial display state
  - Change visibility
  - Validate changed visibility
  
  Additional changes: 
  - Adjusted classifications dataset, now it includes 50k classifications instead of (100k previous number).
  - Adjusted classifications tests to be similar to models/categories trees.
  - Merged some models tree performance tests into one test, since they were using the same dataset
  - This PR includes changes from https://github.com/iTwin/viewer-components-react/pull/1652, without them models tree tests fail
  
  **Note:** All the performance tests will now have different names, so tracking to previous results might be difficult. The new results should be used as a baseline.