### PR TITLE
[Tree widget]: reduce main thread blockage on `next`

### DIFF
--- a/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ClassificationsTree.test.tsx
@@ -70,6 +70,8 @@ describe("classifications tree", () => {
     },
     steps: [
       {
+        // Main thread might get blocked for about 100ms:
+        // query that gets classifications by label takes that long to finish
         name: "get search paths",
         callBack: async (ctx) => {
           using hook = renderUseClassificationsTreeHook({

--- a/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
+++ b/apps/performance-tests/src/tree-widget/ModelsTree.test.tsx
@@ -189,6 +189,8 @@ describe("models tree", () => {
         },
       },
       {
+        // Main thread gets blocked for > 100 ms, due to:
+        // bufferingViewport.commit calls setPerModelCategoryOverride with 50k categories, nothing can be done from tree-widget side
         name: "change visibility",
         callBack: async ({ viewport, handler, elementsModel }) => {
           // Add one element to always draw set to trigger additional queries

--- a/change/@itwin-tree-widget-react-ede030f3-c851-4b96-9c6e-10a61b103eb8.json
+++ b/change/@itwin-tree-widget-react-ede030f3-c851-4b96-9c6e-10a61b103eb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Reduce main thread blockage with large number of nodes",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -1023,7 +1023,7 @@ function createSearchPathsForDifferentTypes(
                       componentId,
                       componentName,
                     }),
-                  10,
+                  2,
                 ),
               )
             : EMPTY,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, EMPTY, from, map, mergeAll, mergeMap, toArray } from "rxjs";
+import { bufferCount, concat, concatMap, delay, EMPTY, from, map, mergeAll, mergeMap, toArray } from "rxjs";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
-import { getIdsFromChildrenTree, getParentElementsIdsPath } from "../../../common/internal/Utils.js";
+import { getIdsFromChildrenTree, getOptimalBatchSize, getParentElementsIdsPath } from "../../../common/internal/Utils.js";
 import { BaseVisibilityHelper } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
 
@@ -48,12 +48,17 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
         includeEmptyCategories: this.#props.hierarchyConfig.showEmptyCategories,
       })
       .pipe(
-        mergeMap((categoryIds) =>
-          this.getCategoriesVisibilityStatus({
-            categoryIds,
-            modelId: undefined,
-          }),
-        ),
+        mergeMap((categoryIds) => {
+          if (categoryIds.size < 1001) {
+            return this.getCategoriesVisibilityStatus({ categoryIds, modelId: undefined });
+          }
+          const optimalBatchSize = getOptimalBatchSize({ totalSize: categoryIds.size, maximumBatchSize: 1001 });
+          return from(categoryIds).pipe(
+            bufferCount(optimalBatchSize),
+            concatMap((categoryIdsBatch) => this.getCategoriesVisibilityStatus({ categoryIds: categoryIdsBatch, modelId: undefined }).pipe(delay(0))),
+            mergeVisibilityStatuses(),
+          );
+        }),
       );
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -457,8 +457,7 @@ function createInstanceKeyPathsFromInstanceLabelObs({
             '${CLASSIFICATION_TABLE_CLASS_NAME_QUERY_ALIAS}',
             this.ECInstanceId,
             ${classificationTableLabelSelectClause}
-          FROM
-            ${CLASS_NAME_ClassificationTable} this
+          FROM ${CLASS_NAME_ClassificationTable} this
           JOIN ${CLASS_NAME_ClassificationSystem} system ON system.ECInstanceId = this.Parent.Id
           WHERE
             system.CodeValue = '${props.hierarchyConfig.rootClassificationSystemCode}'
@@ -659,7 +658,7 @@ function createSearchPathsForDifferentTypes(
                   componentId,
                   componentName,
                 }),
-              10,
+              2,
             ),
           ),
         );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -138,7 +138,7 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
           cl.ParentClassificationId parentId,
           (${categoriesOfClassificationSelector}) relatedCategories
         FROM ${CLASSIFICATIONS_CTE} cl
