### PR TITLE
[Tree widget]: Adjust how categories visibility is changed on `next`

### DIFF
--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -282,16 +282,22 @@ export function setupInitialDisplayState(props: {
   for (const subCategoryInfo of subCategories) {
     viewport.changeSubCategoryDisplay({ subCategoryId: subCategoryInfo.id, display: subCategoryInfo.visible });
   }
-  viewport.changeCategoryDisplay({
-    categoryIds: categories.filter(({ visible }) => visible).map(({ id }) => id),
-    display: true,
-    enableAllSubCategories: false,
-  });
-  viewport.changeCategoryDisplay({
-    categoryIds: categories.filter(({ visible }) => !visible).map(({ id }) => id),
-    display: false,
-    enableAllSubCategories: false,
-  });
+  const visibleCategories = categories.filter(({ visible }) => visible).map(({ id }) => id);
+  if (visibleCategories.length > 0) {
+    viewport.changeCategoryDisplay({
+      categoryIds: visibleCategories,
+      display: true,
+      enableAllSubCategories: false,
+    });
+  }
+  const hiddenCategories = categories.filter(({ visible }) => !visible).map(({ id }) => id);
+  if (hiddenCategories.length > 0) {
+    viewport.changeCategoryDisplay({
+      categoryIds: hiddenCategories,
+      display: false,
+      enableAllSubCategories: false,
+    });
+  }
 
   const alwaysDrawn = elements.filter(({ visible }) => visible).map(({ id }) => id);
   if (alwaysDrawn.length > 0) {
@@ -301,8 +307,15 @@ export function setupInitialDisplayState(props: {
   if (neverDrawn.length > 0) {
     viewport.setNeverDrawn({ elementIds: new Set([...neverDrawn, ...(viewport.neverDrawn ?? [])]) });
   }
-  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => visible).map(({ id }) => id), display: true });
-  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => !visible).map(({ id }) => id), display: false });
+
+  const visibleModels = models.filter(({ visible }) => visible).map(({ id }) => id);
+  if (visibleModels.length > 0) {
+    viewport.changeModelDisplay({ modelIds: visibleModels, display: true });
+  }
+  const hiddenModels = models.filter(({ visible }) => !visible).map(({ id }) => id);
+  if (hiddenModels.length > 0) {
+    viewport.changeModelDisplay({ modelIds: hiddenModels, display: false });
+  }
   viewport.renderFrame();
 }
 

