### PR TITLE
Fix measure-tools coverage teardown leak

### DIFF
--- a/packages/itwin/measure-tools/src/test/TestUtils.ts
+++ b/packages/itwin/measure-tools/src/test/TestUtils.ts
@@ -2,13 +2,27 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+import { SyncUiEventDispatcher } from "@itwin/appui-react";
+import { IModelApp } from "@itwin/core-frontend";
+import { MeasurementManager } from "../api/MeasurementManager.js";
+import { MeasurementUIEvents } from "../api/MeasurementUIEvents.js";
 import { MeasureTools } from "../MeasureTools.js";
 
 export class TestUtils {
 
   /** Waits until all async operations finish */
   public static async cleanup() {
+    MeasurementUIEvents.shouldClearMeasurementHandler = undefined;
+    MeasurementUIEvents.showToggleMeasurementAxesHandler = undefined;
+
+    MeasurementManager.instance.clear();
+    MeasurementManager.instance.stopDecorator();
+
+    // SyncUiEventDispatcher uses debounced window.setTimeout calls internally.
+    // Clear any pending timers before jsdom tears down the global window.
+    SyncUiEventDispatcher.setTimeoutPeriod(0);
+
     MeasureTools.terminate();
-    return new Promise((resolve) => setTimeout(resolve));
+    await IModelApp.shutdown();
   }
 }


### PR DESCRIPTION
## Why

The `@itwin/measure-tools-react cover` job was failing even though the test suite itself was green. The failure came from AppUi SyncUi timers that outlived the jsdom test environment, so coverage runs reported post-teardown `window is not defined` errors instead of real test failures.

That makes the package look unstable when the actual problem is incomplete test cleanup. Fixing the teardown path keeps coverage runs trustworthy and avoids forcing follow-up republish attempts for a false negative.

## What

| Asset | Why it exists |
|---|---|
| `packages/itwin/measure-tools/src/test/TestUtils.ts` (test cleanup) | Coverage runs left `SyncUiEventDispatcher` timers, measurement state, and AppUi handlers alive after tests completed — fully tears down measure-tools test state before jsdom disappears. |

Validated with `pnpm -C packages/itwin/measure-tools cover`.

---
*Nambot 🤖 (powered by GPT 5.4)*
