### PR TITLE
[Tree widget]: add abstract batching cache on `next`

### DIFF
--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -27,14 +27,14 @@ export interface BatchingCacheProps {
  *
  * @template TRequest - A single logical request made by a consumer (e.g. `{ modelId, categoryId, parentElementId }`).
  * @template TResult - The value returned to the consumer for a given request (e.g. `Id64Array`).
- * @template TQueryData - Query data produced by decomposing a batch of requests via `getIterable`
+ * @template TQueryData - Query data produced by decomposing a batch of requests via `getQueryData`
  *   (e.g. a WHERE clause fragment). Items are buffered (up to `bufferSize`) and passed to `executeQuery`.
  * @template TRow - A single result row emitted by `executeQuery`, cached via `insertRow`
  *   (e.g. `{ modelId, reqParent, reqCategory, ownCategory, count }`).
  *
  * Pipeline:
  * 1. Requests arriving within `timerDelay` ms are collected into a batch (`TRequest[]`).
- * 2. `getIterable(batch)` decomposes the batch into a stream of `TQueryData` items.
+ * 2. `getQueryData(batch)` decomposes the batch into a stream of `TQueryData` items.
  * 3. Items are buffered (up to `bufferSize`) and passed to `executeQuery(items)`.
  * 4. Each `TRow` emitted by `executeQuery` is cached via `insertRow`.
  * 5. After completion, `ensureDefaultCacheEntries` fills in empty entries for
@@ -79,7 +79,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
    * those values take shape of a WHERE clause fragments.
    * These TQueryData items are buffered and passed to `executeQuery`.
    */
-  protected abstract getIterable(batch: TRequest[]): Observable<TQueryData>;
+  protected abstract getQueryData(batch: TRequest[]): Observable<TQueryData>;
 
   /** Execute a query for the given query data buffer. Returns an observable of result rows. */
   protected abstract executeQuery(queryData: TQueryData[]): Observable<TRow>;
@@ -150,7 +150,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   }
 
   private executeBatchQuery(batch: TRequest[]): Observable<TRow> {
-    return this.getIterable(batch).pipe(
+    return this.getQueryData(batch).pipe(
       bufferCount(this.#bufferSize),
       mergeMap((queryData: TQueryData[]) => this.executeQuery(queryData).pipe(catchBeSQLiteInterrupts)),
       releaseMainThreadOnItemsCount(this.#releaseOnCount),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { bufferCount, map, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
+import { bufferCount, last, map, merge, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
 import { releaseMainThreadOnItemsCount } from "../Utils.js";
@@ -61,7 +61,10 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
    * Returns `undefined` if the entire request is already in the batch.
    * For caches without partial requests, return `undefined` if in batch, or the full request if not.
    */
-  protected abstract getValuesToRequest(request: TRequest, batch: TBatch): TRequest | undefined;
+  protected abstract getValuesNotInBatch(
+    request: TRequest,
+    batch: TBatch,
+  ): { valuesNotInBatch: TRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true };
 
   /** Create a new empty batch. */
   protected abstract createBatch(): TBatch;
@@ -89,12 +92,16 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
 
     // Check if request is fully covered by an in-flight batch
     let requestNotInBatch: TRequest = request;
+    const sharedObsArray: Array<Observable<void>> = [];
     for (const { values, sharedObs } of this.#requestedValues.values()) {
-      const partOfRequestNotInBatch = this.getValuesToRequest(request, values);
-      if (partOfRequestNotInBatch === undefined) {
-        return this.getResultAfterObservable(request, sharedObs);
+      const { valuesNotInBatch, batchContainsValues } = this.getValuesNotInBatch(requestNotInBatch, values);
+      if (batchContainsValues) {
+        sharedObsArray.push(sharedObs);
       }
-      requestNotInBatch = partOfRequestNotInBatch;
+      if (valuesNotInBatch === undefined) {
+        return this.getResultAfterObservable(request, merge(...sharedObsArray).pipe(last()));
+      }
+      requestNotInBatch = valuesNotInBatch;
     }
 
     if (this.#valuesToRequest === undefined) {
@@ -128,11 +135,13 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
       );
       this.#valuesToRequest = { values: this.createBatch(), sharedObs };
       this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
-      return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+      // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
+      return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
     }
 
     this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
-    return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+    // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
+    return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
   }
 
   private executeBatchQuery(batch: TBatch): Observable<TRow> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { bufferCount, map, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
+import { assert, Guid } from "@itwin/core-bentley";
+import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { releaseMainThreadOnItemsCount } from "../Utils.js";
+
+import type { Observable } from "rxjs";
+
+type RequestId = string;
+
+/** @internal */
+export interface BatchingCacheProps {
+  /** Number of items to buffer before executing a query. Defaults to 100. */
+  bufferSize?: number;
+  /** Time in ms to wait before firing the batch. Defaults to 20 ms. */
+  timerDelay?: number;
+  /** Release main thread after this many items from the query. Defaults to 500. */
+  releaseOnCount?: number;
+}
+
+/**
+ * Abstract base class that provides timer-based batching, deduplication, and caching.
+ *
+ * Subclasses define:
+ * - How requests map to cached values
+ * - How batches are built from requests
+ * - How to produce query items from a batch, execute queries, and cache rows
+ *
+ * @internal
+ */
+export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
+  // When a new request is made:
+  // - If the value is already cached, returns it immediately.
+  // - If it's already in-flight (#requestedValues), subscribes to the same observable.
+  // - Otherwise, adds to #valuesToRequest. After timer fires, the batch executes and caches results.
+
+  #valuesToRequest: { values: TBatch; sharedObs: Observable<void> } | undefined;
+  #requestedValues = new Map<RequestId, { values: TBatch; sharedObs: Observable<void> }>();
+  #bufferSize: number;
+  #timerDelay: number;
+  #releaseOnCount: number;
+
+  protected constructor(props?: BatchingCacheProps) {
+    this.#bufferSize = props?.bufferSize ?? 100;
+    this.#timerDelay = props?.timerDelay ?? 20;
+    this.#releaseOnCount = props?.releaseOnCount ?? 500;
+  }
+
+  /** Return the cached result if available, or `undefined` if not cached. */
+  protected abstract getCachedValue(request: TRequest): TResult | undefined;
+
+  /** Return the result from cache. Called after the batch observable has completed - value is guaranteed to be cached. */
+  protected abstract getGuaranteedCachedValue(request: TRequest): TResult;
+
+  /**
+   * Return the portion of the request which needs to be requested (not in batch or cache).
+   * Returns `undefined` if the entire request is already in the batch.
+   * For caches without partial requests, return `undefined` if in batch, or the full request if not.
+   */
+  protected abstract getValuesToRequest(request: TRequest, batch: TBatch): TRequest | undefined;
+
+  /** Create a new empty batch. */
+  protected abstract createBatch(): TBatch;
+
+  /** Add a request to an existing batch. */
+  protected abstract addRequestToBatch(request: TRequest, batch: TBatch): void;
+
+  /** Produce the items from a batch that will be buffered and passed to `executeQuery`. */
+  protected abstract getIterable(batch: TBatch): Observable<TItem>;
+
+  /** Execute a query for a buffer of items. Returns an observable of result rows. */
+  protected abstract executeQuery(items: TItem[]): Observable<TRow>;
+
+  /** Cache a single row returned by `executeQuery`. */
+  protected abstract insertRow(row: TRow): void;
+
+  /** Ensure default/empty cache entries exist for all values in the batch (called after query completes). */
+  protected abstract ensureDefaultCacheEntries(batch: TBatch): void;
+
+  public get(request: TRequest): Observable<TResult> {
+    const cachedValue = this.getCachedValue(request);
+    if (cachedValue !== undefined) {
+      return of(cachedValue);
+    }
+
+    // Check if request is fully covered by an in-flight batch
+    let requestNotInBatch: TRequest = request;
+    for (const { values, sharedObs } of this.#requestedValues.values()) {
+      const partOfRequestNotInBatch = this.getValuesToRequest(request, values);
+      if (partOfRequestNotInBatch === undefined) {
+        return this.getResultAfterObservable(request, sharedObs);
+      }
+      requestNotInBatch = partOfRequestNotInBatch;
+    }
+
+    if (this.#valuesToRequest === undefined) {
+      const requestId = Guid.createValue();
+      const sharedObs = timer(this.#timerDelay).pipe(
+        switchMap(() => {
+          assert(this.#valuesToRequest !== undefined);
+          // After timer delay ms, assign the observable in #valuesToRequest to the #requestedValues
+          const valuesToRequest = this.#valuesToRequest;
+          this.#requestedValues.set(requestId, valuesToRequest);
+          // Clear #valuesToRequest so new requests can be collected while the query is executing
+          this.#valuesToRequest = undefined;
+          return this.executeBatchQuery(valuesToRequest.values).pipe(
+            reduce((_acc, row: TRow) => {
+              // Cache each row as it arrives, use reduce to emit one value when query completes
+              this.insertRow(row);
+              return undefined;
+            }, undefined),
+            tap(() => {
+              this.ensureDefaultCacheEntries(valuesToRequest.values);
+            }),
+          );
+        }),
+        tap({
+          finalize: () => {
+            // Remove requestedValues entry when the query completes.
+            this.#requestedValues.delete(requestId);
+          },
+        }),
+        shareReplay(1),
+      );
+      this.#valuesToRequest = { values: this.createBatch(), sharedObs };
+      this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+      return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+    }
+
+    this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+    return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+  }
+
+  private executeBatchQuery(batch: TBatch): Observable<TRow> {
+    return this.getIterable(batch).pipe(
+      bufferCount(this.#bufferSize),
+      mergeMap((items: TItem[]) => this.executeQuery(items).pipe(catchBeSQLiteInterrupts)),
+      releaseMainThreadOnItemsCount(this.#releaseOnCount),
+    );
+  }
+
+  private getResultAfterObservable(request: TRequest, observable: Observable<void>): Observable<TResult> {
+    return observable.pipe(map(() => this.getGuaranteedCachedValue(request)));
+  }
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -32,14 +32,14 @@ export interface BatchingCacheProps {
  *
  * @internal
  */
-export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
+export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
   // When a new request is made:
   // - If the value is already cached, returns it immediately.
   // - If it's already in-flight (#requestedValues), subscribes to the same observable.
   // - Otherwise, adds to #valuesToRequest. After timer fires, the batch executes and caches results.
 
-  #valuesToRequest: { values: TBatch; sharedObs: Observable<void> } | undefined;
-  #requestedValues = new Map<RequestId, { values: TBatch; sharedObs: Observable<void> }>();
+  #valuesToRequest: { values: TRequest[]; sharedObs: Observable<void> } | undefined;
+  #requestedValues = new Map<RequestId, { values: TRequest[]; sharedObs: Observable<void> }>();
   #bufferSize: number;
   #timerDelay: number;
   #releaseOnCount: number;
@@ -60,17 +60,11 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
    */
   protected abstract getValuesNotInBatch(
     request: TRequest,
-    batch: TBatch,
+    batch: TRequest[],
   ): { valuesNotInBatch: TRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true };
 
-  /** Create a new empty batch. */
-  protected abstract createBatch(): TBatch;
-
-  /** Add a request to an existing batch. */
-  protected abstract addRequestToBatch(request: TRequest, batch: TBatch): void;
-
   /** Produce the items from a batch that will be buffered and passed to `executeQuery`. */
-  protected abstract getIterable(batch: TBatch): Observable<TItem>;
+  protected abstract getIterable(batch: TRequest[]): Observable<TItem>;
 
   /** Execute a query for a buffer of items. Returns an observable of result rows. */
   protected abstract executeQuery(items: TItem[]): Observable<TRow>;
@@ -79,7 +73,7 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
   protected abstract insertRow(row: TRow): void;
 
   /** Ensure default/empty cache entries exist for all values in the batch (called after query completes). */
-  protected abstract ensureDefaultCacheEntries(batch: TBatch): void;
+  protected abstract ensureDefaultCacheEntries(batch: TRequest[]): void;
 
   public get(request: TRequest): Observable<TResult> {
     const cachedValue = this.getCachedValue(request);
@@ -130,18 +124,17 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
         }),
         shareReplay(1),
       );
-      this.#valuesToRequest = { values: this.createBatch(), sharedObs };
-      this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+      this.#valuesToRequest = { values: [requestNotInBatch], sharedObs };
       // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
       return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
     }
 
-    this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+    this.#valuesToRequest.values.push(requestNotInBatch);
     // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
     return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
   }
 
-  private executeBatchQuery(batch: TBatch): Observable<TRow> {
+  private executeBatchQuery(batch: TRequest[]): Observable<TRow> {
     return this.getIterable(batch).pipe(
       bufferCount(this.#bufferSize),
       mergeMap((items: TItem[]) => this.executeQuery(items).pipe(catchBeSQLiteInterrupts)),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -25,14 +25,24 @@ export interface BatchingCacheProps {
 /**
  * Abstract base class that provides timer-based batching, deduplication, and caching.
  *
- * Subclasses define:
- * - How requests map to cached values
- * - How batches are built from requests
- * - How to produce query items from a batch, execute queries, and cache rows
+ * @template TRequest - A single logical request made by a consumer (e.g. `{ modelId, categoryId, parentElementId }`).
+ * @template TResult - The value returned to the consumer for a given request (e.g. `Id64Array`).
+ * @template TQueryData - Query data produced by decomposing a batch of requests via `getIterable`
+ *   (e.g. a WHERE clause fragment). Items are buffered (up to `bufferSize`) and passed to `executeQuery`.
+ * @template TRow - A single result row emitted by `executeQuery`, cached via `insertRow`
+ *   (e.g. `{ modelId, reqParent, reqCategory, ownCategory, count }`).
+ *
+ * Pipeline:
+ * 1. Requests arriving within `timerDelay` ms are collected into a batch (`TRequest[]`).
+ * 2. `getIterable(batch)` decomposes the batch into a stream of `TQueryData` items.
+ * 3. Items are buffered (up to `bufferSize`) and passed to `executeQuery(items)`.
+ * 4. Each `TRow` emitted by `executeQuery` is cached via `insertRow`.
+ * 5. After completion, `ensureDefaultCacheEntries` fills in empty entries for
+ *    requests that produced no rows, and `getCachedValue` returns the result.
  *
  * @internal
  */
-export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
+export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   // When a new request is made:
   // - If the value is already cached, returns it immediately.
   // - If it's already in-flight (#requestedValues), subscribes to the same observable.
@@ -63,11 +73,16 @@ export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
     batch: TRequest[],
   ): { valuesNotInBatch: TRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true };
 
-  /** Produce the items from a batch that will be buffered and passed to `executeQuery`. */
-  protected abstract getIterable(batch: TRequest[]): Observable<TItem>;
+  /**
+   * Convert batched requests into units of data which are used to execute the query.
+   * For example, TRequest might be an object containing various request values, when converted to TQueryData,
+   * those values take shape of a WHERE clause fragments.
+   * These TQueryData items are buffered and passed to `executeQuery`.
+   */
+  protected abstract getIterable(batch: TRequest[]): Observable<TQueryData>;
 
-  /** Execute a query for a buffer of items. Returns an observable of result rows. */
-  protected abstract executeQuery(items: TItem[]): Observable<TRow>;
+  /** Execute a query for the given query data buffer. Returns an observable of result rows. */
+  protected abstract executeQuery(queryData: TQueryData[]): Observable<TRow>;
 
   /** Cache a single row returned by `executeQuery`. */
   protected abstract insertRow(row: TRow): void;
@@ -137,7 +152,7 @@ export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
   private executeBatchQuery(batch: TRequest[]): Observable<TRow> {
     return this.getIterable(batch).pipe(
       bufferCount(this.#bufferSize),
-      mergeMap((items: TItem[]) => this.executeQuery(items).pipe(catchBeSQLiteInterrupts)),
+      mergeMap((queryData: TQueryData[]) => this.executeQuery(queryData).pipe(catchBeSQLiteInterrupts)),
       releaseMainThreadOnItemsCount(this.#releaseOnCount),
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -53,9 +53,6 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
   /** Return the cached result if available, or `undefined` if not cached. */
   protected abstract getCachedValue(request: TRequest): TResult | undefined;
 
-  /** Return the result from cache. Called after the batch observable has completed - value is guaranteed to be cached. */
-  protected abstract getGuaranteedCachedValue(request: TRequest): TResult;
-
   /**
    * Return the portion of the request which needs to be requested (not in batch or cache).
    * Returns `undefined` if the entire request is already in the batch.
@@ -153,6 +150,12 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
   }
 
   private getResultAfterObservable(request: TRequest, observable: Observable<void>): Observable<TResult> {
-    return observable.pipe(map(() => this.getGuaranteedCachedValue(request)));
+    return observable.pipe(
+      map(() => {
+        const cachedValue = this.getCachedValue(request);
+        assert(cachedValue !== undefined);
+        return cachedValue;
+      }),
+    );
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -3,17 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { bufferCount, defer, EMPTY, from, map, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
+import { defer, EMPTY, from, mergeMap } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
-import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
-import { releaseMainThreadOnItemsCount } from "../Utils.js";
+import { BatchingCache } from "./BatchingCache.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 import type { CategoryId, ElementId, ModelId } from "../Types.js";
-
-type RequestId = string;
 
 interface DescendantsCountBaseRequest {
   modelId: ModelId;
@@ -29,7 +26,20 @@ interface DescendantsCountElementRequest extends DescendantsCountBaseRequest {
   categoryId?: undefined;
 }
 
-type RequestEntry = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>;
+type DescendantsCountRequest = DescendantsCountCategoryRequest | DescendantsCountElementRequest;
+type DescendantsCountResult = Array<{ categoryId: CategoryId; count: number }>;
+type Batch = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>;
+interface WhereClause {
+  whereClause: string;
+  type: "element" | "category";
+}
+interface Row {
+  modelId: ModelId;
+  reqParent: ElementId | undefined | null;
+  reqCategory: CategoryId | undefined | null;
+  ownCategory: CategoryId;
+  cnt: number;
+}
 
 /**
  * Cache used to store count of descendants grouped by category.
@@ -37,52 +47,62 @@ type RequestEntry = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | und
  * Cache makes requests in batches of 20ms.
  * @internal
  */
-export class DescendantsCountCache {
-  // When a new request is made:
-  // - If the value is already cached (#cachedValues), returns it.
-  // - If it's already requested (#requestedValues), pipe through the observable. When observable emits, the cached value can be retrieved,
-  // - If the value is not requested yet, add it to the values which will be requested (#valuesToRequest).
-  // #valuesToRequest observable waits for 20ms, then adds the observable value to #requestedValues and starts the query.
-  // When the query completes the observable removes the value from #requestedValues.
-
-  #cachedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, Array<{ categoryId: CategoryId; count: number }>>>>();
-  #valuesToRequest: { values: RequestEntry; sharedObs: Observable<void> } | undefined;
-  #requestedValues = new Map<RequestId, { values: RequestEntry; sharedObs: Observable<void> }>();
+export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest, Batch, DescendantsCountResult, WhereClause, Row> {
+  #cachedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, DescendantsCountResult>>>();
   #queryExecutor: LimitingECSqlQueryExecutor;
   #elementClassName: string;
   #componentId: GuidString;
   #componentName: string;
 
   public constructor(props: { queryExecutor: LimitingECSqlQueryExecutor; elementClassName: string; componentId: GuidString }) {
+    super();
     this.#componentId = props.componentId;
     this.#queryExecutor = props.queryExecutor;
     this.#elementClassName = props.elementClassName;
     this.#componentName = "DescendantsCountCache";
   }
 
-  private getCachedValueAfterObservable({
-    modelId,
-    categoryId,
-    parentElementId,
-    observable,
-  }: {
-    observable: Observable<void>;
-  } & (DescendantsCountElementRequest | DescendantsCountCategoryRequest)): Observable<Array<{ categoryId: CategoryId; count: number }>> {
-    return observable.pipe(
-      map(() => {
-        const entry = this.#cachedValues.get(modelId)?.get(parentElementId)?.get(categoryId);
-        assert(entry !== undefined);
-        return entry;
-      }),
-    );
+  protected getCachedValue(request: DescendantsCountRequest): DescendantsCountResult | undefined {
+    return this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
   }
 
-  private executeBatchQuery(valuesToRequest: RequestEntry) {
-    return from(valuesToRequest.entries()).pipe(
+  protected getGuaranteedCachedValue(request: DescendantsCountRequest): DescendantsCountResult {
+    const entry = this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
+    assert(entry !== undefined);
+    return entry;
+  }
+
+  protected getValuesToRequest(request: DescendantsCountRequest, batch: Batch): DescendantsCountRequest | undefined {
+    if (batch.get(request.modelId)?.get(request.parentElementId)?.has(request.categoryId)) {
+      return undefined;
+    }
+    return request;
+  }
+
+  protected createBatch(): Batch {
+    return new Map();
+  }
+
+  protected addRequestToBatch(request: DescendantsCountRequest, batch: Batch): void {
+    let modelEntry = batch.get(request.modelId);
+    if (!modelEntry) {
+      modelEntry = new Map();
+      batch.set(request.modelId, modelEntry);
+    }
+    let parentEntry = modelEntry.get(request.parentElementId);
+    if (!parentEntry) {
+      parentEntry = new Set();
+      modelEntry.set(request.parentElementId, parentEntry);
+    }
+    parentEntry.add(request.categoryId);
+  }
+
+  protected getIterable(batch: Batch): Observable<WhereClause> {
+    return from(batch.entries()).pipe(
       mergeMap(([modelId, parentMap]) =>
         from(parentMap.entries()).pipe(
           mergeMap(([parentElementId, categoryIds]) => {
-            const clauses: Array<{ whereClause: string; type: "element" | "category" }> = [];
+            const clauses = new Array<WhereClause>();
             if (categoryIds.has(undefined)) {
               assert(parentElementId !== undefined);
               clauses.push({ whereClause: `Model.Id = ${modelId} AND Parent.Id = ${parentElementId}`, type: "element" });
@@ -98,163 +118,112 @@ export class DescendantsCountCache {
           }),
         ),
       ),
-      bufferCount(100),
-      mergeMap((whereClauses) => {
-        const categoryWhereClauses = whereClauses.filter((c) => c.type === "category").map((c) => c.whereClause);
-        const elementWhereClauses = whereClauses.filter((c) => c.type === "element").map((c) => c.whereClause);
-
-        const baseCases: string[] = [];
-
-        if (categoryWhereClauses.length > 0) {
-          baseCases.push(`
-            SELECT ECInstanceId, Model.Id, Parent.Id, Category.Id, Category.Id
-            FROM ${this.#elementClassName}
-            WHERE ${categoryWhereClauses.join(" OR ")}
-          `);
-        }
-
-        if (elementWhereClauses.length > 0) {
-          baseCases.push(`
-            SELECT ECInstanceId, Model.Id, Parent.Id, CAST(NULL AS TEXT), Category.Id
-            FROM ${this.#elementClassName}
-            WHERE ${elementWhereClauses.join(" OR ")}
-          `);
-        }
-
-        if (baseCases.length === 0) {
-          return EMPTY;
-        }
-
-        return defer(() =>
-          this.#queryExecutor.createQueryReader(
-            {
-              ctes: [
-                `
-                Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
-                  ${baseCases.join(" UNION ALL ")}
-
-                  UNION ALL
-
-                  SELECT c.ECInstanceId, p.modelId, p.reqParent, p.reqCategory, c.Category.Id
-                  FROM ${this.#elementClassName} c
-                  JOIN Descendants p ON c.Parent.Id = p.id
-                )
-                `,
-              ],
-              ecsql: `
-                SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
-                FROM Descendants
-                GROUP BY modelId, reqParent, reqCategory, ownCategory
-              `,
-            },
-            {
-              rowFormat: "ECSqlPropertyNames",
-              limit: "unbounded",
-              restartToken: `${this.#componentName}/${this.#componentId}/descendants-counts/${Guid.createValue()}`,
-            },
-          ),
-        ).pipe(catchBeSQLiteInterrupts);
-      }),
-      releaseMainThreadOnItemsCount(500),
     );
   }
 
-  public getDescendantsCounts(
-    props: DescendantsCountCategoryRequest | DescendantsCountElementRequest,
-  ): Observable<Array<{ categoryId: CategoryId; count: number }>> {
-    const cachedValue = this.#cachedValues.get(props.modelId)?.get(props.parentElementId)?.get(props.categoryId);
-    // Cached values can be returned immediately
-    if (cachedValue !== undefined) {
-      return of(cachedValue);
+  protected executeQuery(items: WhereClause[]): Observable<Row> {
+    const categoryWhereClauses = items.filter((c) => c.type === "category").map((c) => c.whereClause);
+    const elementWhereClauses = items.filter((c) => c.type === "element").map((c) => c.whereClause);
+
+    const baseCases: string[] = [];
+
+    if (categoryWhereClauses.length > 0) {
+      baseCases.push(`
+        SELECT ECInstanceId, Model.Id, Parent.Id, Category.Id, Category.Id
+        FROM ${this.#elementClassName}
+        WHERE ${categoryWhereClauses.join(" OR ")}
+      `);
     }
 
-    // Check if value was already requested. If it was, wait for requested observable to emit and then return the value from cache
-    for (const { values, sharedObs: obs } of this.#requestedValues.values()) {
-      if (values.get(props.modelId)?.get(props.parentElementId)?.has(props.categoryId)) {
-        return this.getCachedValueAfterObservable({ ...props, observable: obs });
+    if (elementWhereClauses.length > 0) {
+      baseCases.push(`
+        SELECT ECInstanceId, Model.Id, Parent.Id, CAST(NULL AS TEXT), Category.Id
+        FROM ${this.#elementClassName}
+        WHERE ${elementWhereClauses.join(" OR ")}
+      `);
+    }
+
+    if (baseCases.length === 0) {
+      return EMPTY;
+    }
+
+    return defer(
+      () =>
+        this.#queryExecutor.createQueryReader(
+          {
+            ctes: [
+              `
+            Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
+              ${baseCases.join(" UNION ALL ")}
+
+              UNION ALL
+
+              SELECT c.ECInstanceId, p.modelId, p.reqParent, p.reqCategory, c.Category.Id
+              FROM ${this.#elementClassName} c
+              JOIN Descendants p ON c.Parent.Id = p.id
+            )
+            `,
+            ],
+            ecsql: `
+            SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
+            FROM Descendants
+            GROUP BY modelId, reqParent, reqCategory, ownCategory
+          `,
+          },
+          {
+            rowFormat: "ECSqlPropertyNames",
+            limit: "unbounded",
+            restartToken: `${this.#componentName}/${this.#componentId}/descendants-counts/${Guid.createValue()}`,
+          },
+        ),
+      // observable returns an ECSqlQueryRow, but the return type is known and can be cast as Row.
+    ) as Observable<Row>;
+  }
+
+  protected insertRow(row: Row): void {
+    const reqParent = row.reqParent ?? undefined;
+    const reqCategory = row.reqCategory ?? undefined;
+    let modelEntry = this.#cachedValues.get(row.modelId);
+    if (!modelEntry) {
+      modelEntry = new Map();
+      this.#cachedValues.set(row.modelId, modelEntry);
+    }
+    let parentEntry = modelEntry.get(reqParent);
+    if (!parentEntry) {
+      parentEntry = new Map();
+      modelEntry.set(reqParent, parentEntry);
+    }
+    let categoryEntry = parentEntry.get(reqCategory);
+    if (!categoryEntry) {
+      categoryEntry = [];
+      parentEntry.set(reqCategory, categoryEntry);
+    }
+    categoryEntry.push({ categoryId: row.ownCategory, count: row.cnt });
+  }
+
+  protected ensureDefaultCacheEntries(batch: Batch): void {
+    for (const [entryModelId, parentMap] of batch.entries()) {
+      let modelEntry = this.#cachedValues.get(entryModelId);
+      if (!modelEntry) {
+        modelEntry = new Map();
+        this.#cachedValues.set(entryModelId, modelEntry);
+      }
+      for (const [parentElementId, categoryIds] of parentMap) {
+        let parentEntry = modelEntry.get(parentElementId);
+        if (!parentEntry) {
+          parentEntry = new Map();
+          modelEntry.set(parentElementId, parentEntry);
+        }
+        for (const entryCategoryId of categoryIds) {
+          if (!parentEntry.has(entryCategoryId)) {
+            parentEntry.set(entryCategoryId, entryCategoryId === undefined ? [] : [{ categoryId: entryCategoryId, count: 0 }]);
+          }
+        }
       }
     }
+  }
 
-    if (this.#valuesToRequest === undefined) {
-      // Store request guid so it can be deleted later.
-      const requestId = Guid.createValue();
-      const sharedObs = timer(20).pipe(
-        switchMap(() => {
-          assert(this.#valuesToRequest !== undefined);
-          // After 20 ms, assign the observable in #valuesToRequest to the #requestedValues
-          const valuesToRequest = this.#valuesToRequest;
-          this.#requestedValues.set(requestId, valuesToRequest);
-          // Clear #valuesToRequest so new requests can be collected while the query is executing
-          this.#valuesToRequest = undefined;
-          return this.executeBatchQuery(valuesToRequest.values).pipe(
-            // Cache each row as it arrives, use reduce to emit one value when query completes
-            reduce((acc, row) => {
-              const reqParent = row.reqParent ?? undefined;
-              const reqCategory = row.reqCategory ?? undefined;
-              let modelEntry = this.#cachedValues.get(row.modelId);
-              if (!modelEntry) {
-                modelEntry = new Map();
-                this.#cachedValues.set(row.modelId, modelEntry);
-              }
-              let parentEntry = modelEntry.get(reqParent);
-              if (!parentEntry) {
-                parentEntry = new Map();
-                modelEntry.set(reqParent, parentEntry);
-              }
-              let categoryEntry = parentEntry.get(reqCategory);
-              if (!categoryEntry) {
-                categoryEntry = [];
-                parentEntry.set(reqCategory, categoryEntry);
-              }
-              categoryEntry.push({ categoryId: row.ownCategory, count: row.cnt });
-              return acc;
-            }, undefined),
-            tap(() => {
-              for (const [entryModelId, parentMap] of valuesToRequest.values.entries()) {
-                let modelEntry = this.#cachedValues.get(entryModelId);
-                if (!modelEntry) {
-                  modelEntry = new Map();
-                  this.#cachedValues.set(entryModelId, modelEntry);
-                }
-                for (const [parentElementId, categoryIds] of parentMap) {
-                  let parentEntry = modelEntry.get(parentElementId);
-                  if (!parentEntry) {
-                    parentEntry = new Map();
-                    modelEntry.set(parentElementId, parentEntry);
-                  }
-                  for (const entryCategoryId of categoryIds) {
-                    if (!parentEntry.has(entryCategoryId)) {
-                      parentEntry.set(entryCategoryId, entryCategoryId === undefined ? [] : [{ categoryId: entryCategoryId, count: 0 }]);
-                    }
-                  }
-                }
-              }
-            }),
-          );
-        }),
-        tap({
-          finalize: () => {
-            // Remove requestedValues entry when the query completes.
-            this.#requestedValues.delete(requestId);
-          },
-        }),
-        shareReplay(1),
-      );
-      this.#valuesToRequest = { values: new Map([[props.modelId, new Map([[props.parentElementId, new Set([props.categoryId])]])]]), sharedObs };
-      return this.getCachedValueAfterObservable({ ...props, observable: this.#valuesToRequest.sharedObs });
-    }
-
-    let existingModelEntry = this.#valuesToRequest.values.get(props.modelId);
-    if (!existingModelEntry) {
-      existingModelEntry = new Map();
-      this.#valuesToRequest.values.set(props.modelId, existingModelEntry);
-    }
-    let existingParentEntry = existingModelEntry.get(props.parentElementId);
-    if (!existingParentEntry) {
-      existingParentEntry = new Set();
-      existingModelEntry.set(props.parentElementId, existingParentEntry);
-    }
-    existingParentEntry.add(props.categoryId);
-    return this.getCachedValueAfterObservable({ ...props, observable: this.#valuesToRequest.sharedObs });
+  public getDescendantsCounts(props: DescendantsCountRequest): Observable<DescendantsCountResult> {
+    return this.get(props);
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -113,9 +113,9 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     );
   }
 
-  protected executeQuery(items: WhereClause[]): Observable<Row> {
-    const categoryWhereClauses = items.filter((c) => c.type === "category").map((c) => c.whereClause);
-    const elementWhereClauses = items.filter((c) => c.type === "element").map((c) => c.whereClause);
+  protected executeQuery(clauses: WhereClause[]): Observable<Row> {
+    const categoryWhereClauses = clauses.filter((c) => c.type === "category").map((c) => c.whereClause);
+    const elementWhereClauses = clauses.filter((c) => c.type === "element").map((c) => c.whereClause);
 
     const baseCases: string[] = [];
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -28,7 +28,6 @@ interface DescendantsCountElementRequest extends DescendantsCountBaseRequest {
 
 type DescendantsCountRequest = DescendantsCountCategoryRequest | DescendantsCountElementRequest;
 type DescendantsCountResult = Array<{ categoryId: CategoryId; count: number }>;
-type Batch = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>;
 interface WhereClause {
   whereClause: string;
   type: "element" | "category";
@@ -47,7 +46,7 @@ interface Row {
  * Cache makes requests in batches of 20ms.
  * @internal
  */
-export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest, Batch, DescendantsCountResult, WhereClause, Row> {
+export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest, DescendantsCountResult, WhereClause, Row> {
   #cachedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, DescendantsCountResult>>>();
   #queryExecutor: LimitingECSqlQueryExecutor;
   #elementClassName: string;
@@ -68,34 +67,30 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
 
   protected getValuesNotInBatch(
     request: DescendantsCountRequest,
-    batch: Batch,
+    batch: DescendantsCountRequest[],
   ): { valuesNotInBatch: DescendantsCountRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true } {
-    if (batch.get(request.modelId)?.get(request.parentElementId)?.has(request.categoryId)) {
+    if (batch.some((r) => r.modelId === request.modelId && r.parentElementId === request.parentElementId && r.categoryId === request.categoryId)) {
       return { valuesNotInBatch: undefined, batchContainsValues: true };
     }
     return { valuesNotInBatch: request, batchContainsValues: false };
   }
 
-  protected createBatch(): Batch {
-    return new Map();
-  }
-
-  protected addRequestToBatch(request: DescendantsCountRequest, batch: Batch): void {
-    let modelEntry = batch.get(request.modelId);
-    if (!modelEntry) {
-      modelEntry = new Map();
-      batch.set(request.modelId, modelEntry);
+  protected getIterable(batch: DescendantsCountRequest[]): Observable<WhereClause> {
+    const groupedValues = new Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>();
+    for (const { modelId, parentElementId, categoryId } of batch) {
+      let modelEntry = groupedValues.get(modelId);
+      if (!modelEntry) {
+        modelEntry = new Map();
+        groupedValues.set(modelId, modelEntry);
+      }
+      let parentEntry = modelEntry.get(parentElementId);
+      if (!parentEntry) {
+        parentEntry = new Set();
+        modelEntry.set(parentElementId, parentEntry);
+      }
+      parentEntry.add(categoryId);
     }
-    let parentEntry = modelEntry.get(request.parentElementId);
-    if (!parentEntry) {
-      parentEntry = new Set();
-      modelEntry.set(request.parentElementId, parentEntry);
-    }
-    parentEntry.add(request.categoryId);
-  }
-
-  protected getIterable(batch: Batch): Observable<WhereClause> {
-    return from(batch.entries()).pipe(
+    return from(groupedValues.entries()).pipe(
       mergeMap(([modelId, parentMap]) =>
         from(parentMap.entries()).pipe(
           mergeMap(([parentElementId, categoryIds]) => {
@@ -198,24 +193,20 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     categoryEntry.push({ categoryId: row.ownCategory, count: row.cnt });
   }
 
-  protected ensureDefaultCacheEntries(batch: Batch): void {
-    for (const [entryModelId, parentMap] of batch.entries()) {
-      let modelEntry = this.#cachedValues.get(entryModelId);
+  protected ensureDefaultCacheEntries(batch: DescendantsCountRequest[]): void {
+    for (const { modelId, categoryId, parentElementId } of batch) {
+      let modelEntry = this.#cachedValues.get(modelId);
       if (!modelEntry) {
         modelEntry = new Map();
-        this.#cachedValues.set(entryModelId, modelEntry);
+        this.#cachedValues.set(modelId, modelEntry);
       }
-      for (const [parentElementId, categoryIds] of parentMap) {
-        let parentEntry = modelEntry.get(parentElementId);
-        if (!parentEntry) {
-          parentEntry = new Map();
-          modelEntry.set(parentElementId, parentEntry);
-        }
-        for (const entryCategoryId of categoryIds) {
-          if (!parentEntry.has(entryCategoryId)) {
-            parentEntry.set(entryCategoryId, entryCategoryId === undefined ? [] : [{ categoryId: entryCategoryId, count: 0 }]);
-          }
-        }
+      let parentEntry = modelEntry.get(parentElementId);
+      if (!parentEntry) {
+        parentEntry = new Map();
+        modelEntry.set(parentElementId, parentEntry);
+      }
+      if (!parentEntry.has(categoryId)) {
+        parentEntry.set(categoryId, categoryId === undefined ? [] : [{ categoryId, count: 0 }]);
       }
     }
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -72,11 +72,14 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     return entry;
   }
 
-  protected getValuesToRequest(request: DescendantsCountRequest, batch: Batch): DescendantsCountRequest | undefined {
+  protected getValuesNotInBatch(
+    request: DescendantsCountRequest,
+    batch: Batch,
+  ): { valuesNotInBatch: DescendantsCountRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true } {
     if (batch.get(request.modelId)?.get(request.parentElementId)?.has(request.categoryId)) {
-      return undefined;
+      return { valuesNotInBatch: undefined, batchContainsValues: true };
     }
-    return request;
+    return { valuesNotInBatch: request, batchContainsValues: false };
   }
 
   protected createBatch(): Batch {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -66,12 +66,6 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     return this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
   }
 
-  protected getGuaranteedCachedValue(request: DescendantsCountRequest): DescendantsCountResult {
-    const entry = this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
-    assert(entry !== undefined);
-    return entry;
-  }
-
   protected getValuesNotInBatch(
     request: DescendantsCountRequest,
     batch: Batch,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -75,7 +75,7 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     return { valuesNotInBatch: request, batchContainsValues: false };
   }
 
-  protected getIterable(batch: DescendantsCountRequest[]): Observable<WhereClause> {
+  protected getQueryData(batch: DescendantsCountRequest[]): Observable<WhereClause> {
     const groupedValues = new Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>();
     for (const { modelId, parentElementId, categoryId } of batch) {
       let modelEntry = groupedValues.get(modelId);


### PR DESCRIPTION
When reviewing https://github.com/iTwin/viewer-components-react/pull/1678,
Realized I hadn't included the `ChildElementsCache` rewrite in the original phases. Thinking we could insert it between phase 1 and phase 2.

While trying to implement `ChildElementsCache`, considered unifying how it works with `DescendantCountsCache`. Currently `ChildElementsCache` executes a query per request, while `DescendantCountsCache` batches requests over a 20ms window. The original plan was to keep the structure as-is, but decided that it's better to batch `ChildElementsCache` as well.


This PR includes:
1. Abstract `BatchingCache` class which is used by `DescendantCountsCache`.
2. `DescendantCountsCache` changes to use `BatchingCache`.

Afterwards will create a separate PR for adjusting `ChildElementsCache`.