### PR TITLE
[Tree widget]: header buttons cancel ongoing changes on `next`

### DIFF
--- a/change/@itwin-tree-widget-react-a4883a94-03f6-4240-90e7-dea64028501d.json
+++ b/change/@itwin-tree-widget-react-a4883a94-03f6-4240-90e7-dea64028501d.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Models & Categories trees: 'hide all' and 'show all' header buttons cancel scheduled visibility changes and 'invert all' button waits for scheduled changes to finish before inverting visibility.",
+  "comment": "Models & Categories trees: 'hide all', 'show all' and 'invert all' header buttons cancel scheduled visibility changes.",
   "packageName": "@itwin/tree-widget-react",
   "email": "100586436+JonasDov@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-tree-widget-react-a4883a94-03f6-4240-90e7-dea64028501d.json
+++ b/change/@itwin-tree-widget-react-a4883a94-03f6-4240-90e7-dea64028501d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Models & Categories trees: 'hide all' and 'show all' header buttons cancel scheduled visibility changes and 'invert all' button waits for scheduled changes to finish before inverting visibility.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeVisibilityHandler.test.ts
@@ -7,11 +7,9 @@ import { afterAll, beforeAll, describe, it } from "vitest";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 import { ClassificationsTreeDefinition } from "../../../tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.js";
 import { ClassificationsTreeIdsCache } from "../../../tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.js";
-import { ClassificationsTreeVisibilityHandler } from "../../../tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.js";
-import { createClassificationsSearchResultsTree } from "../../../tree-widget-react/components/trees/classifications-tree/internal/visibility/SearchResultsTree.js";
+import { createClassificationsTreeVisibilityHandler } from "../../../tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.js";
 import { BaseIdsCache } from "../../../tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.js";
 import { CLASS_NAME_GeometricElement3d } from "../../../tree-widget-react/components/trees/common/internal/ClassNameDefinitions.js";
-import { HierarchyVisibilityHandlerImpl } from "../../../tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.js";
 import { buildIModel, insertPhysicalElement, insertPhysicalModelWithPartition, insertSpatialCategory } from "../../IModelUtils.js";
 import { initializeITwinJs, terminateITwinJs } from "../../Initialize.js";
 import { createIModelAccess } from "../Common.js";
@@ -32,11 +30,8 @@ import { validateNodeVisibility } from "./VisibilityValidation.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { HierarchySearchTree } from "@itwin/presentation-hierarchies";
-import type { ECClassHierarchyInspector, Props } from "@itwin/presentation-shared";
-import type { ClassificationsTreeSearchTargets } from "../../../tree-widget-react/components/trees/classifications-tree/internal/visibility/SearchResultsTree.js";
+import type { Props } from "@itwin/presentation-shared";
 import type { ClassificationsTreeVisibilityHandlerConfiguration } from "../../../tree-widget-react/components/trees/classifications-tree/UseClassificationsTree.js";
-import type { SearchResultsTree } from "../../../tree-widget-react/components/trees/common/internal/visibility/BaseSearchResultsTree.js";
-import type { TreeWidgetViewport } from "../../../tree-widget-react/components/trees/common/TreeWidgetViewport.js";
 
 describe("ClassificationsTreeVisibilityHandler", () => {
   beforeAll(async () => {
@@ -1345,34 +1340,6 @@ describe("ClassificationsTreeVisibilityHandler", () => {
     });
   });
 });
