### PR TITLE
[Tree widget[: performance tests adjustments on `next`

### DIFF
--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -86,30 +86,22 @@ async function* getNodesAndChildren({
   provider,
   parentNode,
   ignoreChildren,
-  ...props
 }: {
   ignoreChildren: (node: HierarchyNode) => boolean;
   provider: HierarchyProvider;
   parentNode?: HierarchyNode;
-  /**
-   * Releases main thread after processing specified amount of nodes.
-   * Threshold specifies how many nodes should be processed before releasing again.
-   */
-  releaseAfterProcessingNodes?: { amount: number; threshold: number };
 }): AsyncIterableIterator<HierarchyNode> {
-  const defaultThreshold = 500;
-  const releaseAfterProcessingNodes = props.releaseAfterProcessingNodes ?? { amount: defaultThreshold, threshold: defaultThreshold };
+  const releaseAfterProcessing = 500;
+  let nodesProcessed = 0;
   for await (const node of provider.getNodes({ parentNode })) {
-    --releaseAfterProcessingNodes.amount;
-    if (!releaseAfterProcessingNodes.amount) {
+    ++nodesProcessed;
+    if (nodesProcessed >= releaseAfterProcessing) {
       await new Promise((resolve) => setTimeout(resolve));
-      releaseAfterProcessingNodes.amount = releaseAfterProcessingNodes.threshold;
+      nodesProcessed = 0;
     }
-
     yield node;
-
     if (node.children && !ignoreChildren(node)) {
-      yield* getNodesAndChildren({ provider, parentNode: node, releaseAfterProcessingNodes, ignoreChildren });
+      yield* getNodesAndChildren({ provider, parentNode: node, ignoreChildren });
     }
   }
 }

--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -91,15 +91,19 @@ async function* getNodesAndChildren({
   ignoreChildren: (node: HierarchyNode) => boolean;
   provider: HierarchyProvider;
   parentNode?: HierarchyNode;
-  releaseAfterProcessingNodes?: { amount: number };
+  /**
+   * Releases main thread after processing specified amount of nodes.
+   * Threshold specifies how many nodes should be processed before releasing again.
+   */
+  releaseAfterProcessingNodes?: { amount: number; threshold: number };
 }): AsyncIterableIterator<HierarchyNode> {
-  const releaseAfterProcessingAmount = 500;
-  const releaseAfterProcessingNodes = props.releaseAfterProcessingNodes ?? { amount: releaseAfterProcessingAmount };
+  const defaultThreshold = 500;
+  const releaseAfterProcessingNodes = props.releaseAfterProcessingNodes ?? { amount: defaultThreshold, threshold: defaultThreshold };
   for await (const node of provider.getNodes({ parentNode })) {
     --releaseAfterProcessingNodes.amount;
     if (!releaseAfterProcessingNodes.amount) {
       await new Promise((resolve) => setTimeout(resolve));
-      releaseAfterProcessingNodes.amount = releaseAfterProcessingAmount;
+      releaseAfterProcessingNodes.amount = releaseAfterProcessingNodes.threshold;
     }
 
     yield node;

--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -3,22 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  bufferCount,
-  concatMap,
-  defaultIfEmpty,
-  delay,
-  EMPTY,
-  expand,
-  firstValueFrom,
-  from,
-  identity,
-  mergeMap,
-  of,
-  queueScheduler,
-  takeLast,
-  toArray,
-} from "rxjs";
+import { bufferCount, concatMap, defaultIfEmpty, delay, firstValueFrom, from, identity, mergeMap, of, takeLast, toArray } from "rxjs";
 import { expect } from "vitest";
 import { assert } from "@itwin/core-bentley";
 import { Code, ColorDef, IModel, RenderMode } from "@itwin/core-common";
@@ -94,12 +79,35 @@ export async function collectNodes({
   ignoreChildren?: (node: HierarchyNode) => boolean;
   provider: HierarchyProvider;
 }): Promise<HierarchyNode[]> {
-  return firstValueFrom(
-    from(provider.getNodes({ parentNode: undefined })).pipe(
-      expand((node) => (node.children && !ignoreChildren(node) ? provider.getNodes({ parentNode: node }) : EMPTY), 1000, queueScheduler),
-      toArray(),
-    ),
-  );
+  return firstValueFrom(from(getNodesAndChildren({ provider, ignoreChildren })).pipe(toArray()));
+}
+
+async function* getNodesAndChildren({
+  provider,
+  parentNode,
+  ignoreChildren,
+  ...props
+}: {
+  ignoreChildren: (node: HierarchyNode) => boolean;
+  provider: HierarchyProvider;
+  parentNode?: HierarchyNode;
+  releaseAfterProcessingNodes?: { amount: number };
+}): AsyncIterableIterator<HierarchyNode> {
+  const releaseAfterProcessingAmount = 500;
+  const releaseAfterProcessingNodes = props.releaseAfterProcessingNodes ?? { amount: releaseAfterProcessingAmount };
+  for await (const node of provider.getNodes({ parentNode })) {
+    --releaseAfterProcessingNodes.amount;
+    if (!releaseAfterProcessingNodes.amount) {
+      await new Promise<void>((resolve) => setTimeout(resolve));
+      releaseAfterProcessingNodes.amount = releaseAfterProcessingAmount;
+    }
+
+    yield node;
+
+    if (node.children && !ignoreChildren(node)) {
+      yield* getNodesAndChildren({ provider, parentNode: node, releaseAfterProcessingNodes, ignoreChildren });
+    }
+  }
 }
 
 export async function validateHierarchyVisibility(

--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -98,7 +98,7 @@ async function* getNodesAndChildren({
   for await (const node of provider.getNodes({ parentNode })) {
     --releaseAfterProcessingNodes.amount;
     if (!releaseAfterProcessingNodes.amount) {
-      await new Promise<void>((resolve) => setTimeout(resolve));
+      await new Promise((resolve) => setTimeout(resolve));
       releaseAfterProcessingNodes.amount = releaseAfterProcessingAmount;
     }
 


### PR DESCRIPTION
Part of https://github.com/iTwin/viewer-components-react/issues/1512.
Purely test code adjustment: `collectNodes` function now releases main thread. This should reduce main thread blockage for `collect nodes` tests