-        ${lastClassificationId === undefined ? "" : `WHERE cl.ClassificationId > ${lastClassificationId ?? 0}`}
+        ${lastClassificationId === undefined ? "" : `WHERE cl.ClassificationId > ${lastClassificationId}`}
         ORDER BY cl.ClassificationId
         LIMIT ${this.#rowLimit}
       `;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defer, from, map, mergeMap, of, reduce, shareReplay } from "rxjs";
+import { defer, EMPTY, expand, from, map, mergeMap, of, reduce, shareReplay } from "rxjs";
 import { Guid, Id64 } from "@itwin/core-bentley";
 import { normalizeFullClassName } from "@itwin/presentation-shared";
 import { BaseIdsCacheImpl } from "../../common/internal/caches/BaseIdsCache.js";
@@ -60,6 +60,7 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
   #props: ClassificationsTreeIdsCacheProps;
   #componentId: GuidString;
   #componentName: string;
+  #rowLimit = 7500;
 
   constructor(props: ClassificationsTreeIdsCacheProps) {
     super(props);
@@ -74,7 +75,7 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
       relatedCategories: CategoryId[];
     } & ({ tableId: ClassificationTableId; parentId: undefined } | { tableId: undefined; parentId: ClassificationId })
   > {
-    return defer(() => {
+    const getQueryReader = (lastClassificationId?: ClassificationId) => {
       const CLASSIFICATIONS_CTE = "Classifications";
       const ctes = [
         `
@@ -137,12 +138,26 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
           cl.ParentClassificationId parentId,
           (${categoriesOfClassificationSelector}) relatedCategories
         FROM ${CLASSIFICATIONS_CTE} cl
+        ${lastClassificationId === undefined ? "" : `WHERE cl.ClassificationId > ${lastClassificationId ?? 0}`}
+        ORDER BY cl.ClassificationId
+        LIMIT ${this.#rowLimit}
       `;
       return this.#props.queryExecutor.createQueryReader(
         { ctes, ecsql },
-        { rowFormat: "ECSqlPropertyNames", limit: "unbounded", restartToken: `${this.#componentName}/${this.#componentId}/classifications` },
+        {
+          rowFormat: "ECSqlPropertyNames",
+          limit: "unbounded",
+          restartToken: `${this.#componentName}/${this.#componentId}/classifications/${lastClassificationId ?? "0"}`,
+        },
       );
-    }).pipe(
+    };
+    return defer(() => getQueryReader()).pipe(
+      expand((row, idx) => {
+        if (idx % this.#rowLimit === this.#rowLimit - 1) {
+          return getQueryReader(row.id);
+        }
+        return EMPTY;
+      }),
       catchBeSQLiteInterrupts,
       map((row) => {
         return {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -152,6 +152,8 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
       );
     };
     return defer(() => getQueryReader()).pipe(
+      // Note: if the total row count is an exact multiple of `#rowLimit`, an extra request that returns
+      // 0 rows will be sent. This is acceptable to keep the implementation simple.
       expand((row, idx) => {
         if (idx % this.#rowLimit === this.#rowLimit - 1) {
           return getQueryReader(row.id);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -6,6 +6,7 @@
 import {
   BehaviorSubject,
   bufferCount,
+  concatMap,
   debounceTime,
   defer,
   EMPTY,
@@ -295,7 +296,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
           from(set).pipe(
             bufferCount(getOptimalBatchSize({ totalSize: set.size, maximumBatchSize: ALWAYS_NEVER_BUFFER_THRESHOLD })),
             releaseMainThreadOnItemsCount(2),
-            mergeMap((block, index) => this.queryElementInfo(block, `${setType}-${index}`), 10),
+            concatMap((block, index) => this.queryElementInfo(block, `${setType}-${index}`)),
           )
         : this.queryElementInfo([...set], `${setType}-0`)
       : EMPTY;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -6,7 +6,6 @@
 import {
   BehaviorSubject,
   bufferCount,
-  concatMap,
   debounceTime,
   defer,
   EMPTY,
@@ -296,7 +295,7 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
           from(set).pipe(
             bufferCount(getOptimalBatchSize({ totalSize: set.size, maximumBatchSize: ALWAYS_NEVER_BUFFER_THRESHOLD })),
             releaseMainThreadOnItemsCount(2),
-            concatMap((block, index) => this.queryElementInfo(block, `${setType}-${index}`)),
+            mergeMap((block, index) => this.queryElementInfo(block, `${setType}-${index}`), 2),
           )
         : this.queryElementInfo([...set], `${setType}-0`)
       : EMPTY;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { mergeAll, mergeMap, toArray } from "rxjs";
+import { mergeAll, mergeMap, of, toArray } from "rxjs";
 import { Guid } from "@itwin/core-bentley";
 import { ElementChildrenCache } from "./ElementChildrenCache.js";
 import { ElementModelCategoriesCache } from "./ElementModelCategoriesCache.js";
@@ -69,20 +69,28 @@ export class BaseIdsCache {
     props: { modelId: Id64String; categoryId?: Id64String } | { categoryId: Id64String; modelId: Id64String | undefined },
   ): Observable<Id64Array> {
     if (props.modelId) {
-      if (props.categoryId) {
-        return this.#modeledElementsCache.getCategoryModeledElements({ modelId: props.modelId, categoryId: props.categoryId }).pipe(toArray());
+      const { modelId, categoryId } = props;
+      if (categoryId) {
+        return this.#modeledElementsCache.getCategoryModeledElements({ modelId, categoryId }).pipe(toArray());
       }
 
-      return this.#elementModelCategoriesCache.getModelCategoryIds({ modelId: props.modelId }).pipe(
-        mergeAll(),
-        mergeMap((modelCategoryId) => this.#modeledElementsCache.getCategoryModeledElements({ modelId: props.modelId!, categoryId: modelCategoryId })),
-        toArray(),
+      return this.#modeledElementsCache.hasModeledElements({ modelId }).pipe(
+        mergeMap((hasModeledElements) => {
+          if (!hasModeledElements) {
+            return of([]);
+          }
+          return this.#elementModelCategoriesCache.getModelCategoryIds({ modelId }).pipe(
+            mergeAll(),
+            mergeMap((modelCategoryId) => this.#modeledElementsCache.getCategoryModeledElements({ modelId, categoryId: modelCategoryId })),
+            toArray(),
+          );
+        }),
       );
     }
 
     return this.#elementModelCategoriesCache.getCategoryElementModels({ categoryId: props.categoryId!, subModels: "exclude" }).pipe(
       mergeAll(),
-      mergeMap((modelId) => this.#modeledElementsCache.getCategoryModeledElements({ modelId, categoryId: props.categoryId! })),
+      mergeMap((categoryModelId) => this.#modeledElementsCache.getCategoryModeledElements({ modelId: categoryModelId, categoryId: props.categoryId! })),
       toArray(),
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
@@ -6,6 +6,7 @@
 import { defer, forkJoin, from, map, mergeMap, reduce, shareReplay } from "rxjs";
 import { CLASS_NAME_Model } from "../ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { releaseMainThreadOnItemsCount } from "../Utils.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString, Id64Array, Id64Set, Id64String } from "@itwin/core-bentley";
@@ -87,6 +88,7 @@ export class ElementModelCategoriesCache {
       ),
       allSubModels: this.#modeledElementsCache.getModeledElementsInfo().pipe(map(({ allSubModels }) => allSubModels)),
     }).pipe(
+      releaseMainThreadOnItemsCount(1),
       map(({ modelCategories, allSubModels }) => {
         const result = new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>();
         for (const [modelId, { categoriesOfTopMostElements, allCategories }] of modelCategories) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModelCategoryElementsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModelCategoryElementsCountCache.ts
@@ -92,10 +92,10 @@ export class ModelCategoryElementsCountCache {
               `,
               ],
               ecsql: `
-              SELECT modelId, categoryId, COUNT(id) elementsCount
-              FROM (SELECT * FROM CategoryElements)
-              GROUP BY modelId, categoryId
-            `,
+                SELECT modelId, categoryId, COUNT(id) elementsCount
+                FROM (SELECT * FROM CategoryElements)
+                GROUP BY modelId, categoryId
+              `,
             },
             {
               rowFormat: "ECSqlPropertyNames",

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
@@ -145,4 +145,8 @@ export class ModeledElementsCache {
       mergeMap(({ modelWithCategoryModeledElements }) => modelWithCategoryModeledElements.get(modelId)?.get(categoryId) ?? new Set<Id64String>()),
     );
   }
+
+  public hasModeledElements({ modelId }: { modelId: Id64String }): Observable<boolean> {
+    return this.getModeledElementsInfo().pipe(map(({ modelWithCategoryModeledElements }) => !!modelWithCategoryModeledElements.get(modelId)?.size));
+  }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/SubCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/SubCategoriesCache.ts
@@ -58,6 +58,8 @@ export class SubCategoriesCache {
       );
     };
     return defer(() => getQueryReader()).pipe(
+      // Note: if the total row count is an exact multiple of `#rowLimit`, an extra request that returns
+      // 0 rows will be sent. This is acceptable to keep the implementation simple.
       expand((row, idx) => {
         if (idx % this.#rowLimit === this.#rowLimit - 1) {
           return getQueryReader(row.id);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/SubCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/SubCategoriesCache.ts
@@ -44,7 +44,7 @@ export class SubCategoriesCache {
           ${CLASS_NAME_SubCategory} sc
         WHERE
           NOT sc.IsPrivate
-          ${lastSubCategoryId === undefined ? "" : `AND sc.ECInstanceId > ${lastSubCategoryId ?? 0}`}
+          ${lastSubCategoryId === undefined ? "" : `AND sc.ECInstanceId > ${lastSubCategoryId}`}
         ORDER BY sc.ECInstanceId
         LIMIT ${this.#rowLimit}
       `;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -228,32 +228,30 @@ export class BaseVisibilityHelper implements Disposable {
 
       return fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
         mergeMap((categoryId) =>
-          // When always drawn exclusive mode is enabled need to get only models for which category has top most element.
-          // This is because always/never drawn elements can be retrieved using top most category.
-          // TODO fix with: https://github.com/iTwin/viewer-components-react/issues/1100
-          this.#props.baseIdsCache
-            .getModels({ categoryId, includeOnlyIfCategoryOfTopMostElement: this.#props.viewport.isAlwaysDrawnExclusive, subModels: "include" })
-            .pipe(
-              mergeMap((models) =>
-                merge(
+          merge(
+            // When always drawn exclusive mode is enabled need to get only models for which category has top most element.
+            // This is because always/never drawn elements can be retrieved using top most category.
+            // TODO fix with: https://github.com/iTwin/viewer-components-react/issues/1100
+            this.#props.baseIdsCache
+              .getModels({ categoryId, includeOnlyIfCategoryOfTopMostElement: this.#props.viewport.isAlwaysDrawnExclusive, subModels: "include" })
+              .pipe(
+                mergeMap((models) =>
                   from(Id64.iterable(models)).pipe(
                     mergeMap((modelId) => this.getModelWithCategoryVisibilityStatus({ modelId, categoryId })),
                     mergeVisibilityStatuses(),
                   ),
-                  // For category not under specific model, need to check subCategories as well
-                  this.#props.baseIdsCache
-                    .getSubCategories({ categoryId })
-                    .pipe(mergeMap((subCategoryIds) => this.getSubCategoriesVisibilityStatus({ categoryId, subCategoryIds }))),
-                ).pipe(
-                  // This can happen when category does not have any geometric elements or sub-categories
-                  defaultIfEmpty(
-                    createVisibilityStatus(
-                      !this.#props.viewport.isAlwaysDrawnExclusive && this.#props.viewport.viewsCategory(categoryId) ? "visible" : "hidden",
-                    ),
-                  ),
                 ),
               ),
+            // For category not under specific model, need to check subCategories as well
+            this.#props.baseIdsCache
+              .getSubCategories({ categoryId })
+              .pipe(mergeMap((subCategoryIds) => this.getSubCategoriesVisibilityStatus({ categoryId, subCategoryIds }))),
+          ).pipe(
+            // This can happen when category does not have any geometric elements or sub-categories
+            defaultIfEmpty(
+              createVisibilityStatus(!this.#props.viewport.isAlwaysDrawnExclusive && this.#props.viewport.viewsCategory(categoryId) ? "visible" : "hidden"),
             ),
+          ),
         ),
         mergeVisibilityStatuses(),
       );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -922,7 +922,7 @@ function createSearchPathsForDifferentTypes(
                   componentName,
                   chunkIndex,
                 }),
-              10,
+              2,
             ),
           ),
         );


### PR DESCRIPTION
closes #1512 
Main changes:
- When getting definition containers visibility status, and definition container has > 1k categories, then categories visibilities are validated in batches. After each batch a delay is added to release the main thread.
- Reduced how many concurrent queries can be executed when searching for geometric elements. Previous was 10, now its 2 (each request contains 5k elements). The change was done due to models tree search tests, but since similar logic contains in categories and classifications trees, they were changed as well.
- Classifications tree ids cache: multiple queries are now executed when there are more than 7.5k classifications (similar to what was done in sub-categories cache).
- Reduced number of concurent quries for always/never drawn elements from 10 to 2.
- When validating subject/model visibility, for each model we have to check if it contains any sub-models. To validate that, used to first request all categories under that model and then for each model & category pair, would be checking if any sub-models exist. Adjusted the code: to check if any sub-models exist under that model and return early if none do.
- Previously, when checking category visibility, would first request it's models, and only after they were retrieved would request sub-categories. Now we request models and categories at the same time.