### PR TITLE
[Tree widget]: increase beforeAll timeout for performance tests

### DIFF
--- a/apps/performance-tests/src/setup.ts
+++ b/apps/performance-tests/src/setup.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
   });
   ECSchemaRpcImpl.register();
   await Datasets.initialize("./datasets");
-}, 30_000);
+}, 60_000);
 
 afterAll(async () => {
   await terminatePresentationTesting();

--- a/apps/performance-tests/vitest.config.ts
+++ b/apps/performance-tests/vitest.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
     environment: "happy-dom",
     include: ["src/**/*.test.{ts,tsx}"],
     restoreMocks: true,
-    testTimeout: 300000,
+    testTimeout: 300_000,
     fileParallelism: false,
     setupFiles: ["src/setup.ts"],
     reporters: [new TestReporter()],


### PR DESCRIPTION
Pipeline seems to be failing when running on `next` https://github.com/iTwin/viewer-components-react/actions/runs/24560404045/job/71807320830