--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -222,7 +222,7 @@ export function createTreeWidgetTestingViewport({ viewState }: { viewState: View
       return treeWidgetViewport.isAlwaysDrawnExclusive;
     },
     changeCategoryDisplay: (props) => treeWidgetViewport.changeCategoryDisplay(props),
-    changeModelDisplay: async (props) => treeWidgetViewport.changeModelDisplay(props),
+    changeModelDisplay: (props) => treeWidgetViewport.changeModelDisplay(props),
     changeSubCategoryDisplay: (props) => treeWidgetViewport.changeSubCategoryDisplay(props),
     clearNeverDrawn: () => treeWidgetViewport.clearNeverDrawn(),
     clearAlwaysDrawn: () => treeWidgetViewport.clearAlwaysDrawn(),
@@ -282,9 +282,16 @@ export function setupInitialDisplayState(props: {
   for (const subCategoryInfo of subCategories) {
     viewport.changeSubCategoryDisplay({ subCategoryId: subCategoryInfo.id, display: subCategoryInfo.visible });
   }
-  for (const categoryInfo of categories) {
-    viewport.changeCategoryDisplay({ categoryIds: categoryInfo.id, display: categoryInfo.visible, enableAllSubCategories: false });
-  }
+  viewport.changeCategoryDisplay({
+    categoryIds: categories.filter(({ visible }) => visible).map(({ id }) => id),
+    display: true,
+    enableAllSubCategories: false,
+  });
+  viewport.changeCategoryDisplay({
+    categoryIds: categories.filter(({ visible }) => !visible).map(({ id }) => id),
+    display: false,
+    enableAllSubCategories: false,
+  });
 
   const alwaysDrawn = elements.filter(({ visible }) => visible).map(({ id }) => id);
   if (alwaysDrawn.length > 0) {
@@ -294,9 +301,8 @@ export function setupInitialDisplayState(props: {
   if (neverDrawn.length > 0) {
     viewport.setNeverDrawn({ elementIds: new Set([...neverDrawn, ...(viewport.neverDrawn ?? [])]) });
   }
-  for (const modelInfo of models) {
-    viewport.changeModelDisplay({ modelIds: modelInfo.id, display: modelInfo.visible });
-  }
+  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => visible).map(({ id }) => id), display: true });
+  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => !visible).map(({ id }) => id), display: false });
   viewport.renderFrame();
 }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import {
-  bufferCount,
   concat,
   concatAll,
   defaultIfEmpty,
@@ -30,7 +29,7 @@ import {
 } from "rxjs";
 import { assert, Id64 } from "@itwin/core-bentley";
 import { createVisibilityStatus } from "../Tooltip.js";
-import { countInSet, fromWithRelease, getOptimalBatchSize, releaseMainThreadOnItemsCount, setDifference } from "../Utils.js";
+import { countInSet, fromWithRelease, releaseMainThreadOnItemsCount, setDifference } from "../Utils.js";
 import { changeElementStateNoChildrenOperator, getVisibilityFromAlwaysAndNeverDrawnElementsImpl, mergeVisibilityStatuses } from "../VisibilityUtils.js";
 
 import type { Observable, Subscription } from "rxjs";
@@ -492,7 +491,7 @@ export class BaseVisibilityHelper implements Disposable {
           this.#props.viewport.setAlwaysDrawn({ elementIds: setDifference(alwaysDrawn, modelAlwaysDrawnElements) });
         }
         this.#props.viewport.changeModelDisplay({ modelIds: modelId, display: true });
-        return from(Id64.iterable(allModelCategories)).pipe(
+        return fromWithRelease({ source: allModelCategories, releaseOnCount: 500 }).pipe(
           categoriesToNotOverride ? filter((modelCategory) => !categoriesToNotOverride.has(modelCategory)) : identity,
           map((categoryId) => this.changeCategoryStateInViewportAccordingToModelVisibility({ modelId, categoryId, on: false, changeSubCategories: false })),
           takeLast(1),
@@ -545,12 +544,9 @@ export class BaseVisibilityHelper implements Disposable {
       if (props.modelId) {
         return this.changeCategoriesUnderModelVisibilityStatus({ categoryIds, modelId: props.modelId, on });
       }
+      this.#props.viewport.changeCategoryDisplay({ categoryIds, display: on, enableAllSubCategories: false });
 
-      const changeCategoriesObs = fromWithRelease({ source: categoryIds, releaseOnCount: 500 }).pipe(
-        bufferCount(getOptimalBatchSize({ totalSize: Id64.sizeOf(categoryIds), maximumBatchSize: 500 })),
-        map((categoryIdsBatch) => this.#props.viewport.changeCategoryDisplay({ categoryIds: categoryIdsBatch, display: on, enableAllSubCategories: false })),
-      );
-      const categoryModelsObs = from(Id64.iterable(categoryIds)).pipe(
+      const categoryModelsObs = fromWithRelease({ source: categoryIds, releaseOnCount: 500 }).pipe(
         mergeMap((categoryId) => forkJoin({ categoryId: of(categoryId), models: this.#props.baseIdsCache.getModels({ categoryId, subModels: "include" }) })),
         reduce((acc, { models, categoryId }) => {
           for (const modelId of Id64.iterable(models)) {
@@ -569,7 +565,9 @@ export class BaseVisibilityHelper implements Disposable {
 
       const changeSubModelsObs = categoryModelsObs.pipe(
         mergeMap(([modelId, modelCategories]) =>
-          from(modelCategories).pipe(mergeMap((modelCategoryId) => this.#props.baseIdsCache.getSubModels({ categoryId: modelCategoryId, modelId }))),
+          fromWithRelease({ source: modelCategories, releaseOnCount: 500 }).pipe(
+            mergeMap((modelCategoryId) => this.#props.baseIdsCache.getSubModels({ categoryId: modelCategoryId, modelId })),
+          ),
         ),
         mergeMap((subModels) => this.changeModelsVisibilityStatus({ modelIds: subModels, on })),
       );
@@ -606,14 +604,7 @@ export class BaseVisibilityHelper implements Disposable {
           )
         : EMPTY;
 
-      return merge(
-        changeCategoriesObs,
-        changeSubModelsObs,
-        changeModelsObs,
-        removeCategoriesOverridesObs,
-        changeAlwaysAndNeverDrawnElementsObs,
-        changeSubCategoriesObs,
-      );
+      return merge(changeSubModelsObs, changeModelsObs, removeCategoriesOverridesObs, changeAlwaysAndNeverDrawnElementsObs, changeSubCategoriesObs);
     });
 
     return this.#props.overrideHandler


### PR DESCRIPTION
Changes on `VisibilityUtilities` do not affect the performance metrics, `setupInitialDisplayState` is only used when performance is not measured.
Changes should reduce the main thread blockage for `categories tree 50k categories > change visibility (P95 of main thread blocks)`