-
-function createClassificationsTreeVisibilityHandler(props: {
-  viewport: TreeWidgetViewport;
-  idsCache: ClassificationsTreeIdsCache;
-  imodelAccess: ECClassHierarchyInspector;
-  searchPaths?: HierarchySearchTree[];
-}) {
-  return new HierarchyVisibilityHandlerImpl<ClassificationsTreeSearchTargets>({
-    getSearchResultsTree: (): undefined | Promise<SearchResultsTree<ClassificationsTreeSearchTargets>> => {
-      if (!props.searchPaths) {
-        return undefined;
-      }
-      return createClassificationsSearchResultsTree({
-        idsCache: props.idsCache,
-        searchPaths: props.searchPaths,
-        imodelAccess: props.imodelAccess,
-      });
-    },
-    getTreeSpecificVisibilityHandler: ({ info, viewport }) => {
-      return new ClassificationsTreeVisibilityHandler({
-        alwaysAndNeverDrawnElementInfo: info,
-        idsCache: props.idsCache,
-        viewport,
-      });
-    },
-    viewport: props.viewport,
-  });
-}
 
 async function validateClassificationsTreeHierarchyVisibility(props: Omit<Props<typeof validateHierarchyVisibility>, "validateNodeVisibility">) {
   return validateHierarchyVisibility({

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/useTreeHooks/UseCachedVisibility.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/useTreeHooks/UseCachedVisibility.test.ts
@@ -43,18 +43,26 @@ function setupTest(overrides?: {
   visibilityHandler?: Partial<TreeSpecificVisibilityHandler<void> & Disposable>;
   viewport?: ReturnType<typeof createFakeViewport>;
   getTreeSpecificVisibilityHandler?: HierarchyVisibilityHandlerImplProps<void>["getTreeSpecificVisibilityHandler"];
+  cancelChangesInProgress?: Subject<void>;
+  updateChangesInProgress?: HierarchyVisibilityHandlerImplProps<void>["updateChangesInProgress"];
 }) {
   const viewport = overrides?.viewport ?? createFakeViewport();
+  const cancelChangesInProgress = overrides?.cancelChangesInProgress ?? new Subject<void>();
+  const updateChangesInProgress = overrides?.updateChangesInProgress ?? vi.fn();
   const defaultVisibilityHandler = createTreeSpecificVisibilityHandler(overrides?.visibilityHandler);
   const handler = new HierarchyVisibilityHandlerImpl<void>({
     viewport,
     getTreeSpecificVisibilityHandler: overrides?.getTreeSpecificVisibilityHandler ?? (() => defaultVisibilityHandler),
     getSearchResultsTree: () => undefined,
+    cancelChangesInProgress,
+    updateChangesInProgress,
   });
   return {
     handler,
     viewport,
     visibilityHandler: defaultVisibilityHandler,
+    cancelChangesInProgress,
+    updateChangesInProgress,
     [Symbol.dispose]: () => handler[Symbol.dispose](),
   };
 }
@@ -390,6 +398,8 @@ describe("HierarchyVisibilityHandlerImpl", () => {
         viewport,
         getTreeSpecificVisibilityHandler: () => createTreeSpecificVisibilityHandler(),
         getSearchResultsTree: () => undefined,
+        cancelChangesInProgress: new Subject<void>(),
+        updateChangesInProgress: vi.fn(),
       });
 
       expect(viewport.onDisplayedModelsChanged.numberOfListeners).toBeGreaterThan(listenerCountBefore);
@@ -397,6 +407,164 @@ describe("HierarchyVisibilityHandlerImpl", () => {
       handler[Symbol.dispose]();
 
       expect(viewport.onDisplayedModelsChanged.numberOfListeners).toBe(listenerCountBefore);
+    });
+  });
+
+  describe("cancelChangesInProgress", () => {
+    it("discards buffered changes when cancelChangesInProgress fires during changeVisibility", async () => {
+      const vp = createFakeViewport();
+      const changeSubject = new Subject<void>();
+      using setup = setupTest({
+        viewport: vp,
+        cancelChangesInProgress: new Subject<void>(),
+        updateChangesInProgress: vi.fn(),
+        getTreeSpecificVisibilityHandler: ({ viewport: bufferingViewport }) =>
+          createTreeSpecificVisibilityHandler({
+            changeVisibilityStatus: vi.fn(() => {
+              bufferingViewport.changeModelDisplay({ modelIds: "0x1", display: true });
+              return changeSubject;
+            }),
+          }),
+      });
+      const { handler, cancelChangesInProgress } = setup;
+
+      const changePromise = handler.changeVisibility(createNode(), true);
+
+      // Cancel all ongoing changes — should unsubscribe and discard
+      cancelChangesInProgress.next();
+
+      await changePromise;
+
+      // The buffered changes should have been discarded, not committed
+      expect(vp.changeModelDisplay).not.toHaveBeenCalled();
+    });
+
+    it("does not affect already completed changes", async () => {
+      const vp = createFakeViewport();
+      using setup = setupTest({
+        viewport: vp,
+        getTreeSpecificVisibilityHandler: ({ viewport: bufferingViewport }) =>
+          createTreeSpecificVisibilityHandler({
+            changeVisibilityStatus: vi.fn(() => {
+              bufferingViewport.changeModelDisplay({ modelIds: "0x1", display: true });
+              return EMPTY;
+            }),
+          }),
+      });
+      const { handler, cancelChangesInProgress } = setup;
+
+      // Let change complete normally
+      await handler.changeVisibility(createNode(), true);
+      expect(vp.changeModelDisplay).toHaveBeenCalledWith({ modelIds: "0x1", display: true });
+
+      // Cancel after completion — should be a no-op
+      cancelChangesInProgress.next();
+      expect(vp.changeModelDisplay).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels multiple in-flight changes at once", async () => {
+      const vp = createFakeViewport();
+      const changeSubjectA = new Subject<void>();
+      const changeSubjectB = new Subject<void>();
+      const getTreeSpecificVisibilityHandler = vi
+        .fn<HierarchyVisibilityHandlerImplProps<void>["getTreeSpecificVisibilityHandler"]>()
+        .mockImplementationOnce(({ viewport: bufferingViewport }) =>
+          createTreeSpecificVisibilityHandler({
+            changeVisibilityStatus: vi.fn(() => {
+              bufferingViewport.changeModelDisplay({ modelIds: "0xA", display: true });
+              return changeSubjectA;
+            }),
+          }),
+        )
+        .mockImplementationOnce(({ viewport: bufferingViewport }) =>
+          createTreeSpecificVisibilityHandler({
+            changeVisibilityStatus: vi.fn(() => {
+              bufferingViewport.changeModelDisplay({ modelIds: "0xB", display: false });
+              return changeSubjectB;
+            }),
+          }),
+        );
+      using setup = setupTest({
+        viewport: vp,
+        getTreeSpecificVisibilityHandler,
+      });
+      const { handler, cancelChangesInProgress } = setup;
+
+      const nodeA = createNode({ instanceKeys: [{ className: "BisCore.Element", id: "0x1" }] });
+      const nodeB = createNode({ instanceKeys: [{ className: "BisCore.Element", id: "0x2" }] });
+
+      const promiseA = handler.changeVisibility(nodeA, true);
+      const promiseB = handler.changeVisibility(nodeB, false);
+
+      // Cancel all
+      cancelChangesInProgress.next();
+
+      await promiseA;
+      await promiseB;
+
+      // Neither change should have been committed
+      expect(vp.changeModelDisplay).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateChangesInProgress", () => {
+    it("calls updateChangesInProgress with 'add' when changeVisibility starts", async () => {
+      const updateChangesInProgress = vi.fn();
+      using setup = setupTest({ updateChangesInProgress });
+      const { handler } = setup;
+
+      const changePromise = handler.changeVisibility(createNode(), true);
+
+      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "add");
+
+      await changePromise;
+    });
+
+    it("calls updateChangesInProgress with 'remove' when changeVisibility completes", async () => {
+      const updateChangesInProgress = vi.fn();
+      using setup = setupTest({ updateChangesInProgress });
+      const { handler } = setup;
+
+      await handler.changeVisibility(createNode(), true);
+
+      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "remove");
+      // "add" called first, then "remove"
+      expect(updateChangesInProgress).toHaveBeenCalledTimes(2);
+      expect(updateChangesInProgress.mock.calls[0][1]).toBe("add");
+      expect(updateChangesInProgress.mock.calls[1][1]).toBe("remove");
+    });
+
+    it("calls updateChangesInProgress with 'remove' when changeVisibility is cancelled", async () => {
+      const updateChangesInProgress = vi.fn();
+      const changeSubject = new Subject<void>();
+      using setup = setupTest({
+        updateChangesInProgress,
+        visibilityHandler: {
+          changeVisibilityStatus: vi.fn(() => changeSubject),
+        },
+      });
+      const { handler, cancelChangesInProgress } = setup;
+
+      const changePromise = handler.changeVisibility(createNode(), true);
+      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "add");
+
+      // Cancel
+      cancelChangesInProgress.next();
+      await changePromise;
+
+      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "remove");
+    });
+
+    it("passes the same promise reference to both 'add' and 'remove'", async () => {
+      const updateChangesInProgress = vi.fn();
+      using setup = setupTest({ updateChangesInProgress });
+      const { handler } = setup;
+
+      await handler.changeVisibility(createNode(), true);
+
+      const addedPromise = updateChangesInProgress.mock.calls[0][0];
+      const removedPromise = updateChangesInProgress.mock.calls[1][0];
+      expect(addedPromise).toBe(removedPromise);
     });
   });
 });

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/useTreeHooks/UseCachedVisibility.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/useTreeHooks/UseCachedVisibility.test.ts
@@ -433,29 +433,6 @@ describe("HierarchyVisibilityHandlerImpl", () => {
       expect(vp.changeModelDisplay).not.toHaveBeenCalled();
     });
 
-    it("does not affect already completed changes", async () => {
-      const vp = createFakeViewport();
-      using setup = setupTest({
-        viewport: vp,
-        getTreeSpecificVisibilityHandler: ({ viewport: bufferingViewport }) =>
-          createTreeSpecificVisibilityHandler({
-            changeVisibilityStatus: vi.fn(() => {
-              bufferingViewport.changeModelDisplay({ modelIds: "0x1", display: true });
-              return EMPTY;
-            }),
-          }),
-      });
-      const { handler, cancelChangesInProgress } = setup;
-
-      // Let change complete normally
-      await handler.changeVisibility(createNode(), true);
-      expect(vp.changeModelDisplay).toHaveBeenCalledWith({ modelIds: "0x1", display: true });
-
-      // Cancel after completion — should be a no-op
-      cancelChangesInProgress.next();
-      expect(vp.changeModelDisplay).toHaveBeenCalledTimes(1);
-    });
-
     it("cancels multiple in-flight changes at once", async () => {
       const vp = createFakeViewport();
       const changeSubjectA = new Subject<void>();

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/useTreeHooks/UseCachedVisibility.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/useTreeHooks/UseCachedVisibility.test.ts
@@ -44,25 +44,21 @@ function setupTest(overrides?: {
   viewport?: ReturnType<typeof createFakeViewport>;
   getTreeSpecificVisibilityHandler?: HierarchyVisibilityHandlerImplProps<void>["getTreeSpecificVisibilityHandler"];
   cancelChangesInProgress?: Subject<void>;
-  updateChangesInProgress?: HierarchyVisibilityHandlerImplProps<void>["updateChangesInProgress"];
 }) {
   const viewport = overrides?.viewport ?? createFakeViewport();
   const cancelChangesInProgress = overrides?.cancelChangesInProgress ?? new Subject<void>();
-  const updateChangesInProgress = overrides?.updateChangesInProgress ?? vi.fn();
   const defaultVisibilityHandler = createTreeSpecificVisibilityHandler(overrides?.visibilityHandler);
   const handler = new HierarchyVisibilityHandlerImpl<void>({
     viewport,
     getTreeSpecificVisibilityHandler: overrides?.getTreeSpecificVisibilityHandler ?? (() => defaultVisibilityHandler),
     getSearchResultsTree: () => undefined,
     cancelChangesInProgress,
-    updateChangesInProgress,
   });
   return {
     handler,
     viewport,
     visibilityHandler: defaultVisibilityHandler,
     cancelChangesInProgress,
-    updateChangesInProgress,
     [Symbol.dispose]: () => handler[Symbol.dispose](),
   };
 }
@@ -399,7 +395,6 @@ describe("HierarchyVisibilityHandlerImpl", () => {
         getTreeSpecificVisibilityHandler: () => createTreeSpecificVisibilityHandler(),
         getSearchResultsTree: () => undefined,
         cancelChangesInProgress: new Subject<void>(),
-        updateChangesInProgress: vi.fn(),
       });
 
       expect(viewport.onDisplayedModelsChanged.numberOfListeners).toBeGreaterThan(listenerCountBefore);
@@ -417,7 +412,6 @@ describe("HierarchyVisibilityHandlerImpl", () => {
       using setup = setupTest({
         viewport: vp,
         cancelChangesInProgress: new Subject<void>(),
-        updateChangesInProgress: vi.fn(),
         getTreeSpecificVisibilityHandler: ({ viewport: bufferingViewport }) =>
           createTreeSpecificVisibilityHandler({
             changeVisibilityStatus: vi.fn(() => {
@@ -504,67 +498,6 @@ describe("HierarchyVisibilityHandlerImpl", () => {
 
       // Neither change should have been committed
       expect(vp.changeModelDisplay).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("updateChangesInProgress", () => {
-    it("calls updateChangesInProgress with 'add' when changeVisibility starts", async () => {
-      const updateChangesInProgress = vi.fn();
-      using setup = setupTest({ updateChangesInProgress });
-      const { handler } = setup;
-
-      const changePromise = handler.changeVisibility(createNode(), true);
-
-      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "add");
-
-      await changePromise;
-    });
-
-    it("calls updateChangesInProgress with 'remove' when changeVisibility completes", async () => {
-      const updateChangesInProgress = vi.fn();
-      using setup = setupTest({ updateChangesInProgress });
-      const { handler } = setup;
-
-      await handler.changeVisibility(createNode(), true);
-
-      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "remove");
-      // "add" called first, then "remove"
-      expect(updateChangesInProgress).toHaveBeenCalledTimes(2);
-      expect(updateChangesInProgress.mock.calls[0][1]).toBe("add");
-      expect(updateChangesInProgress.mock.calls[1][1]).toBe("remove");
-    });
-
-    it("calls updateChangesInProgress with 'remove' when changeVisibility is cancelled", async () => {
-      const updateChangesInProgress = vi.fn();
-      const changeSubject = new Subject<void>();
-      using setup = setupTest({
-        updateChangesInProgress,
-        visibilityHandler: {
-          changeVisibilityStatus: vi.fn(() => changeSubject),
-        },
-      });
-      const { handler, cancelChangesInProgress } = setup;
-
-      const changePromise = handler.changeVisibility(createNode(), true);
-      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "add");
-
-      // Cancel
-      cancelChangesInProgress.next();
-      await changePromise;
-
-      expect(updateChangesInProgress).toHaveBeenCalledWith(expect.any(Promise), "remove");
-    });
-
-    it("passes the same promise reference to both 'add' and 'remove'", async () => {
-      const updateChangesInProgress = vi.fn();
-      using setup = setupTest({ updateChangesInProgress });
-      const { handler } = setup;
-
-      await handler.changeVisibility(createNode(), true);
-
-      const addedPromise = updateChangesInProgress.mock.calls[0][0];
-      const removedPromise = updateChangesInProgress.mock.calls[1][0];
-      expect(addedPromise).toBe(removedPromise);
     });
   });
 });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
@@ -139,7 +139,7 @@ export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
       label={translate("categoriesTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.(`categories-tree-invert`);
-        void Promise.all([...changesInProgress]).then(async () => {
+        void Promise.allSettled([...changesInProgress]).then(async () => {
           await invertAllCategories(props.categories, props.viewport);
         });
       }}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
@@ -131,7 +131,7 @@ export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
 
 /** @public */
 export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
-  const { changesInProgress } = useSharedTreeContextInternal();
+  const { cancelChangesInProgress } = useSharedTreeContextInternal();
   const translate = useTranslation();
   return (
     <IconButton
@@ -139,10 +139,8 @@ export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
       label={translate("categoriesTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.(`categories-tree-invert`);
-        void (async () => {
-          await Promise.allSettled([...changesInProgress]);
-          await invertAllCategories(props.categories, props.viewport);
-        })();
+        cancelChangesInProgress.next();
+        void invertAllCategories(props.categories, props.viewport);
       }}
       icon={visibilityInvertSvg}
     />

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
@@ -139,9 +139,10 @@ export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
       label={translate("categoriesTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.(`categories-tree-invert`);
-        void Promise.allSettled([...changesInProgress]).then(async () => {
+        void (async () => {
+          await Promise.allSettled([...changesInProgress]);
           await invertAllCategories(props.categories, props.viewport);
-        });
+        })();
       }}
       icon={visibilityInvertSvg}
     />

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeButtons.tsx
@@ -84,6 +84,7 @@ export type CategoriesTreeHeaderButtonType = (props: CategoriesTreeHeaderButtonP
 /** @public */
 export function ShowAllButton(props: CategoriesTreeHeaderButtonProps) {
   const componentId = useGuid();
+  const { cancelChangesInProgress } = useSharedTreeContextInternal();
   const translate = useTranslation();
   return (
     <IconButton
@@ -92,6 +93,7 @@ export function ShowAllButton(props: CategoriesTreeHeaderButtonProps) {
       onClick={() => {
         // cspell:disable-next-line
         props.onFeatureUsed?.(`categories-tree-showall`);
+        cancelChangesInProgress.next();
         void showAll({
           models: props.models,
           viewport: props.viewport,
@@ -106,6 +108,7 @@ export function ShowAllButton(props: CategoriesTreeHeaderButtonProps) {
 
 /** @public */
 export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
+  const { cancelChangesInProgress } = useSharedTreeContextInternal();
   const translate = useTranslation();
   return (
     <IconButton
@@ -114,6 +117,7 @@ export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
       onClick={() => {
         // cspell:disable-next-line
         props.onFeatureUsed?.(`categories-tree-hideall`);
+        cancelChangesInProgress.next();
         void hideAllCategories(
           props.categories.map((category) => category.categoryId),
           props.viewport,
@@ -127,6 +131,7 @@ export function HideAllButton(props: CategoriesTreeHeaderButtonProps) {
 
 /** @public */
 export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
+  const { changesInProgress } = useSharedTreeContextInternal();
   const translate = useTranslation();
   return (
     <IconButton
@@ -134,7 +139,9 @@ export function InvertAllButton(props: CategoriesTreeHeaderButtonProps) {
       label={translate("categoriesTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.(`categories-tree-invert`);
-        void invertAllCategories(props.categories, props.viewport);
+        void Promise.all([...changesInProgress]).then(async () => {
+          await invertAllCategories(props.categories, props.viewport);
+        });
       }}
       icon={visibilityInvertSvg}
     />

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -437,7 +437,6 @@ export function createCategoriesTreeVisibilityHandler(props: {
 }) {
   return new HierarchyVisibilityHandlerImpl<CategoriesTreeSearchTargets>({
     cancelChangesInProgress: new Subject<void>(),
-    updateChangesInProgress: () => {},
     getSearchResultsTree: (): undefined | Promise<SearchResultsTree<CategoriesTreeSearchTargets>> => {
       if (!props.searchPaths) {
         return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of } from "rxjs";
+import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of, Subject } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
@@ -436,6 +436,8 @@ export function createCategoriesTreeVisibilityHandler(props: {
   hierarchyConfig: CategoriesTreeHierarchyConfiguration;
 }) {
   return new HierarchyVisibilityHandlerImpl<CategoriesTreeSearchTargets>({
+    cancelChangesInProgress: new Subject<void>(),
+    updateChangesInProgress: () => {},
     getSearchResultsTree: (): undefined | Promise<SearchResultsTree<CategoriesTreeSearchTargets>> => {
       if (!props.searchPaths) {
         return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of } from "rxjs";
+import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of, Subject } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
@@ -326,6 +326,8 @@ export function createClassificationsTreeVisibilityHandler(props: {
   searchPaths?: HierarchySearchTree[];
 }) {
   return new HierarchyVisibilityHandlerImpl<ClassificationsTreeSearchTargets>({
+    cancelChangesInProgress: new Subject<void>(),
+    updateChangesInProgress: () => {},
     getSearchResultsTree: (): undefined | Promise<SearchResultsTree<ClassificationsTreeSearchTargets>> => {
       if (!props.searchPaths) {
         return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -327,7 +327,6 @@ export function createClassificationsTreeVisibilityHandler(props: {
 }) {
   return new HierarchyVisibilityHandlerImpl<ClassificationsTreeSearchTargets>({
     cancelChangesInProgress: new Subject<void>(),
-    updateChangesInProgress: () => {},
     getSearchResultsTree: (): undefined | Promise<SearchResultsTree<ClassificationsTreeSearchTargets>> => {
       if (!props.searchPaths) {
         return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/SharedTreeContextProviderInternal.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/SharedTreeContextProviderInternal.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { Subject } from "rxjs";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { BaseIdsCache } from "./caches/BaseIdsCache.js";
@@ -48,8 +48,12 @@ function SharedTreeContextProviderInternalImpl({ children, showWarning }: PropsW
   const { getCache } = useIdsCache();
   const [cancelChangesInProgress] = useState(() => new Subject<void>());
   const [changesInProgress, setOngoing] = useState(() => new Set<Promise<void>>());
+  const isMounted = useRef(true);
   const updateChangesInProgress = useCallback(
     (promise: Promise<void>, action: "add" | "remove") => {
+      if (!isMounted.current) {
+        return;
+      }
       if (action === "add") {
         setOngoing((prev) => new Set(prev).add(promise));
         return;
@@ -62,6 +66,12 @@ function SharedTreeContextProviderInternalImpl({ children, showWarning }: PropsW
     },
     [setOngoing],
   );
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+      cancelChangesInProgress.complete();
+    };
+  }, [cancelChangesInProgress]);
   useEffect(() => {
     if (showWarning) {
       // eslint-disable-next-line no-console

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/SharedTreeContextProviderInternal.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/SharedTreeContextProviderInternal.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { Subject } from "rxjs";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { BaseIdsCache } from "./caches/BaseIdsCache.js";
@@ -19,8 +19,6 @@ interface SharedTreeContextInternal {
   getCache: <TCache extends object = {}>(props: GetCacheProps<TCache>) => TCache;
   getBaseIdsCache: (props: Omit<BaseIdsCacheProps, "queryExecutor"> & { imodel: IModelConnection }) => BaseIdsCache;
   cancelChangesInProgress: Subject<void>;
-  changesInProgress: Set<Promise<void>>;
-  updateChangesInProgress: (promise: Promise<void>, action: "add" | "remove") => void;
 }
 
 const treeWidgetContextInternal = createContext<SharedTreeContextInternal | undefined>(undefined);
@@ -47,31 +45,6 @@ export function SharedTreeContextProviderInternal({ children, showWarning }: Pro
 function SharedTreeContextProviderInternalImpl({ children, showWarning }: PropsWithChildren<{ showWarning?: boolean }>) {
   const { getCache } = useIdsCache();
   const [cancelChangesInProgress] = useState(() => new Subject<void>());
-  const [changesInProgress, setOngoing] = useState(() => new Set<Promise<void>>());
-  const isMounted = useRef(true);
-  const updateChangesInProgress = useCallback(
-    (promise: Promise<void>, action: "add" | "remove") => {
-      if (!isMounted.current) {
-        return;
-      }
-      if (action === "add") {
-        setOngoing((prev) => new Set(prev).add(promise));
-        return;
-      }
-      setOngoing((prev) => {
-        const newSet = new Set(prev);
-        newSet.delete(promise);
-        return newSet;
-      });
-    },
-    [setOngoing],
-  );
-  useEffect(() => {
-    return () => {
-      isMounted.current = false;
-      cancelChangesInProgress.complete();
-    };
-  }, [cancelChangesInProgress]);
   useEffect(() => {
     if (showWarning) {
       // eslint-disable-next-line no-console
@@ -88,9 +61,5 @@ function SharedTreeContextProviderInternalImpl({ children, showWarning }: PropsW
     },
     [getCache],
   );
-  return (
-    <treeWidgetContextInternal.Provider value={{ getCache, getBaseIdsCache, cancelChangesInProgress, changesInProgress, updateChangesInProgress }}>
-      {children}
-    </treeWidgetContextInternal.Provider>
-  );
+  return <treeWidgetContextInternal.Provider value={{ getCache, getBaseIdsCache, cancelChangesInProgress }}>{children}</treeWidgetContextInternal.Provider>;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/SharedTreeContextProviderInternal.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/SharedTreeContextProviderInternal.tsx
@@ -3,7 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { createContext, useCallback, useContext, useEffect } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { Subject } from "rxjs";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
 import { BaseIdsCache } from "./caches/BaseIdsCache.js";
 import { useIdsCache } from "./useTreeHooks/UseIdsCache.js";
@@ -17,6 +18,9 @@ import type { GetCacheProps } from "./useTreeHooks/UseIdsCache.js";
 interface SharedTreeContextInternal {
   getCache: <TCache extends object = {}>(props: GetCacheProps<TCache>) => TCache;
   getBaseIdsCache: (props: Omit<BaseIdsCacheProps, "queryExecutor"> & { imodel: IModelConnection }) => BaseIdsCache;
+  cancelChangesInProgress: Subject<void>;
+  changesInProgress: Set<Promise<void>>;
+  updateChangesInProgress: (promise: Promise<void>, action: "add" | "remove") => void;
 }
 
 const treeWidgetContextInternal = createContext<SharedTreeContextInternal | undefined>(undefined);
@@ -42,6 +46,22 @@ export function SharedTreeContextProviderInternal({ children, showWarning }: Pro
 
 function SharedTreeContextProviderInternalImpl({ children, showWarning }: PropsWithChildren<{ showWarning?: boolean }>) {
   const { getCache } = useIdsCache();
+  const [cancelChangesInProgress] = useState(() => new Subject<void>());
+  const [changesInProgress, setOngoing] = useState(() => new Set<Promise<void>>());
+  const updateChangesInProgress = useCallback(
+    (promise: Promise<void>, action: "add" | "remove") => {
+      if (action === "add") {
+        setOngoing((prev) => new Set(prev).add(promise));
+        return;
+      }
+      setOngoing((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(promise);
+        return newSet;
+      });
+    },
+    [setOngoing],
+  );
   useEffect(() => {
     if (showWarning) {
       // eslint-disable-next-line no-console
@@ -58,5 +78,9 @@ function SharedTreeContextProviderInternalImpl({ children, showWarning }: PropsW
     },
     [getCache],
   );
-  return <treeWidgetContextInternal.Provider value={{ getCache, getBaseIdsCache }}>{children}</treeWidgetContextInternal.Provider>;
+  return (
+    <treeWidgetContextInternal.Provider value={{ getCache, getBaseIdsCache, cancelChangesInProgress, changesInProgress, updateChangesInProgress }}>
+      {children}
+    </treeWidgetContextInternal.Provider>
+  );
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
@@ -10,6 +10,7 @@ import { HierarchyVisibilityOverrideHandler } from "../../UseHierarchyVisibility
 import { BufferingViewport } from "../BufferingViewport.js";
 import { AlwaysAndNeverDrawnElementInfoCache } from "../caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import { toVoidPromise } from "../Rxjs.js";
+import { useSharedTreeContextInternal } from "../SharedTreeContextProviderInternal.js";
 import { createVisibilityStatus } from "../Tooltip.js";
 import { createVisibilityChangeEventListener } from "../VisibilityChangeEventListener.js";
 
@@ -52,6 +53,7 @@ export interface UseCachedVisibilityProps<TCache, TSearchTargets> {
 export function useCachedVisibility<TCache, TSearchTargets>(props: UseCachedVisibilityProps<TCache, TSearchTargets>) {
   const [searchPaths, setSearchPaths] = useState<HierarchySearchTree[] | undefined>(undefined);
   const { activeView, idsCache, createSearchResultsTree, createTreeSpecificVisibilityHandler, componentId } = props;
+  const { cancelChangesInProgress, updateChangesInProgress } = useSharedTreeContextInternal();
 
   const visibilityHandlerFactory = useMemo<VisibilityTreeProps["visibilityHandlerFactory"]>(
     () =>
@@ -62,8 +64,19 @@ export function useCachedVisibility<TCache, TSearchTargets>(props: UseCachedVisi
         createTreeSpecificVisibilityHandler,
         searchPaths,
         componentId,
+        cancelChangesInProgress,
+        updateChangesInProgress,
       }),
-    [activeView, idsCache, searchPaths, createSearchResultsTree, createTreeSpecificVisibilityHandler, componentId],
+    [
+      activeView,
+      idsCache,
+      searchPaths,
+      createSearchResultsTree,
+      createTreeSpecificVisibilityHandler,
+      componentId,
+      cancelChangesInProgress,
+      updateChangesInProgress,
+    ],
   );
 
   return {
@@ -74,15 +87,27 @@ export function useCachedVisibility<TCache, TSearchTargets>(props: UseCachedVisi
 }
 
 function createVisibilityHandlerFactory<TCache, TSearchTargets>(
-  props: UseCachedVisibilityProps<TCache, TSearchTargets> & {
-    searchPaths: HierarchySearchTree[] | undefined;
-  },
+  props: UseCachedVisibilityProps<TCache, TSearchTargets> &
+    Pick<ReturnType<typeof useSharedTreeContextInternal>, "cancelChangesInProgress" | "updateChangesInProgress"> & {
+      searchPaths: HierarchySearchTree[] | undefined;
+    },
 ): VisibilityTreeProps["visibilityHandlerFactory"] {
-  const { activeView, createSearchResultsTree, createTreeSpecificVisibilityHandler, idsCache, searchPaths, componentId } = props;
+  const {
+    activeView,
+    createSearchResultsTree,
+    createTreeSpecificVisibilityHandler,
+    idsCache,
+    searchPaths,
+    componentId,
+    updateChangesInProgress,
+    cancelChangesInProgress,
+  } = props;
   return ({ imodelAccess }) =>
     new HierarchyVisibilityHandlerImpl<TSearchTargets>({
       componentId,
       viewport: activeView,
+      updateChangesInProgress,
+      cancelChangesInProgress,
       getSearchResultsTree: (): Promise<SearchResultsTree<TSearchTargets>> | undefined => {
         if (searchPaths) {
           return createSearchResultsTree({ imodelAccess, searchPaths, idsCache });
@@ -109,6 +134,8 @@ export interface HierarchyVisibilityHandlerImplProps<TSearchTargets> {
   }) => TreeSpecificVisibilityHandler<TSearchTargets> & Disposable;
   getSearchResultsTree: () => Promise<SearchResultsTree<TSearchTargets>> | undefined;
   componentId?: GuidString;
+  cancelChangesInProgress: Subject<void>;
+  updateChangesInProgress: (promise: Promise<void>, action: "add" | "remove") => void;
 }
 
 /**
@@ -206,6 +233,8 @@ export class HierarchyVisibilityHandlerImpl<TSearchTargets> implements Hierarchy
       }),
       // unsubscribe from the observable if the change request for this node is received
       takeUntil(this.#changeRequest.pipe(filter(({ key, depth }) => depth === node.parentKeys.length && HierarchyNodeKey.equals(node.key, key)))),
+      // unsubscribe if all ongoing changes are cancelled
+      takeUntil(this.#props.cancelChangesInProgress),
       tap({
         finalize: () => {
           // Discard any changes that were made. If commit was called, then this will have no effect
@@ -217,7 +246,12 @@ export class HierarchyVisibilityHandlerImpl<TSearchTargets> implements Hierarchy
       }),
     );
 
-    return toVoidPromise(changeObservable);
+    const promise = toVoidPromise(changeObservable);
+    this.#props.updateChangesInProgress(promise, "add");
+    void promise.finally(() => {
+      this.#props.updateChangesInProgress(promise, "remove");
+    });
+    return promise;
   }
 
   public [Symbol.dispose]() {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
@@ -53,7 +53,7 @@ export interface UseCachedVisibilityProps<TCache, TSearchTargets> {
 export function useCachedVisibility<TCache, TSearchTargets>(props: UseCachedVisibilityProps<TCache, TSearchTargets>) {
   const [searchPaths, setSearchPaths] = useState<HierarchySearchTree[] | undefined>(undefined);
   const { activeView, idsCache, createSearchResultsTree, createTreeSpecificVisibilityHandler, componentId } = props;
-  const { cancelChangesInProgress, updateChangesInProgress } = useSharedTreeContextInternal();
+  const { cancelChangesInProgress } = useSharedTreeContextInternal();
 
   const visibilityHandlerFactory = useMemo<VisibilityTreeProps["visibilityHandlerFactory"]>(
     () =>
@@ -65,18 +65,8 @@ export function useCachedVisibility<TCache, TSearchTargets>(props: UseCachedVisi
         searchPaths,
         componentId,
         cancelChangesInProgress,
-        updateChangesInProgress,
       }),
-    [
-      activeView,
-      idsCache,
-      searchPaths,
-      createSearchResultsTree,
-      createTreeSpecificVisibilityHandler,
-      componentId,
-      cancelChangesInProgress,
-      updateChangesInProgress,
-    ],
+    [activeView, idsCache, searchPaths, createSearchResultsTree, createTreeSpecificVisibilityHandler, componentId, cancelChangesInProgress],
   );
 
   return {
@@ -88,25 +78,15 @@ export function useCachedVisibility<TCache, TSearchTargets>(props: UseCachedVisi
 
 function createVisibilityHandlerFactory<TCache, TSearchTargets>(
   props: UseCachedVisibilityProps<TCache, TSearchTargets> &
-    Pick<ReturnType<typeof useSharedTreeContextInternal>, "cancelChangesInProgress" | "updateChangesInProgress"> & {
+    Pick<ReturnType<typeof useSharedTreeContextInternal>, "cancelChangesInProgress"> & {
       searchPaths: HierarchySearchTree[] | undefined;
     },
 ): VisibilityTreeProps["visibilityHandlerFactory"] {
-  const {
-    activeView,
-    createSearchResultsTree,
-    createTreeSpecificVisibilityHandler,
-    idsCache,
-    searchPaths,
-    componentId,
-    updateChangesInProgress,
-    cancelChangesInProgress,
-  } = props;
+  const { activeView, createSearchResultsTree, createTreeSpecificVisibilityHandler, idsCache, searchPaths, componentId, cancelChangesInProgress } = props;
   return ({ imodelAccess }) =>
     new HierarchyVisibilityHandlerImpl<TSearchTargets>({
       componentId,
       viewport: activeView,
-      updateChangesInProgress,
       cancelChangesInProgress,
       getSearchResultsTree: (): Promise<SearchResultsTree<TSearchTargets>> | undefined => {
         if (searchPaths) {
@@ -135,7 +115,6 @@ export interface HierarchyVisibilityHandlerImplProps<TSearchTargets> {
   getSearchResultsTree: () => Promise<SearchResultsTree<TSearchTargets>> | undefined;
   componentId?: GuidString;
   cancelChangesInProgress: Subject<void>;
-  updateChangesInProgress: (promise: Promise<void>, action: "add" | "remove") => void;
 }
 
 /**
@@ -246,12 +225,7 @@ export class HierarchyVisibilityHandlerImpl<TSearchTargets> implements Hierarchy
       }),
     );
 
-    const promise = toVoidPromise(changeObservable);
-    this.#props.updateChangesInProgress(promise, "add");
-    void promise.finally(() => {
-      this.#props.updateChangesInProgress(promise, "remove");
-    });
-    return promise;
+    return toVoidPromise(changeObservable);
   }
 
   public [Symbol.dispose]() {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
@@ -157,7 +157,7 @@ export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
 
 /** @public */
 export function InvertButton(props: ModelsTreeHeaderButtonProps) {
-  const { changesInProgress } = useSharedTreeContextInternal();
+  const { cancelChangesInProgress } = useSharedTreeContextInternal();
   const translate = useTranslation();
   return (
     <IconButton
@@ -165,13 +165,11 @@ export function InvertButton(props: ModelsTreeHeaderButtonProps) {
       label={translate("modelsTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.("models-tree-invert");
-        void (async () => {
-          await Promise.allSettled([...changesInProgress]);
-          invertAllModels(
-            props.models.map((model) => model.id),
-            props.viewport,
-          );
-        })();
+        cancelChangesInProgress.next();
+        invertAllModels(
+          props.models.map((model) => model.id),
+          props.viewport,
+        );
       }}
       icon={visibilityInvertSvg}
     />

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
@@ -165,12 +165,13 @@ export function InvertButton(props: ModelsTreeHeaderButtonProps) {
       label={translate("modelsTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.("models-tree-invert");
-        void Promise.allSettled([...changesInProgress]).then(() => {
+        void (async () => {
+          await Promise.allSettled([...changesInProgress]);
           invertAllModels(
             props.models.map((model) => model.id),
             props.viewport,
           );
-        });
+        })();
       }}
       icon={visibilityInvertSvg}
     />

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
@@ -165,7 +165,7 @@ export function InvertButton(props: ModelsTreeHeaderButtonProps) {
       label={translate("modelsTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.("models-tree-invert");
-        void Promise.all([...changesInProgress]).then(() => {
+        void Promise.allSettled([...changesInProgress]).then(() => {
           invertAllModels(
             props.models.map((model) => model.id),
             props.viewport,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeButtons.tsx
@@ -105,11 +105,12 @@ export type ModelsTreeHeaderButtonType = (props: ModelsTreeHeaderButtonProps) =>
  * @public
  */
 export function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
-  const { getBaseIdsCache } = useSharedTreeContextInternal();
+  const { getBaseIdsCache, cancelChangesInProgress } = useSharedTreeContextInternal();
   const baseIdsCache = getBaseIdsCache({ imodel: props.viewport.iModel, elementClassName: getClassesByView("3d").elementClass, type: "3d" });
   const translate = useTranslation();
   const onClick = useCallback(async () => {
     try {
+      cancelChangesInProgress.next();
       const categories = await firstValueFrom(baseIdsCache.getAllCategoriesOfElements().pipe(mergeAll(), toArray()));
       return await showAll({
         models: props.models.map((model) => model.id),
@@ -117,7 +118,7 @@ export function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
         viewport: props.viewport,
       });
     } catch {}
-  }, [baseIdsCache, props.viewport, props.models]);
+  }, [baseIdsCache, props.viewport, props.models, cancelChangesInProgress]);
   return (
     <IconButton
       variant={"ghost"}
@@ -134,6 +135,7 @@ export function ShowAllButton(props: ModelsTreeHeaderButtonProps) {
 
 /** @public */
 export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
+  const { cancelChangesInProgress } = useSharedTreeContextInternal();
   const translate = useTranslation();
   return (
     <IconButton
@@ -142,6 +144,7 @@ export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
       onClick={() => {
         // cspell:disable-next-line
         props.onFeatureUsed?.("models-tree-hideall");
+        cancelChangesInProgress.next();
         hideAllModels(
           props.models.map((model) => model.id),
           props.viewport,
@@ -154,6 +157,7 @@ export function HideAllButton(props: ModelsTreeHeaderButtonProps) {
 
 /** @public */
 export function InvertButton(props: ModelsTreeHeaderButtonProps) {
+  const { changesInProgress } = useSharedTreeContextInternal();
   const translate = useTranslation();
   return (
     <IconButton
@@ -161,10 +165,12 @@ export function InvertButton(props: ModelsTreeHeaderButtonProps) {
       label={translate("modelsTree.buttons.invert.tooltip")}
       onClick={() => {
         props.onFeatureUsed?.("models-tree-invert");
-        invertAllModels(
-          props.models.map((model) => model.id),
-          props.viewport,
-        );
+        void Promise.all([...changesInProgress]).then(() => {
+          invertAllModels(
+            props.models.map((model) => model.id),
+            props.viewport,
+          );
+        });
       }}
       icon={visibilityInvertSvg}
     />

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of } from "rxjs";
+import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of, Subject } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
@@ -432,6 +432,8 @@ export function createModelsTreeVisibilityHandler(props: {
   searchPaths?: HierarchySearchTree[];
 }) {
   return new HierarchyVisibilityHandlerImpl<ModelsTreeSearchTargets>({
+    cancelChangesInProgress: new Subject<void>(),
+    updateChangesInProgress: () => {},
     getSearchResultsTree: (): undefined | Promise<SearchResultsTree<ModelsTreeSearchTargets>> => {
       if (!props.searchPaths) {
         return undefined;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -433,7 +433,6 @@ export function createModelsTreeVisibilityHandler(props: {
 }) {
   return new HierarchyVisibilityHandlerImpl<ModelsTreeSearchTargets>({
     cancelChangesInProgress: new Subject<void>(),
-    updateChangesInProgress: () => {},
     getSearchResultsTree: (): undefined | Promise<SearchResultsTree<ModelsTreeSearchTargets>> => {
       if (!props.searchPaths) {
         return undefined;


### PR DESCRIPTION
Adjusted models and categories tree's buttons:
- `hide all` & `show all`: now cancels any ongoing changes.
- `invert all`: waits for changes to complete before inverting.