### PR TITLE
[Tree widget]: parent elements correct visibility on `next`

### DIFF
--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
@@ -104,7 +104,6 @@ export function createClassGroupingHierarchyNode({
   parentKeys?: Array<InstanceKey | ClassGroupingNodeKey>;
   hasDirectNonSearchTargets?: boolean;
   hasSearchTargetAncestor?: boolean;
-  childrenCount?: number;
 }): GroupingHierarchyNode & { key: ClassGroupingNodeKey } {
   const className = props.className ?? CLASS_NAME_Element;
   return {
@@ -122,7 +121,6 @@ export function createClassGroupingHierarchyNode({
     extendedData: {
       categoryId: props.categoryId,
       modelElementsMap,
-      childrenCount: props.childrenCount !== undefined ? props.childrenCount : 0,
       ...(props.hasDirectNonSearchTargets ? { hasDirectNonSearchTargets: props.hasDirectNonSearchTargets } : {}),
       ...(props.hasSearchTargetAncestor ? { hasSearchTargetAncestor: props.hasSearchTargetAncestor } : {}),
     },
@@ -158,7 +156,6 @@ export function createElementHierarchyNode(props: {
   elementId: Id64String;
   viewType?: "2d" | "3d";
   parentKeys?: Array<InstanceKey | ClassGroupingNodeKey>;
-  childrenCount?: number;
   search?: NonGroupingHierarchyNode["search"];
 }): NonGroupingHierarchyNode {
   const { elementClass } = getClassesByView(props.viewType ?? "3d");
@@ -177,7 +174,6 @@ export function createElementHierarchyNode(props: {
       modelId: props.modelId,
       categoryId: props.categoryId,
       isElement: true,
-      childrenCount: props.childrenCount !== undefined ? props.childrenCount : 0,
     },
   };
 }

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/ChildElementsCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/ChildElementsCache.test.ts
@@ -14,6 +14,7 @@ import {
 } from "test-utilities";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEditTxn } from "@itwin/core-backend";
+import { CompressedId64Set } from "@itwin/core-bentley";
 import { IModelReadRpcInterface } from "@itwin/core-common";
 import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
@@ -211,10 +212,11 @@ describe("ChildElementsCache", () => {
       expect(result2).toEqual(expect.arrayContaining(["0x100"]));
       // Both requests are served by a single query since they're in the same batch
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
-      const query = vi.mocked(vp.iModel.createQueryReader).mock.calls[0][0];
+      const params = vi.mocked(vp.iModel.createQueryReader).mock.calls[0][1];
+      const ids = CompressedId64Set.decompressSet((params?.serialize() as any)[1].value);
 
-      expect(query.split("0x3")).toHaveLength(2); // "0x3" appears once
-      expect(query.split("0x4")).toHaveLength(2); // "0x4" appears once
+      expect(ids.has("0x3")).toBe(true);
+      expect(ids.has("0x4")).toBe(true);
     });
 
     it("only requests missing childCategoryIds on subsequent calls", async () => {
@@ -237,9 +239,10 @@ describe("ChildElementsCache", () => {
       ]);
       expect(result2).toEqual(expect.arrayContaining(["0x100"]));
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
-      const secondQuery = vi.mocked(vp.iModel.createQueryReader).mock.calls[1][0];
-      expect(secondQuery.split("0x3")).toHaveLength(1); // "0x3" does not appear
-      expect(secondQuery.split("0x4")).toHaveLength(2); // "0x4" appears once
+      const secondParams = vi.mocked(vp.iModel.createQueryReader).mock.calls[1][1];
+      const secondIds = CompressedId64Set.decompressSet((secondParams?.serialize() as any)[1].value);
+      expect(secondIds.has("0x3")).toBe(false); // "0x3" does not appear
+      expect(secondIds.has("0x4")).toBe(true); // "0x4" appears
     });
 
     it("returns combined results from multiple childCategoryIds", async () => {

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/ChildElementsCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/ChildElementsCache.test.ts
@@ -1,0 +1,490 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { firstValueFrom } from "rxjs";
+import {
+  HierarchyCacheMode,
+  initializeCore,
+  insertPhysicalElement,
+  insertPhysicalModelWithPartition,
+  insertSpatialCategory,
+  terminateCore,
+} from "test-utilities";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEditTxn } from "@itwin/core-backend";
+import { IModelReadRpcInterface } from "@itwin/core-common";
+import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
+import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
+import { PresentationRpcInterface } from "@itwin/presentation-common";
+import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
+import { createLimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
+import { ChildElementsCache } from "../../../../tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.js";
+import { CLASS_NAME_GeometricElement3d } from "../../../../tree-widget-react/components/trees/common/internal/ClassNameDefinitions.js";
+import { buildIModel } from "../../../IModelUtils.js";
+import { createFakeViewport } from "../../Common.js";
+
+import type { IModelConnection } from "@itwin/core-frontend";
+
+function createCache(imodel: IModelConnection) {
+  return new ChildElementsCache({
+    queryExecutor: createLimitingECSqlQueryExecutor(createECSqlQueryExecutor(imodel), 1000),
+    componentId: "test",
+    elementClassName: CLASS_NAME_GeometricElement3d,
+  });
+}
+
+function createFakeCache(viewport: ReturnType<typeof createFakeViewport>) {
+  return new ChildElementsCache({
+    queryExecutor: createECSqlQueryExecutor(viewport.iModel),
+    componentId: "test",
+    elementClassName: CLASS_NAME_GeometricElement3d,
+  });
+}
+
+describe("ChildElementsCache", () => {
+  describe("batching and caching", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns empty array for empty childCategoryIds", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const result = await firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: [] }));
+      expect(result).toEqual([]);
+      expect(vp.iModel.createQueryReader).not.toHaveBeenCalled();
+    });
+
+    it("returns empty array for category request with no results", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const [result] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      expect(result).toEqual([]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("returns empty array for element request with no results", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const [result] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", parentElementId: "0x10", childCategoryIds: ["0x3"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      expect(result).toEqual([]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("returns element ids from query results", async () => {
+      using vp = createFakeViewport({
+        queryHandler: () => [
+          { modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x3", id: "0x100" },
+          { modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x3", id: "0x101" },
+        ],
+      });
+      const cache = createFakeCache(vp);
+
+      const [result] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      expect(result).toEqual(expect.arrayContaining(["0x100", "0x101"]));
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("batches multiple requests into single query", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const promise1 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      const promise2 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x4", childCategoryIds: ["0x3"] }));
+      await Promise.all([promise1, promise2, vi.advanceTimersByTimeAsync(20)]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("batches requests which are less than 20 ms apart", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const promise1 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      await vi.advanceTimersByTimeAsync(19);
+      const promise2 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x4", childCategoryIds: ["0x3"] }));
+      await Promise.all([promise1, promise2, vi.advanceTimersByTimeAsync(2)]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("does not batch requests which are more than 20 ms apart", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const promise1 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      await vi.advanceTimersByTimeAsync(21);
+      const promise2 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x4", childCategoryIds: ["0x3"] }));
+      await Promise.all([promise1, promise2, vi.advanceTimersByTimeAsync(20)]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
+    });
+
+    it("batches mixed category and element requests into single query", async () => {
+      using vp = createFakeViewport({
+        queryHandler: () => [
+          { modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x3", id: "0x100" },
+          { modelId: "0x1", reqParent: "0x10", reqCategory: null, ownCategory: "0x3", id: "0x200" },
+        ],
+      });
+      const cache = createFakeCache(vp);
+
+      const promise1 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      const promise2 = firstValueFrom(cache.getChildElements({ modelId: "0x1", parentElementId: "0x10", childCategoryIds: ["0x3"] }));
+      await Promise.all([promise1, promise2, vi.advanceTimersByTimeAsync(20)]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("caches empty values", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const [result1] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      const result2 = await firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      expect(result1).toEqual([]);
+      expect(result2).toEqual([]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("caches values returned by query", async () => {
+      using vp = createFakeViewport({
+        queryHandler: () => [{ modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x3", id: "0x100" }],
+      });
+      const cache = createFakeCache(vp);
+
+      const [result1] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      const result2 = await firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      expect(result1).toEqual(["0x100"]);
+      expect(result2).toEqual(["0x100"]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("caches element request values", async () => {
+      using vp = createFakeViewport({
+        queryHandler: () => [{ modelId: "0x1", reqParent: "0x10", reqCategory: null, ownCategory: "0x3", id: "0x100" }],
+      });
+      const cache = createFakeCache(vp);
+
+      const [result1] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", parentElementId: "0x10", childCategoryIds: ["0x3"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      const result2 = await firstValueFrom(cache.getChildElements({ modelId: "0x1", parentElementId: "0x10", childCategoryIds: ["0x3"] }));
+      expect(result1).toEqual(["0x100"]);
+      expect(result2).toEqual(["0x100"]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("only requests missing childCategoryIds when in-flight batch covers them", async () => {
+      using vp = createFakeViewport({
+        queryHandler: () => [{ modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x3", id: "0x100" }],
+      });
+      const cache = createFakeCache(vp);
+
+      // First request caches childCategoryId "0x3"
+      const promise1 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      // Second request arrives before the first batch fires — "0x3" is in-flight, so only "0x4" needs to be added
+      const promise2 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3", "0x4"] }));
+      const [result1, result2] = await Promise.all([promise1, promise2, vi.advanceTimersByTimeAsync(20)]);
+      expect(result1).toEqual(["0x100"]);
+      expect(result2).toEqual(expect.arrayContaining(["0x100"]));
+      // Both requests are served by a single query since they're in the same batch
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+      const query = vi.mocked(vp.iModel.createQueryReader).mock.calls[0][0];
+
+      expect(query.split("0x3")).toHaveLength(2); // "0x3" appears once
+      expect(query.split("0x4")).toHaveLength(2); // "0x4" appears once
+    });
+
+    it("only requests missing childCategoryIds on subsequent calls", async () => {
+      using vp = createFakeViewport({
+        queryHandler: () => [{ modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x3", id: "0x100" }],
+      });
+      const cache = createFakeCache(vp);
+
+      // First request caches childCategoryId "0x3"
+      const [result1] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      expect(result1).toEqual(["0x100"]);
+
+      // Second request after first batch completed — "0x3" is cached, only "0x4" should be queried
+      const [result2] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3", "0x4"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      expect(result2).toEqual(expect.arrayContaining(["0x100"]));
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
+      const secondQuery = vi.mocked(vp.iModel.createQueryReader).mock.calls[1][0];
+      expect(secondQuery.split("0x3")).toHaveLength(1); // "0x3" does not appear
+      expect(secondQuery.split("0x4")).toHaveLength(2); // "0x4" appears once
+    });
+
+    it("returns combined results from multiple childCategoryIds", async () => {
+      using vp = createFakeViewport({
+        queryHandler: () => [
+          { modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x3", id: "0x100" },
+          { modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x4", id: "0x200" },
+        ],
+      });
+      const cache = createFakeCache(vp);
+
+      const [result] = await Promise.all([
+        firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3", "0x4"] })),
+        vi.advanceTimersByTimeAsync(20),
+      ]);
+      expect(result).toEqual(expect.arrayContaining(["0x100", "0x200"]));
+    });
+
+    it("does not re-request childCategoryIds already in-flight", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+
+      const promise1 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      const promise2 = firstValueFrom(cache.getChildElements({ modelId: "0x1", categoryId: "0x2", childCategoryIds: ["0x3"] }));
+      await Promise.all([promise1, promise2, vi.advanceTimersByTimeAsync(20)]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("executes single query if 100 where clauses are generated", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+      const promises = new Array<Promise<unknown>>();
+      for (let i = 1; i <= 100; ++i) {
+        promises.push(firstValueFrom(cache.getChildElements({ modelId: `0x${i}`, categoryId: "0x1000", childCategoryIds: ["0x2000"] })));
+      }
+      await Promise.all([...promises, vi.advanceTimersByTimeAsync(20)]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
+
+    it("executes separate queries if > 100 where clauses are generated", async () => {
+      using vp = createFakeViewport();
+      const cache = createFakeCache(vp);
+      const promises = new Array<Promise<unknown>>();
+      for (let i = 1; i <= 101; ++i) {
+        promises.push(firstValueFrom(cache.getChildElements({ modelId: `0x${i}`, categoryId: "0x1000", childCategoryIds: ["0x2000"] })));
+      }
+      await Promise.all([...promises, vi.advanceTimersByTimeAsync(20)]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("query results", () => {
+    beforeAll(async () => {
+      await initializeCore({
+        backendProps: {
+          caching: {
+            hierarchies: {
+              // eslint-disable-next-line @typescript-eslint/no-deprecated
+              mode: HierarchyCacheMode.Memory,
+            },
+          },
+        },
+        rpcs: [IModelReadRpcInterface, PresentationRpcInterface, ECSchemaRpcInterface],
+      });
+      // eslint-disable-next-line @itwin/no-internal
+      ECSchemaRpcImpl.register();
+    });
+
+    afterAll(async () => {
+      await terminateCore();
+    });
+
+    describe("category requests", () => {
+      it("returns element ids for root category elements", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const category = insertSpatialCategory({ txn, codeValue: "category" });
+            const el1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: category.id });
+            const el2 = insertPhysicalElement({ txn, modelId: model.id, categoryId: category.id });
+            return { model, category, el1, el2 };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        const result = await firstValueFrom(
+          cache.getChildElements({ modelId: keys.model.id, categoryId: keys.category.id, childCategoryIds: [keys.category.id] }),
+        );
+        expect(result).toEqual([keys.el1.id, keys.el2.id]);
+        expect(result).toHaveLength(2);
+      });
+
+      it("returns empty array for incorrect model", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const category = insertSpatialCategory({ txn, codeValue: "category" });
+            insertPhysicalElement({ txn, modelId: model.id, categoryId: category.id });
+            return { model, category };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        const result = await firstValueFrom(cache.getChildElements({ modelId: "0x123", categoryId: keys.category.id, childCategoryIds: [keys.category.id] }));
+        expect(result).toEqual([]);
+      });
+
+      it("returns descendant elements including nested children", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const catA = insertSpatialCategory({ txn, codeValue: "catA" });
+            const catB = insertSpatialCategory({ txn, codeValue: "catB" });
+            // root element catA
+            const el1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id });
+            // child catB
+            const el1_1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catB.id, parentId: el1.id });
+            // grandchild catB
+            const el1_1_1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catB.id, parentId: el1_1.id });
+            return { model, catA, catB, el1, el1_1, el1_1_1 };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        const result = await firstValueFrom(cache.getChildElements({ modelId: keys.model.id, categoryId: keys.catA.id, childCategoryIds: [keys.catB.id] }));
+        expect(result).toEqual([keys.el1_1.id, keys.el1_1_1.id]);
+        expect(result).toHaveLength(2);
+      });
+
+      it("returns elements scoped to parentElementId", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const catA = insertSpatialCategory({ txn, codeValue: "catA" });
+            const catB = insertSpatialCategory({ txn, codeValue: "catB" });
+            const el1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id });
+            // direct child of el1 in catA (matches category request)
+            const el1_childA = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id, parentId: el1.id });
+            // el1_childA has a descendant in catB
+            const el1_grandchildB = insertPhysicalElement({ txn, modelId: model.id, categoryId: catB.id, parentId: el1_childA.id });
+            // another root element in catA with its own catB descendant (should not appear)
+            const el2 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id });
+            const el2_childA = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id, parentId: el2.id });
+            insertPhysicalElement({ txn, modelId: model.id, categoryId: catB.id, parentId: el2_childA.id });
+            return { model, catA, catB, el1, el1_childA, el1_grandchildB, el2 };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        // Request: find descendants of catA elements under el1, filter by catB
+        const result = await firstValueFrom(
+          cache.getChildElements({ modelId: keys.model.id, categoryId: keys.catA.id, parentElementId: keys.el1.id, childCategoryIds: [keys.catB.id] }),
+        );
+        expect(result).toEqual([keys.el1_grandchildB.id]);
+      });
+
+      it("returns elements from multiple childCategoryIds", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const catA = insertSpatialCategory({ txn, codeValue: "catA" });
+            const catB = insertSpatialCategory({ txn, codeValue: "catB" });
+            const catC = insertSpatialCategory({ txn, codeValue: "catC" });
+            const el1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id });
+            const childB = insertPhysicalElement({ txn, modelId: model.id, categoryId: catB.id, parentId: el1.id });
+            const childC = insertPhysicalElement({ txn, modelId: model.id, categoryId: catC.id, parentId: el1.id });
+            return { model, catA, catB, catC, el1, childB, childC };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        const result = await firstValueFrom(
+          cache.getChildElements({ modelId: keys.model.id, categoryId: keys.catA.id, childCategoryIds: [keys.catB.id, keys.catC.id] }),
+        );
+        expect(result).toEqual(expect.arrayContaining([keys.childB.id, keys.childC.id]));
+        expect(result).toHaveLength(2);
+      });
+    });
+
+    describe("element requests", () => {
+      it("returns empty array when element has no children", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const category = insertSpatialCategory({ txn, codeValue: "category" });
+            const el = insertPhysicalElement({ txn, modelId: model.id, categoryId: category.id });
+            return { model, category, el };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        const result = await firstValueFrom(
+          cache.getChildElements({ modelId: keys.model.id, parentElementId: keys.el.id, childCategoryIds: [keys.category.id] }),
+        );
+        expect(result).toEqual([]);
+      });
+
+      it("returns all descendant elements in specified child categories", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const catA = insertSpatialCategory({ txn, codeValue: "catA" });
+            const catB = insertSpatialCategory({ txn, codeValue: "catB" });
+            const el1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id });
+            const child1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id, parentId: el1.id });
+            const child2 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catB.id, parentId: el1.id });
+            const grandchild = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id, parentId: child2.id });
+            return { model, catA, catB, el1, child1, child2, grandchild };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        const result = await firstValueFrom(
+          cache.getChildElements({ modelId: keys.model.id, parentElementId: keys.el1.id, childCategoryIds: [keys.catA.id, keys.catB.id] }),
+        );
+        expect(result).toEqual(expect.arrayContaining([keys.child1.id, keys.child2.id, keys.grandchild.id]));
+        expect(result).toHaveLength(3);
+      });
+
+      it("returns only elements in specified childCategoryIds", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+            const catA = insertSpatialCategory({ txn, codeValue: "catA" });
+            const catB = insertSpatialCategory({ txn, codeValue: "catB" });
+            const el1 = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id });
+            const childA = insertPhysicalElement({ txn, modelId: model.id, categoryId: catA.id, parentId: el1.id });
+            insertPhysicalElement({ txn, modelId: model.id, categoryId: catB.id, parentId: el1.id });
+            return { model, catA, catB, el1, childA };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+        const cache = createCache(imodelConnection);
+
+        // Only request catA children
+        const result = await firstValueFrom(cache.getChildElements({ modelId: keys.model.id, parentElementId: keys.el1.id, childCategoryIds: [keys.catA.id] }));
+        expect(result).toEqual([keys.childA.id]);
+      });
+    });
+  });
+});

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/ChildElementsCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/ChildElementsCache.test.ts
@@ -213,8 +213,7 @@ describe("ChildElementsCache", () => {
       // Both requests are served by a single query since they're in the same batch
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
       const params = vi.mocked(vp.iModel.createQueryReader).mock.calls[0][1];
-      const ids = CompressedId64Set.decompressSet((params?.serialize() as any)[1].value);
-
+      const ids = CompressedId64Set.decompressSet((params?.serialize() as any)[2].value);
       expect(ids.has("0x3")).toBe(true);
       expect(ids.has("0x4")).toBe(true);
     });
@@ -240,7 +239,7 @@ describe("ChildElementsCache", () => {
       expect(result2).toEqual(expect.arrayContaining(["0x100"]));
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
       const secondParams = vi.mocked(vp.iModel.createQueryReader).mock.calls[1][1];
-      const secondIds = CompressedId64Set.decompressSet((secondParams?.serialize() as any)[1].value);
+      const secondIds = CompressedId64Set.decompressSet((secondParams?.serialize() as any)[2].value);
       expect(secondIds.has("0x3")).toBe(false); // "0x3" does not appear
       expect(secondIds.has("0x4")).toBe(true); // "0x4" appears
     });

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -121,8 +121,11 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
     getElementsCount: vi.fn(({ categoryId }: { modelId: Id64String; categoryId: Id64String }) => {
       return of(props?.categoryElements?.get(categoryId)?.length ?? 0);
     }),
-    getChildElementsTree: vi.fn(() => {
-      return of(new Map());
+    getDescendantsCounts: vi.fn(() => {
+      return of([]);
+    }),
+    getChildElements: vi.fn(() => {
+      return of([]);
     }),
     getAllChildElementsCount: vi.fn(() => {
       return of(new Map());

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -87,6 +87,7 @@ interface IdsCacheMockProps {
   subjectModels?: Map<Id64String, Id64String[]>;
   modelCategories?: Map<Id64String, Id64Array>;
   categoryElements?: Map<Id64String, Id64Array>;
+  elementChildren?: Map<Id64String, Id64Array>;
 }
 
 export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCache {
@@ -118,8 +119,14 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
       }
       return of(result);
     }),
-    getElementsCount: vi.fn(({ categoryId }: { modelId: Id64String; categoryId: Id64String }) => {
-      return of(props?.categoryElements?.get(categoryId)?.length ?? 0);
+    getElementsCount: vi.fn(({ categoryId, parentElementId }: { modelId: Id64String; categoryId?: Id64String; parentElementId?: Id64String }) => {
+      if (parentElementId) {
+        return of(props?.elementChildren?.get(parentElementId)?.length ?? 0);
+      }
+      if (categoryId) {
+        return of(props?.categoryElements?.get(categoryId)?.length ?? 0);
+      }
+      return of(0);
     }),
     getDescendantsCounts: vi.fn(() => {
       return of([]);

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -134,9 +134,6 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
     getChildElements: vi.fn(() => {
       return of([]);
     }),
-    getAllChildElementsCount: vi.fn(() => {
-      return of(new Map());
-    }),
     getSubModelsUnderElement: vi.fn(() => of([])),
     getSubModels: vi.fn(() => EMPTY),
     hasSubModels: vi.fn(() => of(false)),

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -219,7 +219,6 @@ export function createElementHierarchyNode(props: {
   elementId?: Id64String;
   parentKeys?: Array<InstanceKey | ClassGroupingNodeKey>;
   search?: NonGroupingHierarchyNode["search"];
-  childrenCount?: number;
   topMostParentElementId?: Id64String;
 }): NonGroupingHierarchyNode {
   return {
@@ -237,7 +236,6 @@ export function createElementHierarchyNode(props: {
       isElement: true,
       modelId: props.modelId,
       categoryId: props.categoryId,
-      childrenCount: props.childrenCount !== undefined ? props.childrenCount : 0,
       topMostParentElementId: props.topMostParentElementId ?? props.elementId,
     },
   };
@@ -247,7 +245,6 @@ export function createClassGroupingHierarchyNode({
   parentKeys,
   modelId,
   categoryId,
-  childrenCount,
   ...props
 }: {
   elements: Id64Array;
@@ -257,7 +254,6 @@ export function createClassGroupingHierarchyNode({
   categoryId: Id64String;
   hasDirectNonSearchTargets?: boolean;
   hasSearchTargetAncestor?: boolean;
-  childrenCount?: number;
   topMostParentElementId?: Id64String;
 }): GroupingHierarchyNode & { key: ClassGroupingNodeKey } {
   const className = props.className ?? CLASS_NAME_Element;
@@ -275,7 +271,6 @@ export function createClassGroupingHierarchyNode({
       modelId,
       categoryOfTopMostParentElement: categoryId,
       topMostParentElementId: props.topMostParentElementId,
-      childrenCount: childrenCount !== undefined ? childrenCount : 0,
       ...(props.hasDirectNonSearchTargets ? { hasDirectNonSearchTargets: props.hasDirectNonSearchTargets } : {}),
       ...(props.hasSearchTargetAncestor ? { hasSearchTargetAncestor: props.hasSearchTargetAncestor } : {}),
     },

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeIdsCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeIdsCache.test.ts
@@ -30,7 +30,7 @@ describe("ModelsTreeIdsCache", () => {
     const categoryId = "0x2";
     const elementCount = 3;
     const stub = vi.fn((query: string) => {
-      if (query.includes("Descendants") && query.includes(`Model.Id = ${modelId} AND Category.Id IN (${categoryId}) AND Parent.Id IS NULL `)) {
+      if (query.includes("Descendants") && query.includes(`Model.Id = ${modelId}`)) {
         return [{ modelId, reqParent: null, reqCategory: categoryId, ownCategory: categoryId, cnt: elementCount }];
       }
       throw new Error(`Unexpected query: ${query}`);
@@ -49,7 +49,7 @@ describe("ModelsTreeIdsCache", () => {
     const elementCount1 = 3;
     const elementCount2 = 4;
     const stub = vi.fn((query: string) => {
-      if (query.includes("Descendants") && query.includes(`Model.Id = ${modelId} AND Category.Id IN (${categoryId}, ${categoryId2}) AND Parent.Id IS NULL`)) {
+      if (query.includes("Descendants") && query.includes(`Model.Id = ${modelId}`)) {
         return [
           { modelId, reqParent: null, reqCategory: categoryId, ownCategory: categoryId, cnt: elementCount1 },
           { modelId, reqParent: null, reqCategory: categoryId2, ownCategory: categoryId2, cnt: elementCount2 },

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
@@ -2874,7 +2874,7 @@ describe("ModelsTreeVisibilityHandler", () => {
               [modelId]: "partial",
                 // Only categories of elements without parents are shown in the tree
                 [`${modelId}-${parentCategoryId}`]: "visible",
-                  [parentElementId]: "visible",
+                  [parentElementId]: "partial",
                     [childElementWithDifferentCategoryId]: "hidden",
 
           },
@@ -2920,7 +2920,7 @@ describe("ModelsTreeVisibilityHandler", () => {
             [IModel.rootSubjectId]: "partial",
               [modelId]: "partial",
                 [`${modelId}-${parentCategoryId}`]: "visible",
-                  [parentElementId]: "visible",
+                  [parentElementId]: "partial",
                     [childElementId]: "visible",
                     [childElementWithDifferentCategoryId]: "hidden",
           },
@@ -2978,7 +2978,7 @@ describe("ModelsTreeVisibilityHandler", () => {
             [IModel.rootSubjectId]: "partial",
               [modelId]: "partial",
                 [`${modelId}-${category1Id}`]: "visible",
-                  [parentElementId]: "visible",
+                  [parentElementId]: "partial",
                     [childElementWithDifferentCategoryId]: "hidden",
 
                 [`${modelId}-${category2Id}`]: "hidden",
@@ -3044,7 +3044,7 @@ describe("ModelsTreeVisibilityHandler", () => {
                   [elementWithSharedCategoryId]: "visible",
 
                 [`${modelId}-${parentCategoryId}`]: "hidden",
-                  [parentElementId]: "hidden",
+                  [parentElementId]: "partial",
                     [childElementWithSharedCategoryId]: "visible",
           },
         });
@@ -3097,6 +3097,54 @@ describe("ModelsTreeVisibilityHandler", () => {
                 [`${modelId}-${unrelatedCategoryId}`]: "hidden",
                   [unrelatedParentElementId]: "hidden",
                     [childOfUnrelatedElementId]: "hidden",
+          },
+        });
+      });
+
+      it("parent element visibility is partial when its category is hidden but child element category is visible", async () => {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const parentCategory = insertSpatialCategory({ txn, codeValue: "parentCategory" });
+            const childCategory = insertSpatialCategory({ txn, codeValue: "childCategory" });
+            const model = insertPhysicalModelWithPartition({ txn, codeValue: "model" });
+
+            const parentElement = insertPhysicalElement({ txn, modelId: model.id, categoryId: parentCategory.id });
+            const childElementWithDifferentCategory = insertPhysicalElement({
+              txn,
+              modelId: model.id,
+              categoryId: childCategory.id,
+              parentId: parentElement.id,
+            });
+            return {
+              modelId: model.id,
+              parentCategoryId: parentCategory.id,
+              childCategoryId: childCategory.id,
+              parentElementId: parentElement.id,
+              childElementWithDifferentCategoryId: childElementWithDifferentCategory.id,
+            };
+          }),
+        );
+        const { imodelConnection, modelId, parentCategoryId, childCategoryId, parentElementId, childElementWithDifferentCategoryId } = buildIModelResult;
+        using visibilityTestData = createVisibilityTestData({ imodelConnection });
+        const { handler, viewport, ...props } = visibilityTestData;
+
+        viewport.changeModelDisplay({ modelIds: modelId, display: true });
+        viewport.clearPerModelCategoryOverrides();
+        viewport.changeCategoryDisplay({ categoryIds: parentCategoryId, display: false });
+        viewport.changeCategoryDisplay({ categoryIds: childCategoryId, display: true });
+        viewport.clearNeverDrawn();
+        viewport.clearAlwaysDrawn();
+        await validateModelsTreeHierarchyVisibility({
+          ...props,
+          handler,
+          viewport,
+          // prettier-ignore
+          expectations: {
+            [IModel.rootSubjectId]: "partial",
+              [modelId]: "partial",
+                [`${modelId}-${parentCategoryId}`]: "hidden",
+                  [parentElementId]: "partial",
+                    [childElementWithDifferentCategoryId]: "visible",
           },
         });
       });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -44,6 +44,7 @@ import {
   releaseMainThreadOnItemsCount,
 } from "../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../common/TreeErrors.js";
+import { CategoriesTreeNode } from "./CategoriesTreeNode.js";
 
 import type { Observable, ObservedValueOf, OperatorFunction } from "rxjs";
 import type { GuidString, Id64Array, Id64String, MarkRequired } from "@itwin/core-bentley";
@@ -162,9 +163,11 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
           };
           modelElementsMap.set(child.extendedData?.modelId, modelEntry);
         }
-        assert(child.key.type === "instances");
+        assert(CategoriesTreeNode.isElementNode(child));
         for (const { id } of child.key.instanceKeys) {
           modelEntry.elementIds.add(id);
+          // Pre-warm descendants count cache for grouped element nodes
+          this.#idsCache.storeRequest({ modelId: child.extendedData?.modelId, parentElementId: id });
         }
       }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -168,7 +168,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
         }
       }
 
-      const { hasSearchTargetAncestor, hasDirectNonSearchTargets, childrenCount, searchTargets } = groupingNodeDataFromChildren(node.children);
+      const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
       const firstChild = node.children[0];
       assert(HierarchyNode.isInstancesNode(firstChild));
       return {
@@ -182,8 +182,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
           // add `categoryId` from the first grouped element
           categoryId: firstChild.extendedData?.categoryId,
           modelElementsMap,
-          childrenCount,
-          ...(!!searchTargets?.size ? { searchTargets } : {}),
           ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
           ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
           // `imageId` is assigned to instance nodes at query time, but grouping ones need to
@@ -558,23 +556,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     ];
   }
 
-  private createElementChildrenCountSelector(props: { elementIdSelector: string }): string {
-    return `(
-      WITH RECURSIVE
-        ElementWithParent(id) AS (
-          SELECT e.ECInstanceId
-          FROM ${this.#categoryElementClass} e
-          WHERE e.ECInstanceId = ${props.elementIdSelector}
-          UNION ALL
-          SELECT c.ECInstanceId
-          FROM ${this.#categoryElementClass} c
-          JOIN ElementWithParent p ON p.id = c.Parent.Id
-        )
-      SELECT COUNT(1) - 1
-      FROM ElementWithParent
-    )`;
-  }
-
   private async createCategoryElementsQuery({
     parentNodeInstanceIds: categoryIds,
     instanceFilter,
@@ -648,7 +629,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                 categoryId: { selector: "IdToHex(this.Category.Id)" },
                 imageId: "icon-item",
                 isElement: true,
-                childrenCount: { selector: this.createElementChildrenCountSelector({ elementIdSelector: "this.ECInstanceId" }) },
                 categoryOfTopMostParentElement: { selector: "IdToHex(this.Category.Id)" },
                 topMostParentElementId: { selector: "IdToHex(this.ECInstanceId)" },
               },
@@ -719,7 +699,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                   categoryId: { selector: "IdToHex(this.Category.Id)" },
                   imageId: "icon-item",
                   isElement: true,
-                  childrenCount: { selector: this.createElementChildrenCountSelector({ elementIdSelector: "this.ECInstanceId" }) },
                   categoryOfTopMostParentElement: {
                     selector: `IdToHex(${parentNode.extendedData?.categoryOfTopMostParentElement})`,
                   },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -166,8 +166,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
         assert(CategoriesTreeNode.isElementNode(child));
         for (const { id } of child.key.instanceKeys) {
           modelEntry.elementIds.add(id);
-          // Pre-warm descendants count cache for grouped element nodes
-          this.#idsCache.storeRequest({ modelId: child.extendedData?.modelId, parentElementId: id });
         }
       }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeNodeInternal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeNodeInternal.ts
@@ -44,7 +44,6 @@ export namespace CategoriesTreeNodeInternal {
     extendedData: {
       modelId: Id64String;
       categoryId: Id64String;
-      childrenCount: number;
       categoryOfTopMostParentElement: Id64String;
       topMostParentElementId: Id64String;
     };
@@ -57,8 +56,6 @@ export namespace CategoriesTreeNodeInternal {
       categoryId: Id64String;
       topMostParentElementId?: Id64String;
       modelElementsMap: Map<Id64String, { elementIds: Set<Id64String>; categoryOfTopMostParentElement: Id64String }>;
-      childrenCount: number;
-      searchTargets?: Map<Id64String, { childrenCount: number }>;
     };
   } => CategoriesTreeNode.isElementClassGroupingNode(node);
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -3,31 +3,23 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of, Subject } from "rxjs";
-import { assert, Guid } from "@itwin/core-bentley";
+import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject } from "rxjs";
+import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
 import { HierarchyVisibilityHandlerImpl } from "../../../common/internal/useTreeHooks/UseCachedVisibility.js";
-import {
-  fromWithRelease,
-  getClassesByView,
-  getIdsFromChildrenTree,
-  getParentElementsIdsPath,
-  setDifference,
-  setIntersection,
-} from "../../../common/internal/Utils.js";
+import { fromWithRelease, getClassesByView, getParentElementsIdsPath, setDifference } from "../../../common/internal/Utils.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
 import { CategoriesTreeNodeInternal } from "../../internal/CategoriesTreeNodeInternal.js";
 import { CategoriesTreeVisibilityHelper } from "./CategoriesTreeVisibilityHelper.js";
 import { createCategoriesSearchResultsTree } from "./SearchResultsTree.js";
 
 import type { Observable } from "rxjs";
-import type { Id64Set, Id64String } from "@itwin/core-bentley";
+import type { Id64String } from "@itwin/core-bentley";
 import type { ClassGroupingNodeKey, HierarchyNode, HierarchySearchTree, InstancesNodeKey } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
 import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
-import type { ChildrenTree } from "../../../common/internal/Utils.js";
 import type { SearchResultsTree } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
 import type { TreeSpecificVisibilityHandler } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import type { TreeWidgetViewport } from "../../../common/TreeWidgetViewport.js";
@@ -98,7 +90,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       }
 
       if (elements?.length) {
-        const searchTargetElements = new Array<Id64String>();
+        const searchTargetElements = new Array<{ modelId: Id64String; elementId: Id64String }>();
         const elementIdsSet = new Set<Id64String>();
         const modelCategoryElementMap = new Map<`${ModelId}-${CategoryId}`, Array<ElementId>>();
         // elements is an array that stores elements grouped by:
@@ -117,40 +109,44 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
             mapEntry.push(elementId);
             elementIdsSet.add(elementId);
             if (isSearchTarget) {
-              searchTargetElements.push(elementId);
+              searchTargetElements.push({ modelId, elementId });
             }
           }
         }
         observables.push(
           // Get children for search targets, since non search targets don't have all the children present in the hierarchy.
-          this.#props.idsCache.getChildElementsTree({ elementIds: searchTargetElements }).pipe(
+          from(searchTargetElements).pipe(
+            mergeMap(({ modelId, elementId }) =>
+              forkJoin({
+                modelId: of(modelId),
+                elementId: of(elementId),
+                childCategoryIds: this.#props.idsCache
+                  .getDescendantsCounts({ parentElementId: elementId, modelId })
+                  .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
+              }),
+            ),
+            mergeMap(({ modelId, elementId, childCategoryIds }) =>
+              this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds }),
+            ),
+            reduce((acc, childElements) => {
+              acc.push(...childElements);
+              return acc;
+            }, new Array<ElementId>()),
             // Need to filter out and keep only those children ids that are not part of elements that are present in search paths.
             // Elements in search paths will have their visibility changed directly: they will be provided as elementIds to changeElementsVisibilityStatus.
-            map((childrenTree) => ({
-              childrenNotInSearchPaths: setDifference(getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 }), elementIdsSet),
-              childrenTree,
+            map((childElements) => ({
+              childrenNotInSearchPaths: setDifference(new Set(childElements), elementIdsSet),
             })),
-            mergeMap(({ childrenNotInSearchPaths, childrenTree }) =>
+            mergeMap(({ childrenNotInSearchPaths }) =>
               fromWithRelease({ source: modelCategoryElementMap.entries(), size: modelCategoryElementMap.size, releaseOnCount: 50 }).pipe(
                 mergeMap(([key, elementsInSearchPathsGroupedByModelAndCategory]) => {
                   const [modelId, categoryId] = key.split("-");
-                  const childrenIds = new Set<Id64String>();
-                  // A shared children tree was created, need to get the children for each element in the group.
-                  for (const elementId of elementsInSearchPathsGroupedByModelAndCategory) {
-                    const elementChildrenTree: ChildrenTree | undefined = childrenTree.get(elementId)?.children;
-                    if (!elementChildrenTree) {
-                      continue;
-                    }
-                    for (const childId of getIdsFromChildrenTree({ tree: elementChildrenTree })) {
-                      childrenIds.add(childId);
-                    }
-                  }
                   return this.#visibilityHelper.changeElementsVisibilityStatus({
                     modelId,
                     categoryId,
                     elementIds: elementsInSearchPathsGroupedByModelAndCategory,
                     // Pass only those children that are not part of search paths.
-                    children: setIntersection(childrenIds, childrenNotInSearchPaths),
+                    children: childrenNotInSearchPaths,
                     on,
                   });
                 }),
@@ -266,17 +262,27 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       assert(CategoriesTreeNodeInternal.isElementNode(node));
 
       const elementIds = node.key.instanceKeys.map(({ id }) => id);
-      return this.#props.idsCache.getChildElementsTree({ elementIds }).pipe(
-        map((childrenTree): Id64Set => {
-          // Children tree contains provided elementIds, they are at the root of this tree.
-          // We want to skip them and only get ids of children.
-          return getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 });
-        }),
+      return from(Id64.iterable(elementIds)).pipe(
+        mergeMap((elementId) =>
+          forkJoin({
+            elementId: of(elementId),
+            childCategoryIds: this.#props.idsCache
+              .getDescendantsCounts({ parentElementId: elementId, modelId: node.extendedData.modelId })
+              .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
+          }),
+        ),
+        mergeMap(({ elementId, childCategoryIds }) =>
+          this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId: node.extendedData.modelId, childCategoryIds }),
+        ),
+        reduce((acc, childElements) => {
+          acc.push(...childElements);
+          return acc;
+        }, new Array<ElementId>()),
         mergeMap((children) =>
           this.#visibilityHelper.changeElementsVisibilityStatus({
             elementIds,
             modelId: node.extendedData.modelId,
-            children: children.size > 0 ? children : undefined,
+            children: children.length > 0 ? children : undefined,
             categoryId: node.extendedData.categoryId,
             on,
           }),
@@ -332,21 +338,31 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       }
 
       if (elements?.length) {
-        const searchTargetElements = new Array<Id64String>();
-        for (const { elements: elementsMap } of elements) {
+        const searchTargetElements = new Array<{ elementId: Id64String; modelId: Id64String }>();
+        for (const { elements: elementsMap, modelId } of elements) {
           for (const [elementId, { isSearchTarget }] of elementsMap) {
             if (isSearchTarget) {
-              searchTargetElements.push(elementId);
+              searchTargetElements.push({ elementId, modelId });
             }
           }
         }
         let childrenCountMapObs: Observable<Map<Id64String, number>>;
         if (CategoriesTreeNodeInternal.isElementClassGroupingNode(node)) {
           const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData?.searchTargets;
-          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget));
+          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
           // Only need to request children count for indirect children search targets.
           // Direct children search targets already have children count stored in grouping nodes extended data.
-          childrenCountMapObs = this.#props.idsCache.getAllChildElementsCount({ elementIds: nestedSearchTargetElements }).pipe(
+          childrenCountMapObs = from(nestedSearchTargetElements).pipe(
+            mergeMap(({ elementId, modelId }) =>
+              forkJoin({
+                elementId: of(elementId),
+                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
+              }),
+            ),
+            reduce((acc, { elementId, childrenCount }) => {
+              acc.set(elementId, childrenCount);
+              return acc;
+            }, new Map<Id64String, number>()),
             map((elementCountMap) => {
               // Direct children search targets already have children count stored in grouping nodes extended data.
               for (const [key, value] of node.extendedData.searchTargets ?? []) {
@@ -356,7 +372,18 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
             }),
           );
         } else {
-          childrenCountMapObs = this.#props.idsCache.getAllChildElementsCount({ elementIds: searchTargetElements });
+          childrenCountMapObs = from(searchTargetElements).pipe(
+            mergeMap(({ elementId, modelId }) =>
+              forkJoin({
+                elementId: of(elementId),
+                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
+              }),
+            ),
+            reduce((acc, { elementId, childrenCount }) => {
+              acc.set(elementId, childrenCount);
+              return acc;
+            }, new Map<Id64String, number>()),
+          );
         }
         observables.push(
           childrenCountMapObs.pipe(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -118,35 +118,43 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
           from(searchTargetElements).pipe(
             mergeMap(({ modelId, elementId }) =>
               forkJoin({
-                modelId: of(modelId),
                 elementId: of(elementId),
                 childCategoryIds: this.#props.idsCache
                   .getDescendantsCounts({ parentElementId: elementId, modelId })
                   .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
-              }),
+              }).pipe(
+                mergeMap(({ elementId: eid, childCategoryIds }) =>
+                  this.#props.idsCache
+                    .getChildElements({ parentElementId: eid, modelId, childCategoryIds })
+                    .pipe(map((children) => ({ elementId: eid, children }))),
+                ),
+              ),
             ),
-            mergeMap(({ modelId, elementId, childCategoryIds }) =>
-              this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds }),
-            ),
-            reduce((acc, childElements) => {
-              acc.push(...childElements);
+            reduce((acc, { elementId, children }) => {
+              acc.set(elementId, children);
               return acc;
-            }, new Array<ElementId>()),
-            // Need to filter out and keep only those children ids that are not part of elements that are present in search paths.
-            // Elements in search paths will have their visibility changed directly: they will be provided as elementIds to changeElementsVisibilityStatus.
-            map((childElements) => ({
-              childrenNotInSearchPaths: setDifference(new Set(childElements), elementIdsSet),
-            })),
-            mergeMap(({ childrenNotInSearchPaths }) =>
+            }, new Map<ElementId, Array<ElementId>>()),
+            mergeMap((childrenByElement) =>
               fromWithRelease({ source: modelCategoryElementMap.entries(), size: modelCategoryElementMap.size, releaseOnCount: 50 }).pipe(
                 mergeMap(([key, elementsInSearchPathsGroupedByModelAndCategory]) => {
                   const [modelId, categoryId] = key.split("-");
+                  // Union only the children of elements that belong to this group.
+                  const childrenIds = new Set<Id64String>();
+                  for (const elementId of elementsInSearchPathsGroupedByModelAndCategory) {
+                    const elementChildren = childrenByElement.get(elementId);
+                    if (!elementChildren) {
+                      continue;
+                    }
+                    for (const childId of elementChildren) {
+                      childrenIds.add(childId);
+                    }
+                  }
                   return this.#visibilityHelper.changeElementsVisibilityStatus({
                     modelId,
                     categoryId,
                     elementIds: elementsInSearchPathsGroupedByModelAndCategory,
                     // Pass only those children that are not part of search paths.
-                    children: childrenNotInSearchPaths,
+                    children: setDifference(childrenIds, elementIdsSet),
                     on,
                   });
                 }),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -363,7 +363,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
                       elementIds: searchTargetIds,
                       parentElementsIdsPath,
                       // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
-                      // or at the root, categoryId can be used here here.
+                      // or at the root, categoryId can be used here.
                       categoryOfTopMostParentElement: categoryId,
                     })
                   : EMPTY,
@@ -373,7 +373,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
                       modelId,
                       categoryId,
                       elementIds: nonSearchTargetIds,
-                      ignoreDescendants: true,
+                      computeOnlyOwnStatus: true,
                     })
                   : EMPTY,
               );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -353,12 +353,8 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
           }
         }
         let childrenCountMapObs: Observable<Map<Id64String, number>>;
-        if (CategoriesTreeNodeInternal.isElementClassGroupingNode(node)) {
-          const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData?.searchTargets;
-          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
-          // Only need to request children count for indirect children search targets.
-          // Direct children search targets already have children count stored in grouping nodes extended data.
-          childrenCountMapObs = from(nestedSearchTargetElements).pipe(
+        const getChildrenCountMapObs = (elementsWithModels: Array<{ elementId: Id64String; modelId: Id64String }>) => {
+          return from(elementsWithModels).pipe(
             mergeMap(({ elementId, modelId }) =>
               forkJoin({
                 elementId: of(elementId),
@@ -369,6 +365,15 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
               acc.set(elementId, childrenCount);
               return acc;
             }, new Map<Id64String, number>()),
+          );
+        };
+
+        if (CategoriesTreeNodeInternal.isElementClassGroupingNode(node)) {
+          const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData?.searchTargets;
+          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
+          // Only need to request children count for indirect children search targets.
+          // Direct children search targets already have children count stored in grouping nodes extended data.
+          childrenCountMapObs = getChildrenCountMapObs(nestedSearchTargetElements).pipe(
             map((elementCountMap) => {
               // Direct children search targets already have children count stored in grouping nodes extended data.
               for (const [key, value] of node.extendedData.searchTargets ?? []) {
@@ -378,18 +383,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
             }),
           );
         } else {
-          childrenCountMapObs = from(searchTargetElements).pipe(
-            mergeMap(({ elementId, modelId }) =>
-              forkJoin({
-                elementId: of(elementId),
-                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
-              }),
-            ),
-            reduce((acc, { elementId, childrenCount }) => {
-              acc.set(elementId, childrenCount);
-              return acc;
-            }, new Map<Id64String, number>()),
-          );
+          childrenCountMapObs = getChildrenCountMapObs(searchTargetElements);
         }
         observables.push(
           childrenCountMapObs.pipe(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject } from "rxjs";
+import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject, toArray } from "rxjs";
 import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
@@ -282,10 +282,8 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
         mergeMap(({ elementId, childCategoryIds }) =>
           this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId: node.extendedData.modelId, childCategoryIds }),
         ),
-        reduce((acc, childElements) => {
-          acc.push(...childElements);
-          return acc;
-        }, new Array<ElementId>()),
+        toArray(),
+        map((childElements) => ([] as ElementId[]).concat(...childElements)),
         mergeMap((children) =>
           this.#visibilityHelper.changeElementsVisibilityStatus({
             elementIds,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -16,7 +16,7 @@ import { createCategoriesSearchResultsTree } from "./SearchResultsTree.js";
 
 import type { Observable } from "rxjs";
 import type { Id64String } from "@itwin/core-bentley";
-import type { ClassGroupingNodeKey, HierarchyNode, HierarchySearchTree, InstancesNodeKey } from "@itwin/presentation-hierarchies";
+import type { HierarchyNode, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
 import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
@@ -178,7 +178,6 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
         categoryId: node.extendedData.categoryId,
         modelElementsMap: node.extendedData.modelElementsMap,
         parentKeys: node.parentKeys,
-        childrenCount: node.extendedData.childrenCount,
         topMostParentElementId: node.extendedData.topMostParentElementId,
       });
     }
@@ -219,7 +218,6 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       modelId: node.extendedData.modelId,
       categoryId: node.extendedData.categoryId,
       parentElementsIdsPath,
-      childrenCount: node.extendedData.childrenCount,
       categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
     });
   }
@@ -302,12 +300,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
     return changeObs;
   }
 
-  public getSearchTargetsVisibilityStatus(
-    targets: CategoriesTreeSearchTargets,
-    node: HierarchyNode & {
-      key: ClassGroupingNodeKey | InstancesNodeKey;
-    },
-  ): Observable<VisibilityStatus> {
+  public getSearchTargetsVisibilityStatus(targets: CategoriesTreeSearchTargets): Observable<VisibilityStatus> {
     if (this.#props.viewport.viewType === "other") {
       return of(createVisibilityStatus("disabled"));
     }
@@ -344,104 +337,47 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       }
 
       if (elements?.length) {
-        const searchTargetElements = new Array<{ elementId: Id64String; modelId: Id64String }>();
-        for (const { elements: elementsMap, modelId } of elements) {
-          for (const [elementId, { isSearchTarget }] of elementsMap) {
-            if (isSearchTarget) {
-              searchTargetElements.push({ elementId, modelId });
-            }
-          }
-        }
-        let childrenCountMapObs: Observable<Map<Id64String, number>>;
-        const getChildrenCountMapObs = (elementsWithModels: Array<{ elementId: Id64String; modelId: Id64String }>) => {
-          return from(elementsWithModels).pipe(
-            mergeMap(({ elementId, modelId }) =>
-              forkJoin({
-                elementId: of(elementId),
-                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
-              }),
-            ),
-            reduce((acc, { elementId, childrenCount }) => {
-              acc.set(elementId, childrenCount);
-              return acc;
-            }, new Map<Id64String, number>()),
-          );
-        };
-
-        if (CategoriesTreeNodeInternal.isElementClassGroupingNode(node)) {
-          const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData?.searchTargets;
-          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
-          // Only need to request children count for indirect children search targets.
-          // Direct children search targets already have children count stored in grouping nodes extended data.
-          childrenCountMapObs = getChildrenCountMapObs(nestedSearchTargetElements).pipe(
-            map((elementCountMap) => {
-              // Direct children search targets already have children count stored in grouping nodes extended data.
-              for (const [key, value] of node.extendedData.searchTargets ?? []) {
-                elementCountMap.set(key, value.childrenCount);
-              }
-              return elementCountMap;
-            }),
-          );
-        } else {
-          childrenCountMapObs = getChildrenCountMapObs(searchTargetElements);
-        }
         observables.push(
-          childrenCountMapObs.pipe(
-            mergeMap((elementsChildrenCountMap) =>
-              fromWithRelease({ source: elements, releaseOnCount: 50 }).pipe(
-                mergeMap(({ modelId, elements: elementsMap, categoryId, pathToElements, topMostParentElementId }) => {
-                  const parentElementsIdsPath = topMostParentElementId
-                    ? getParentElementsIdsPath({
-                        parentInstanceKeys: pathToElements.map((instanceKey) => [instanceKey]),
-                        topMostParentElementId,
-                      })
-                    : [];
-                  let totalSearchTargetsChildrenCount = 0;
-                  const nonSearchTargetIds = new Array<Id64String>();
-                  const searchTargetIds = new Array<Id64String>();
-                  for (const [elementId, { isSearchTarget }] of elementsMap) {
-                    if (!isSearchTarget) {
-                      nonSearchTargetIds.push(elementId);
-                      continue;
-                    }
-                    searchTargetIds.push(elementId);
-                    const childCount = elementsChildrenCountMap.get(elementId);
-                    if (childCount) {
-                      totalSearchTargetsChildrenCount += childCount;
-                    }
-                  }
-                  return merge(
-                    searchTargetIds.length > 0
-                      ? this.#visibilityHelper.getElementsVisibilityStatus({
-                          modelId,
-                          categoryId,
-                          elementIds: searchTargetIds,
-                          parentElementsIdsPath,
-                          childrenCount: totalSearchTargetsChildrenCount,
-                          // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
-                          // or at the root, categoryId can be used here here.
-                          categoryOfTopMostParentElement: categoryId,
-                        })
-                      : EMPTY,
-                    // Set childrenCount to undefined for non search targets, as some of their child elements might be filtered out.
-                    // Since childrenCount is set to undefined, these elements won't check child always/never drawn child elements status.
-                    // Child always/never drawn elements will be in search paths, and their visibility status will be handled separately.
-                    nonSearchTargetIds.length > 0
-                      ? this.#visibilityHelper.getElementsVisibilityStatus({
-                          modelId,
-                          categoryId,
-                          elementIds: nonSearchTargetIds,
-                          parentElementsIdsPath,
-                          childrenCount: undefined,
-                          // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
-                          // or at the root, categoryId can be used here here.
-                          categoryOfTopMostParentElement: categoryId,
-                        })
-                      : EMPTY,
-                  ).pipe(mergeVisibilityStatuses());
-                }),
-              ),
-            ),
+          fromWithRelease({ source: elements, releaseOnCount: 50 }).pipe(
+            mergeMap(({ modelId, elements: elementsMap, categoryId, pathToElements, topMostParentElementId }) => {
+              const parentElementsIdsPath = topMostParentElementId
+                ? getParentElementsIdsPath({
+                    parentInstanceKeys: pathToElements.map((instanceKey) => [instanceKey]),
+                    topMostParentElementId,
+                  })
+                : [];
+              const nonSearchTargetIds = new Array<Id64String>();
+              const searchTargetIds = new Array<Id64String>();
+              for (const [elementId, { isSearchTarget }] of elementsMap) {
+                if (!isSearchTarget) {
+                  nonSearchTargetIds.push(elementId);
+                  continue;
+                }
+                searchTargetIds.push(elementId);
+              }
+              return merge(
+                searchTargetIds.length > 0
+                  ? this.#visibilityHelper.getElementsVisibilityStatus({
+                      modelId,
+                      categoryId,
+                      elementIds: searchTargetIds,
+                      parentElementsIdsPath,
+                      // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
+                      // or at the root, categoryId can be used here here.
+                      categoryOfTopMostParentElement: categoryId,
+                    })
+                  : EMPTY,
+                // Child always/never drawn elements will be in search paths, and their visibility status will be handled separately.
+                nonSearchTargetIds.length > 0
+                  ? this.#visibilityHelper.getElementsVisibilityStatus({
+                      modelId,
+                      categoryId,
+                      elementIds: nonSearchTargetIds,
+                      ignoreDescendants: true,
+                    })
+                  : EMPTY,
+              );
+            }),
           ),
         );
       }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -67,7 +67,6 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
     modelElementsMap: Map<ModelId, { elementIds: Set<ElementId>; categoryOfTopMostParentElement: CategoryId }>;
     categoryId: Id64String;
     parentKeys: HierarchyNodeKey[];
-    childrenCount: number;
     topMostParentElementId?: ElementId;
   }): Observable<VisibilityStatus> {
     const { modelElementsMap, categoryId, topMostParentElementId } = props;
@@ -83,7 +82,6 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
                 topMostParentElementId,
               })
             : [],
-          childrenCount: props.childrenCount,
           categoryOfTopMostParentElement,
         }),
       ),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { bufferCount, concat, concatMap, delay, EMPTY, from, map, mergeAll, mergeMap, toArray } from "rxjs";
+import { bufferCount, concat, concatMap, delay, EMPTY, forkJoin, from, map, mergeAll, mergeMap, of, reduce, toArray } from "rxjs";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
-import { getIdsFromChildrenTree, getOptimalBatchSize, getParentElementsIdsPath } from "../../../common/internal/Utils.js";
+import { getOptimalBatchSize, getParentElementsIdsPath } from "../../../common/internal/Utils.js";
 import { BaseVisibilityHelper } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
 
@@ -124,25 +124,31 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
     categoryId: Id64String;
     on: boolean;
   }): Observable<void> {
-    const elementIds = new Array<ElementId>();
-    for (const { elementIds: ids } of props.modelElementsMap.values()) {
-      for (const id of ids) {
-        elementIds.push(id);
-      }
-    }
-    return this.#props.idsCache.getChildElementsTree({ elementIds }).pipe(
-      map((childrenTree) => getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 })),
-      mergeMap((children) =>
-        from(props.modelElementsMap).pipe(
-          mergeMap(([modelId, { elementIds: modelElementIds }]) => {
-            return this.changeElementsVisibilityStatus({
+    return from(props.modelElementsMap).pipe(
+      mergeMap(([modelId, { elementIds: modelElementIds }]) =>
+        from(modelElementIds).pipe(
+          mergeMap((elementId) =>
+            forkJoin({
+              elementId: of(elementId),
+              childCategoryIds: this.#props.idsCache
+                .getDescendantsCounts({ parentElementId: elementId, modelId })
+                .pipe(map((counts) => counts.map((entry) => entry.categoryId))),
+            }),
+          ),
+          mergeMap(({ elementId, childCategoryIds }) => this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds })),
+          reduce((acc, childElements) => {
+            acc.push(...childElements);
+            return acc;
+          }, new Array<ElementId>()),
+          mergeMap((children) =>
+            this.changeElementsVisibilityStatus({
               modelId,
               elementIds: modelElementIds,
               categoryId: props.categoryId,
               on: props.on,
               children,
-            });
-          }),
+            }),
+          ),
         ),
       ),
     );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -20,6 +20,7 @@ import {
 import { catchBeSQLiteInterrupts } from "../common/internal/UseErrorState.js";
 import { fromWithRelease, getOptimalBatchSize, releaseMainThreadOnItemsCount } from "../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../common/TreeErrors.js";
+import { ClassificationsTreeNode } from "./ClassificationsTreeNode.js";
 
 import type { Observable, ObservedValueOf, OperatorFunction } from "rxjs";
 import type { GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
@@ -32,6 +33,7 @@ import type {
   HierarchyNodeIdentifiersPath,
   InstancesNodeKey,
   LimitingECSqlQueryExecutor,
+  NodePostProcessor,
   NodesQueryClauseFactory,
 } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector, ECSchemaProvider, ECSqlQueryRow, IInstanceLabelSelectClauseFactory, InstanceKey } from "@itwin/presentation-shared";
@@ -79,6 +81,18 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
   #impl: HierarchyDefinition;
   #props: ClassificationsTreeDefinitionProps;
   static #componentName = "ClassificationsTreeDefinition";
+  public postProcessNode: NodePostProcessor = async ({ node }) => {
+    // Pre-warm descendants count cache for element nodes
+    if (ClassificationsTreeNode.isGeometricElementNode(node)) {
+      for (const { id, imodelKey } of node.key.instanceKeys) {
+        if (!imodelKey) {
+          continue;
+        }
+        this.#props.getIdsCache(imodelKey).storeRequest({ modelId: node.extendedData.modelId, categoryId: id });
+      }
+    }
+    return node;
+  };
 
   public constructor(props: ClassificationsTreeDefinitionProps) {
     this.#props = props;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -358,24 +358,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
         type: elementClassName,
         modelId: { selector: "IdToHex(this.Model.Id)" },
         categoryId: { selector: "IdToHex(this.Category.Id)" },
-        childrenCount: {
-          selector: `
-            (
-              WITH RECURSIVE
-                ElementWithParent(id) AS (
-                  SELECT e.ECInstanceId
-                  FROM ${CLASS_NAME_GeometricElement3d} e
-                  WHERE e.ECInstanceId = this.ECInstanceId
-                  UNION ALL
-                  SELECT c.ECInstanceId
-                  FROM ${CLASS_NAME_GeometricElement3d} c
-                  JOIN ElementWithParent p ON p.id = c.Parent.Id
-                )
-              SELECT COUNT(1) - 1
-              FROM ElementWithParent
-            )
-          `,
-        },
         categoryOfTopMostParentElement: {
           selector: `IdToHex(${categoryOfTopMostParentElement ?? "this.Category.Id"})`,
         },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -20,7 +20,6 @@ import {
 import { catchBeSQLiteInterrupts } from "../common/internal/UseErrorState.js";
 import { fromWithRelease, getOptimalBatchSize, releaseMainThreadOnItemsCount } from "../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../common/TreeErrors.js";
-import { ClassificationsTreeNode } from "./ClassificationsTreeNode.js";
 
 import type { Observable, ObservedValueOf, OperatorFunction } from "rxjs";
 import type { GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
@@ -33,7 +32,6 @@ import type {
   HierarchyNodeIdentifiersPath,
   InstancesNodeKey,
   LimitingECSqlQueryExecutor,
-  NodePostProcessor,
   NodesQueryClauseFactory,
 } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector, ECSchemaProvider, ECSqlQueryRow, IInstanceLabelSelectClauseFactory, InstanceKey } from "@itwin/presentation-shared";
@@ -81,18 +79,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
   #impl: HierarchyDefinition;
   #props: ClassificationsTreeDefinitionProps;
   static #componentName = "ClassificationsTreeDefinition";
-  public postProcessNode: NodePostProcessor = async ({ node }) => {
-    // Pre-warm descendants count cache for element nodes
-    if (ClassificationsTreeNode.isGeometricElementNode(node)) {
-      for (const { id, imodelKey } of node.key.instanceKeys) {
-        if (!imodelKey) {
-          continue;
-        }
-        this.#props.getIdsCache(imodelKey).storeRequest({ modelId: node.extendedData.modelId, categoryId: id });
-      }
-    }
-    return node;
-  };
 
   public constructor(props: ClassificationsTreeDefinitionProps) {
     this.#props = props;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeNodeInternal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeNodeInternal.ts
@@ -26,7 +26,6 @@ export namespace ClassificationsTreeNodeInternal {
     extendedData: {
       modelId: Id64String;
       categoryId: Id64String;
-      childrenCount: number;
       categoryOfTopMostParentElement: Id64String;
       topMostParentElementId: Id64String;
     };

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -183,7 +183,6 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
       modelId: node.extendedData.modelId,
       categoryId: node.extendedData.categoryId,
       parentElementsIdsPath,
-      childrenCount: node.extendedData.childrenCount,
       categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
     });
   }
@@ -268,76 +267,44 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
   }: {
     elements: Required<ClassificationsTreeSearchTargets>["elements"];
   }): Observable<VisibilityStatus> {
-    const searchTargetElements = new Array<{ elementId: Id64String; modelId: Id64String }>();
-    for (const { elements: elementsMap, modelId } of elements) {
-      for (const [elementId, { isSearchTarget }] of elementsMap) {
-        if (isSearchTarget) {
-          searchTargetElements.push({ elementId, modelId });
+    return fromWithRelease({ source: elements, releaseOnCount: 50 }).pipe(
+      mergeMap(({ modelId, categoryId, elements: elementsMap, pathToElements, categoryOfTopMostParentElement, topMostParentElementId }) => {
+        const parentElementsIdsPath = topMostParentElementId
+          ? getParentElementsIdsPath({
+              parentInstanceKeys: pathToElements.map((instanceKey) => [instanceKey]),
+              topMostParentElementId,
+            })
+          : [];
+        const nonSearchTargetIds = new Array<Id64String>();
+        const searchTargetIds = new Array<Id64String>();
+        for (const [elementId, { isSearchTarget }] of elementsMap) {
+          if (!isSearchTarget) {
+            nonSearchTargetIds.push(elementId);
+            continue;
+          }
+          searchTargetIds.push(elementId);
         }
-      }
-    }
-    return from(searchTargetElements).pipe(
-      mergeMap(({ elementId, modelId }) =>
-        forkJoin({
-          elementId: of(elementId),
-          childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
-        }),
-      ),
-      reduce((acc, { elementId, childrenCount }) => {
-        acc.set(elementId, childrenCount);
-        return acc;
-      }, new Map<Id64String, number>()),
-      mergeMap((elementsChildrenCountMap) =>
-        fromWithRelease({ source: elements, releaseOnCount: 50 }).pipe(
-          mergeMap(({ modelId, categoryId, elements: elementsMap, pathToElements, categoryOfTopMostParentElement, topMostParentElementId }) => {
-            const parentElementsIdsPath = topMostParentElementId
-              ? getParentElementsIdsPath({
-                  parentInstanceKeys: pathToElements.map((instanceKey) => [instanceKey]),
-                  topMostParentElementId,
-                })
-              : [];
-            let totalSearchTargetsChildrenCount = 0;
-            const nonSearchTargetIds = new Array<Id64String>();
-            const searchTargetIds = new Array<Id64String>();
-            for (const [elementId, { isSearchTarget }] of elementsMap) {
-              if (!isSearchTarget) {
-                nonSearchTargetIds.push(elementId);
-                continue;
-              }
-              searchTargetIds.push(elementId);
-              const childCount = elementsChildrenCountMap.get(elementId);
-              if (childCount) {
-                totalSearchTargetsChildrenCount += childCount;
-              }
-            }
-            return merge(
-              searchTargetIds.length > 0
-                ? this.#visibilityHelper.getElementsVisibilityStatus({
-                    modelId,
-                    categoryId,
-                    elementIds: searchTargetIds,
-                    parentElementsIdsPath,
-                    childrenCount: totalSearchTargetsChildrenCount,
-                    categoryOfTopMostParentElement,
-                  })
-                : EMPTY,
-              // Set childrenCount to undefined for non search targets, as some of their child elements might be filtered out.
-              // Since childrenCount is set to undefined, these elements won't check child always/never drawn child elements status.
-              // Child always/never drawn elements will be in search paths, and their visibility status will be handled separately.
-              nonSearchTargetIds.length > 0
-                ? this.#visibilityHelper.getElementsVisibilityStatus({
-                    modelId,
-                    categoryId,
-                    elementIds: nonSearchTargetIds,
-                    parentElementsIdsPath,
-                    childrenCount: undefined,
-                    categoryOfTopMostParentElement,
-                  })
-                : EMPTY,
-            ).pipe(mergeVisibilityStatuses());
-          }),
-        ),
-      ),
+        return merge(
+          searchTargetIds.length > 0
+            ? this.#visibilityHelper.getElementsVisibilityStatus({
+                modelId,
+                categoryId,
+                elementIds: searchTargetIds,
+                parentElementsIdsPath,
+                categoryOfTopMostParentElement,
+              })
+            : EMPTY,
+          // Child always/never drawn elements will be in search paths, and their visibility status will be handled separately.
+          nonSearchTargetIds.length > 0
+            ? this.#visibilityHelper.getElementsVisibilityStatus({
+                modelId,
+                categoryId,
+                elementIds: nonSearchTargetIds,
+                ignoreDescendants: true,
+              })
+            : EMPTY,
+        );
+      }),
     );
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -300,7 +300,7 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
                 modelId,
                 categoryId,
                 elementIds: nonSearchTargetIds,
-                ignoreDescendants: true,
+                computeOnlyOwnStatus: true,
               })
             : EMPTY,
         );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -3,24 +3,23 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of, Subject } from "rxjs";
-import { assert, Guid } from "@itwin/core-bentley";
+import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject } from "rxjs";
+import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
 import { HierarchyVisibilityHandlerImpl } from "../../../common/internal/useTreeHooks/UseCachedVisibility.js";
-import { fromWithRelease, getIdsFromChildrenTree, getParentElementsIdsPath, setDifference, setIntersection } from "../../../common/internal/Utils.js";
+import { fromWithRelease, getParentElementsIdsPath, setDifference } from "../../../common/internal/Utils.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
 import { ClassificationsTreeNodeInternal } from "../ClassificationsTreeNodeInternal.js";
 import { ClassificationsTreeVisibilityHelper } from "./ClassificationsTreeVisibilityHelper.js";
 import { createClassificationsSearchResultsTree } from "./SearchResultsTree.js";
 
 import type { Observable } from "rxjs";
-import type { Id64Set, Id64String } from "@itwin/core-bentley";
+import type { Id64String } from "@itwin/core-bentley";
 import type { HierarchyNode, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
 import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
-import type { ChildrenTree } from "../../../common/internal/Utils.js";
 import type { SearchResultsTree } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
 import type { TreeSpecificVisibilityHandler } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import type { TreeWidgetViewport } from "../../../common/TreeWidgetViewport.js";
@@ -89,7 +88,7 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
     elements: Required<ClassificationsTreeSearchTargets>["elements"];
     on: boolean;
   }): Observable<void> {
-    const searchTargetElements = new Array<Id64String>();
+    const searchTargetElements = new Array<{ modelId: Id64String; elementId: Id64String }>();
     const elementIdsSet = new Set<Id64String>();
     const modelCategoryElementMap = new Map<`${ModelId}-${CategoryId}`, Array<ElementId>>();
     // elements is an array that stores elements grouped by:
@@ -108,39 +107,41 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
         mapEntry.push(elementId);
         elementIdsSet.add(elementId);
         if (isSearchTarget) {
-          searchTargetElements.push(elementId);
+          searchTargetElements.push({ modelId, elementId });
         }
       }
     }
     // Get children for search targets, since non search targets don't have all the children present in the hierarchy.
-    return this.#props.idsCache.getChildElementsTree({ elementIds: searchTargetElements }).pipe(
+    return from(searchTargetElements).pipe(
+      mergeMap(({ modelId, elementId }) =>
+        forkJoin({
+          modelId: of(modelId),
+          elementId: of(elementId),
+          childCategoryIds: this.#props.idsCache
+            .getDescendantsCounts({ parentElementId: elementId, modelId })
+            .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
+        }),
+      ),
+      mergeMap(({ modelId, elementId, childCategoryIds }) => this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds })),
+      reduce((acc, childElements) => {
+        acc.push(...childElements);
+        return acc;
+      }, new Array<ElementId>()),
       // Need to filter out and keep only those children ids that are not part of elements that are present in search paths.
       // Elements in search paths will have their visibility changed directly: they will be provided as elementIds to changeElementsVisibilityStatus.
-      map((childrenTree) => ({
-        childrenNotInSearchPaths: setDifference(getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 }), elementIdsSet),
-        childrenTree,
+      map((childElements) => ({
+        childrenNotInSearchPaths: setDifference(new Set(childElements), elementIdsSet),
       })),
-      mergeMap(({ childrenNotInSearchPaths, childrenTree }) =>
+      mergeMap(({ childrenNotInSearchPaths }) =>
         fromWithRelease({ source: modelCategoryElementMap.entries(), size: modelCategoryElementMap.size, releaseOnCount: 50 }).pipe(
           mergeMap(([key, elementsInSearchPathsGroupedByModelAndCategory]) => {
             const [modelId, categoryId] = key.split("-");
-            const childrenIds = new Set<Id64String>();
-            // A shared children tree was created, need to get the children for each element in the group.
-            for (const elementId of elementsInSearchPathsGroupedByModelAndCategory) {
-              const elementChildrenTree: ChildrenTree | undefined = childrenTree.get(elementId)?.children;
-              if (!elementChildrenTree) {
-                continue;
-              }
-              for (const childId of getIdsFromChildrenTree({ tree: elementChildrenTree })) {
-                childrenIds.add(childId);
-              }
-            }
             return this.#visibilityHelper.changeElementsVisibilityStatus({
               modelId,
               categoryId,
               elementIds: elementsInSearchPathsGroupedByModelAndCategory,
               // Pass only those children that are not part of search paths.
-              children: setIntersection(childrenIds, childrenNotInSearchPaths),
+              children: childrenNotInSearchPaths,
               on,
             });
           }),
@@ -200,18 +201,28 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
       }
       assert(ClassificationsTreeNodeInternal.isGeometricElementNode(node));
       const elementIds = node.key.instanceKeys.map(({ id }) => id);
-      return this.#props.idsCache.getChildElementsTree({ elementIds }).pipe(
-        map((childrenTree): Id64Set => {
-          // Children tree contains provided elementIds, they are at the root of this tree.
-          // We want to skip them and only get ids of children.
-          return getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 });
-        }),
+      return from(Id64.iterable(elementIds)).pipe(
+        mergeMap((elementId) =>
+          forkJoin({
+            elementId: of(elementId),
+            childCategoryIds: this.#props.idsCache
+              .getDescendantsCounts({ parentElementId: elementId, modelId: node.extendedData.modelId })
+              .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
+          }),
+        ),
+        mergeMap(({ elementId, childCategoryIds }) =>
+          this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId: node.extendedData.modelId, childCategoryIds }),
+        ),
+        reduce((acc, childElements) => {
+          acc.push(...childElements);
+          return acc;
+        }, new Array<ElementId>()),
         mergeMap((children) =>
           this.#visibilityHelper.changeElementsVisibilityStatus({
             elementIds,
             modelId: node.extendedData.modelId,
             categoryId: node.extendedData.categoryId,
-            children: children.size > 0 ? children : undefined,
+            children: children.length > 0 ? children : undefined,
             on,
           }),
         ),
@@ -251,15 +262,25 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
   }: {
     elements: Required<ClassificationsTreeSearchTargets>["elements"];
   }): Observable<VisibilityStatus> {
-    const searchTargetElements = new Array<Id64String>();
-    for (const { elements: elementsMap } of elements) {
+    const searchTargetElements = new Array<{ elementId: Id64String; modelId: Id64String }>();
+    for (const { elements: elementsMap, modelId } of elements) {
       for (const [elementId, { isSearchTarget }] of elementsMap) {
         if (isSearchTarget) {
-          searchTargetElements.push(elementId);
+          searchTargetElements.push({ elementId, modelId });
         }
       }
     }
-    return this.#props.idsCache.getAllChildElementsCount({ elementIds: searchTargetElements }).pipe(
+    return from(searchTargetElements).pipe(
+      mergeMap(({ elementId, modelId }) =>
+        forkJoin({
+          elementId: of(elementId),
+          childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
+        }),
+      ),
+      reduce((acc, { elementId, childrenCount }) => {
+        acc.set(elementId, childrenCount);
+        return acc;
+      }, new Map<Id64String, number>()),
       mergeMap((elementsChildrenCountMap) =>
         fromWithRelease({ source: elements, releaseOnCount: 50 }).pipe(
           mergeMap(({ modelId, categoryId, elements: elementsMap, pathToElements, categoryOfTopMostParentElement, topMostParentElementId }) => {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -115,33 +115,41 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
     return from(searchTargetElements).pipe(
       mergeMap(({ modelId, elementId }) =>
         forkJoin({
-          modelId: of(modelId),
           elementId: of(elementId),
           childCategoryIds: this.#props.idsCache
             .getDescendantsCounts({ parentElementId: elementId, modelId })
             .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
-        }),
+        }).pipe(
+          mergeMap(({ elementId: eid, childCategoryIds }) =>
+            this.#props.idsCache.getChildElements({ parentElementId: eid, modelId, childCategoryIds }).pipe(map((children) => ({ elementId: eid, children }))),
+          ),
+        ),
       ),
-      mergeMap(({ modelId, elementId, childCategoryIds }) => this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds })),
-      reduce((acc, childElements) => {
-        acc.push(...childElements);
+      reduce((acc, { elementId, children }) => {
+        acc.set(elementId, children);
         return acc;
-      }, new Array<ElementId>()),
-      // Need to filter out and keep only those children ids that are not part of elements that are present in search paths.
-      // Elements in search paths will have their visibility changed directly: they will be provided as elementIds to changeElementsVisibilityStatus.
-      map((childElements) => ({
-        childrenNotInSearchPaths: setDifference(new Set(childElements), elementIdsSet),
-      })),
-      mergeMap(({ childrenNotInSearchPaths }) =>
+      }, new Map<ElementId, Array<ElementId>>()),
+      mergeMap((childrenByElement) =>
         fromWithRelease({ source: modelCategoryElementMap.entries(), size: modelCategoryElementMap.size, releaseOnCount: 50 }).pipe(
           mergeMap(([key, elementsInSearchPathsGroupedByModelAndCategory]) => {
             const [modelId, categoryId] = key.split("-");
+            // Union only the children of elements that belong to this group.
+            const childrenIds = new Set<Id64String>();
+            for (const elementId of elementsInSearchPathsGroupedByModelAndCategory) {
+              const elementChildren = childrenByElement.get(elementId);
+              if (!elementChildren) {
+                continue;
+              }
+              for (const childId of elementChildren) {
+                childrenIds.add(childId);
+              }
+            }
             return this.#visibilityHelper.changeElementsVisibilityStatus({
               modelId,
               categoryId,
               elementIds: elementsInSearchPathsGroupedByModelAndCategory,
               // Pass only those children that are not part of search paths.
-              children: childrenNotInSearchPaths,
+              children: setDifference(childrenIds, elementIdsSet),
               on,
             });
           }),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject } from "rxjs";
+import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject, toArray } from "rxjs";
 import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
@@ -221,10 +221,8 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
         mergeMap(({ elementId, childCategoryIds }) =>
           this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId: node.extendedData.modelId, childCategoryIds }),
         ),
-        reduce((acc, childElements) => {
-          acc.push(...childElements);
-          return acc;
-        }, new Array<ElementId>()),
+        toArray(),
+        map((childElements) => ([] as ElementId[]).concat(...childElements)),
         mergeMap((children) =>
           this.#visibilityHelper.changeElementsVisibilityStatus({
             elementIds,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Utils.ts
@@ -6,7 +6,7 @@
 import { useEffect, useRef } from "react";
 import { bufferCount, concatAll, concatMap, delay, from, of } from "rxjs";
 import { assert, Id64 } from "@itwin/core-bentley";
-import { HierarchyNodeKey, ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
+import { ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
 import {
   CLASS_NAME_DrawingCategory,
   CLASS_NAME_GeometricElement2d,
@@ -229,44 +229,25 @@ export function groupingNodeDataFromChildren(children: ProcessedHierarchyNode[])
   | {
       hasSearchTargetAncestor: true;
       hasDirectNonSearchTargets: undefined;
-      childrenCount: number;
-      searchTargets: undefined;
     }
   | {
       hasSearchTargetAncestor: false;
       hasDirectNonSearchTargets: boolean;
-      childrenCount: number;
-      searchTargets: Map<Id64String, { childrenCount: number }>;
     } {
-  let childrenCount = 0;
-  const searchTargets = new Map<Id64String, { childrenCount: number }>();
-  let hasDirectNonSearchTargets = false;
-  let hasSearchTargetAncestor = false;
+  if (children.length > 0) {
+    assert(!ProcessedHierarchyNode.isGroupingNode(children[0]), "Expected only non-grouping nodes as children");
+    if (children[0].search?.hasSearchTargetAncestor) {
+      return { hasSearchTargetAncestor: true, hasDirectNonSearchTargets: undefined };
+    }
+  }
   for (const child of children) {
     assert(!ProcessedHierarchyNode.isGroupingNode(child), "Expected only non-grouping nodes as children");
-    if (child.extendedData?.childrenCount) {
-      childrenCount += child.extendedData.childrenCount;
-    }
-    if (!hasSearchTargetAncestor && child.search) {
-      if (child.search.hasSearchTargetAncestor) {
-        hasSearchTargetAncestor = true;
-        continue;
-      }
-      if (!child.search.isSearchTarget) {
-        hasDirectNonSearchTargets = true;
-        if (!child.search.childrenTargetPaths?.length || child.search.isSearchTarget) {
-          assert(HierarchyNodeKey.isInstances(child.key));
-          for (const key of child.key.instanceKeys) {
-            searchTargets.set(key.id, { childrenCount: child.extendedData?.childrenCount ?? 0 });
-          }
-        }
-      }
+    if (child.search && !child.search.isSearchTarget) {
+      return { hasSearchTargetAncestor: false, hasDirectNonSearchTargets: true };
     }
   }
 
-  return hasSearchTargetAncestor
-    ? { hasSearchTargetAncestor, hasDirectNonSearchTargets: undefined, childrenCount, searchTargets: undefined }
-    : { hasSearchTargetAncestor, hasDirectNonSearchTargets, childrenCount, searchTargets };
+  return { hasSearchTargetAncestor: false, hasDirectNonSearchTargets: false };
 }
 
 /** @internal */

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/VisibilityUtils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/VisibilityUtils.ts
@@ -107,7 +107,7 @@ export function changeElementStateNoChildrenOperator(props: {
 }
 
 /** @internal */
-export function getVisibilityFromAlwaysAndNeverDrawnElementsImpl(props: {
+export function getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl(props: {
   numberOfElementsInOppositeSet: number;
   totalCount: number;
   defaultStatus: NonPartialVisibilityStatus;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.ts
@@ -34,7 +34,7 @@ import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
 import { getClassesByView, getIdsFromChildrenTree, getOptimalBatchSize, releaseMainThreadOnItemsCount, updateChildrenTree } from "../Utils.js";
 
 import type { Observable, Subscription } from "rxjs";
-import type { GuidString, Id64Arg, Id64Array, Id64String } from "@itwin/core-bentley";
+import type { GuidString, Id64Arg, Id64Array, Id64Set, Id64String } from "@itwin/core-bentley";
 import type { TreeWidgetViewport } from "../../TreeWidgetViewport.js";
 import type { ElementId } from "../Types.js";
 import type { ChildrenTree } from "../Utils.js";
@@ -376,13 +376,21 @@ export class AlwaysAndNeverDrawnElementInfoCache implements Disposable {
     );
   }
 
-  public getAlwaysOrNeverDrawnElements(props: GetElementsTreeProps) {
+  public getAlwaysOrNeverDrawnElements(props: GetElementsTreeProps & { childCategoryIds?: Id64Set }) {
     const cache = props.setType === "always" ? this.#viewport.alwaysDrawn : this.#viewport.neverDrawn;
     if (!cache?.size) {
       return of(new Set<ElementId>());
     }
+    const childCategoryIds = props.childCategoryIds;
     return this.getElementsTree(props).pipe(
-      map((childrenTree) => getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ treeEntry }) => treeEntry.isInAlwaysOrNeverDrawnSet })),
+      map((childrenTree) =>
+        getIdsFromChildrenTree({
+          tree: childrenTree,
+          predicate: childCategoryIds?.size
+            ? ({ treeEntry }) => treeEntry.isInAlwaysOrNeverDrawnSet && childCategoryIds.has(treeEntry.categoryId)
+            : ({ treeEntry }) => treeEntry.isInAlwaysOrNeverDrawnSet,
+        }),
+      ),
     );
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -131,18 +131,14 @@ export class BaseIdsCache {
     return this.#descendantsCountCache.getDescendantsCounts(props);
   }
 
-  public getElementsCount(props: { modelId: Id64String; categoryId: Id64String }): Observable<number> {
+  public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {
     return this.#descendantsCountCache.getDescendantsCounts(props).pipe(map((counts) => counts.reduce((sum, entry) => sum + entry.count, 0)));
   }
 
   // ChildElementsCache methods
 
-  public getChildElementsTree(props: Props<ChildElementsCache["getChildElementsTree"]>): ReturnType<ChildElementsCache["getChildElementsTree"]> {
-    return this.#childElementsCache.getChildElementsTree(props);
-  }
-
-  public getAllChildElementsCount(props: Props<ChildElementsCache["getAllChildElementsCount"]>): ReturnType<ChildElementsCache["getAllChildElementsCount"]> {
-    return this.#childElementsCache.getAllChildElementsCount(props);
+  public getChildElements(props: Props<ChildElementsCache["getChildElements"]>): ReturnType<ChildElementsCache["getChildElements"]> {
+    return this.#childElementsCache.getChildElements(props);
   }
 
   // SubCategoriesCache methods
@@ -182,12 +178,8 @@ export class BaseIdsCacheImpl {
 
   // Implement IBaseIdsCache by re-exporting BaseIdsCache methods
 
-  public getChildElementsTree(props: Props<ChildElementsCache["getChildElementsTree"]>): ReturnType<ChildElementsCache["getChildElementsTree"]> {
-    return this.#baseIdsCache.getChildElementsTree(props);
-  }
-
-  public getAllChildElementsCount(props: Props<ChildElementsCache["getAllChildElementsCount"]>): ReturnType<ChildElementsCache["getAllChildElementsCount"]> {
-    return this.#baseIdsCache.getAllChildElementsCount(props);
+  public getChildElements(props: Props<ChildElementsCache["getChildElements"]>): ReturnType<ChildElementsCache["getChildElements"]> {
+    return this.#baseIdsCache.getChildElements(props);
   }
 
   public getSubCategories(props: Props<SubCategoriesCache["getSubCategories"]>): ReturnType<SubCategoriesCache["getSubCategories"]> {
@@ -214,7 +206,7 @@ export class BaseIdsCacheImpl {
     return this.#baseIdsCache.getDescendantsCounts(props);
   }
 
-  public getElementsCount(props: { modelId: Id64String; categoryId: Id64String }): Observable<number> {
+  public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {
     return this.#baseIdsCache.getElementsCount(props);
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -131,6 +131,10 @@ export class BaseIdsCache {
     return this.#descendantsCountCache.getDescendantsCounts(props);
   }
 
+  public storeRequest(props: Props<DescendantsCountCache["storeRequest"]>): ReturnType<DescendantsCountCache["storeRequest"]> {
+    return this.#descendantsCountCache.storeRequest(props);
+  }
+
   public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {
     return this.#descendantsCountCache.getDescendantsCounts(props).pipe(map((counts) => counts.reduce((sum, entry) => sum + entry.count, 0)));
   }
@@ -204,6 +208,10 @@ export class BaseIdsCacheImpl {
 
   public getDescendantsCounts(props: Props<DescendantsCountCache["getDescendantsCounts"]>): ReturnType<DescendantsCountCache["getDescendantsCounts"]> {
     return this.#baseIdsCache.getDescendantsCounts(props);
+  }
+
+  public storeRequest(props: Props<DescendantsCountCache["storeRequest"]>): ReturnType<DescendantsCountCache["storeRequest"]> {
+    return this.#baseIdsCache.storeRequest(props);
   }
 
   public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -131,10 +131,6 @@ export class BaseIdsCache {
     return this.#descendantsCountCache.getDescendantsCounts(props);
   }
 
-  public storeRequest(props: Props<DescendantsCountCache["storeRequest"]>): ReturnType<DescendantsCountCache["storeRequest"]> {
-    return this.#descendantsCountCache.storeRequest(props);
-  }
-
   public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {
     return this.#descendantsCountCache.getDescendantsCounts(props).pipe(map((counts) => counts.reduce((sum, entry) => sum + entry.count, 0)));
   }
@@ -208,10 +204,6 @@ export class BaseIdsCacheImpl {
 
   public getDescendantsCounts(props: Props<DescendantsCountCache["getDescendantsCounts"]>): ReturnType<DescendantsCountCache["getDescendantsCounts"]> {
     return this.#baseIdsCache.getDescendantsCounts(props);
-  }
-
-  public storeRequest(props: Props<DescendantsCountCache["storeRequest"]>): ReturnType<DescendantsCountCache["storeRequest"]> {
-    return this.#baseIdsCache.storeRequest(props);
   }
 
   public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -27,14 +27,14 @@ export interface BatchingCacheProps {
  *
  * @template TRequest - A single logical request made by a consumer (e.g. `{ modelId, categoryId, parentElementId }`).
  * @template TResult - The value returned to the consumer for a given request (e.g. `Id64Array`).
- * @template TQueryData - Query data produced by decomposing a batch of requests via `getIterable`
+ * @template TQueryData - Query data produced by decomposing a batch of requests via `getQueryData`
  *   (e.g. a WHERE clause fragment). Items are buffered (up to `bufferSize`) and passed to `executeQuery`.
  * @template TRow - A single result row emitted by `executeQuery`, cached via `insertRow`
  *   (e.g. `{ modelId, reqParent, reqCategory, ownCategory, count }`).
  *
  * Pipeline:
  * 1. Requests arriving within `timerDelay` ms are collected into a batch (`TRequest[]`).
- * 2. `getIterable(batch)` decomposes the batch into a stream of `TQueryData` items.
+ * 2. `getQueryData(batch)` decomposes the batch into a stream of `TQueryData` items.
  * 3. Items are buffered (up to `bufferSize`) and passed to `executeQuery(items)`.
  * 4. Each `TRow` emitted by `executeQuery` is cached via `insertRow`.
  * 5. After completion, `ensureDefaultCacheEntries` fills in empty entries for
@@ -79,7 +79,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
    * those values take shape of a WHERE clause fragments.
    * These TQueryData items are buffered and passed to `executeQuery`.
    */
-  protected abstract getIterable(batch: TRequest[]): Observable<TQueryData>;
+  protected abstract getQueryData(batch: TRequest[]): Observable<TQueryData>;
 
   /** Execute a query for the given query data buffer. Returns an observable of result rows. */
   protected abstract executeQuery(queryData: TQueryData[]): Observable<TRow>;
@@ -150,7 +150,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   }
 
   private executeBatchQuery(batch: TRequest[]): Observable<TRow> {
-    return this.getIterable(batch).pipe(
+    return this.getQueryData(batch).pipe(
       bufferCount(this.#bufferSize),
       mergeMap((queryData: TQueryData[]) => this.executeQuery(queryData).pipe(catchBeSQLiteInterrupts)),
       releaseMainThreadOnItemsCount(this.#releaseOnCount),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { bufferCount, map, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
+import { bufferCount, last, map, merge, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
 import { releaseMainThreadOnItemsCount } from "../Utils.js";
@@ -61,7 +61,10 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
    * Returns `undefined` if the entire request is already in the batch.
    * For caches without partial requests, return `undefined` if in batch, or the full request if not.
    */
-  protected abstract getValuesToRequest(request: TRequest, batch: TBatch): TRequest | undefined;
+  protected abstract getValuesNotInBatch(
+    request: TRequest,
+    batch: TBatch,
+  ): { valuesNotInBatch: TRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true };
 
   /** Create a new empty batch. */
   protected abstract createBatch(): TBatch;
@@ -89,12 +92,16 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
 
     // Check if request is fully covered by an in-flight batch
     let requestNotInBatch: TRequest = request;
+    const sharedObsArray: Array<Observable<void>> = [];
     for (const { values, sharedObs } of this.#requestedValues.values()) {
-      const partOfRequestNotInBatch = this.getValuesToRequest(request, values);
-      if (partOfRequestNotInBatch === undefined) {
-        return this.getResultAfterObservable(request, sharedObs);
+      const { valuesNotInBatch, batchContainsValues } = this.getValuesNotInBatch(requestNotInBatch, values);
+      if (batchContainsValues) {
+        sharedObsArray.push(sharedObs);
       }
-      requestNotInBatch = partOfRequestNotInBatch;
+      if (valuesNotInBatch === undefined) {
+        return this.getResultAfterObservable(request, merge(...sharedObsArray).pipe(last()));
+      }
+      requestNotInBatch = valuesNotInBatch;
     }
 
     if (this.#valuesToRequest === undefined) {
@@ -128,11 +135,13 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
       );
       this.#valuesToRequest = { values: this.createBatch(), sharedObs };
       this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
-      return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+      // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
+      return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
     }
 
     this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
-    return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+    // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
+    return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
   }
 
   private executeBatchQuery(batch: TBatch): Observable<TRow> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -43,12 +43,15 @@ export interface BatchingCacheProps {
  * @internal
  */
 export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
-  // When a new request is made:
-  // - If the value is already cached, returns it immediately.
-  // - If it's already in-flight (#requestedValues), subscribes to the same observable.
-  // - Otherwise, adds to #valuesToRequest. After timer fires, the batch executes and caches results.
+  // When a new request is made (via `get`) or stored (via `store`):
+  // - If the value is already cached, returns it immediately (get) or skips (store).
+  // - If it's already in-flight (#requestedValues), subscribes to the same observable (get) or skips (store).
+  // - Otherwise, adds to #valuesToRequest. For `get`, a timer is started if not already running;
+  //   after the timer fires, the batch executes and caches results. For `store`, the request
+  //   is only queued — the batch executes when a subsequent `get` triggers the timer.
 
-  #valuesToRequest: { values: TRequest[]; sharedObs: Observable<void> } | undefined;
+  /** Pending requests buffer. `sharedObs` is created lazily on the first `get` call. */
+  #valuesToRequest: { values: TRequest[]; sharedObs?: Observable<void> } = { values: [] };
   #requestedValues = new Map<RequestId, { values: TRequest[]; sharedObs: Observable<void> }>();
   #bufferSize: number;
   #timerDelay: number;
@@ -90,6 +93,31 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   /** Ensure default/empty cache entries exist for all values in the batch (called after query completes). */
   protected abstract ensureDefaultCacheEntries(batch: TRequest[]): void;
 
+  /**
+   * Queues a request into the next batch without subscribing to results.
+   * Used to pre-warm the cache - the request will be included in the next batch query
+   * triggered by a subsequent `get` call.
+   */
+  public store(request: TRequest): void {
+    const cachedValue = this.getCachedValue(request);
+    if (cachedValue !== undefined) {
+      return;
+    }
+    let requestNotInBatch: TRequest = request;
+    for (const { values } of this.#requestedValues.values()) {
+      const { valuesNotInBatch } = this.getValuesNotInBatch(requestNotInBatch, values);
+      if (valuesNotInBatch === undefined) {
+        return;
+      }
+      requestNotInBatch = valuesNotInBatch;
+    }
+    this.#valuesToRequest.values.push(requestNotInBatch);
+  }
+
+  /**
+   * Queues a request and returns an observable that emits the result once the batch query completes.
+   * If no batch timer is running, creates one. The request is included in the current batch.
+   */
   public get(request: TRequest): Observable<TResult> {
     const cachedValue = this.getCachedValue(request);
     if (cachedValue !== undefined) {
@@ -110,43 +138,44 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
       requestNotInBatch = valuesNotInBatch;
     }
 
-    if (this.#valuesToRequest === undefined) {
-      const requestId = Guid.createValue();
-      const sharedObs = timer(this.#timerDelay).pipe(
-        switchMap(() => {
-          assert(this.#valuesToRequest !== undefined);
-          // After timer delay ms, assign the observable in #valuesToRequest to the #requestedValues
-          const valuesToRequest = this.#valuesToRequest;
-          this.#requestedValues.set(requestId, valuesToRequest);
-          // Clear #valuesToRequest so new requests can be collected while the query is executing
-          this.#valuesToRequest = undefined;
-          return this.executeBatchQuery(valuesToRequest.values).pipe(
-            reduce((_acc, row: TRow) => {
-              // Cache each row as it arrives, use reduce to emit one value when query completes
-              this.insertRow(row);
-              return undefined;
-            }, undefined),
-            tap(() => {
-              this.ensureDefaultCacheEntries(valuesToRequest.values);
-            }),
-          );
-        }),
-        tap({
-          finalize: () => {
-            // Remove requestedValues entry when the query completes.
-            this.#requestedValues.delete(requestId);
-          },
-        }),
-        shareReplay(1),
-      );
-      this.#valuesToRequest = { values: [requestNotInBatch], sharedObs };
-      // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
-      return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
+    if (this.#valuesToRequest.sharedObs === undefined) {
+      this.#valuesToRequest.sharedObs = this.createSharedObs();
     }
 
     this.#valuesToRequest.values.push(requestNotInBatch);
     // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
     return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
+  }
+
+  private createSharedObs(): Observable<void> {
+    const requestId = Guid.createValue();
+    return timer(this.#timerDelay).pipe(
+      switchMap(() => {
+        // After timer delay ms, assign the observable in #valuesToRequest to the #requestedValues
+        const { values, sharedObs } = this.#valuesToRequest;
+        assert(sharedObs !== undefined);
+        this.#requestedValues.set(requestId, { values, sharedObs });
+        // Clear #valuesToRequest so new requests can be collected while the query is executing
+        this.#valuesToRequest = { values: [] };
+        return this.executeBatchQuery(values).pipe(
+          reduce((_acc, row: TRow) => {
+            // Cache each row as it arrives, use reduce to emit one value when query completes
+            this.insertRow(row);
+            return undefined;
+          }, undefined),
+          tap(() => {
+            this.ensureDefaultCacheEntries(values);
+          }),
+        );
+      }),
+      tap({
+        finalize: () => {
+          // Remove requestedValues entry when the query completes.
+          this.#requestedValues.delete(requestId);
+        },
+      }),
+      shareReplay(1),
+    );
   }
 
   private executeBatchQuery(batch: TRequest[]): Observable<TRow> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { bufferCount, map, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
+import { assert, Guid } from "@itwin/core-bentley";
+import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { releaseMainThreadOnItemsCount } from "../Utils.js";
+
+import type { Observable } from "rxjs";
+
+type RequestId = string;
+
+/** @internal */
+export interface BatchingCacheProps {
+  /** Number of items to buffer before executing a query. Defaults to 100. */
+  bufferSize?: number;
+  /** Time in ms to wait before firing the batch. Defaults to 20 ms. */
+  timerDelay?: number;
+  /** Release main thread after this many items from the query. Defaults to 500. */
+  releaseOnCount?: number;
+}
+
+/**
+ * Abstract base class that provides timer-based batching, deduplication, and caching.
+ *
+ * Subclasses define:
+ * - How requests map to cached values
+ * - How batches are built from requests
+ * - How to produce query items from a batch, execute queries, and cache rows
+ *
+ * @internal
+ */
+export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
+  // When a new request is made:
+  // - If the value is already cached, returns it immediately.
+  // - If it's already in-flight (#requestedValues), subscribes to the same observable.
+  // - Otherwise, adds to #valuesToRequest. After timer fires, the batch executes and caches results.
+
+  #valuesToRequest: { values: TBatch; sharedObs: Observable<void> } | undefined;
+  #requestedValues = new Map<RequestId, { values: TBatch; sharedObs: Observable<void> }>();
+  #bufferSize: number;
+  #timerDelay: number;
+  #releaseOnCount: number;
+
+  protected constructor(props?: BatchingCacheProps) {
+    this.#bufferSize = props?.bufferSize ?? 100;
+    this.#timerDelay = props?.timerDelay ?? 20;
+    this.#releaseOnCount = props?.releaseOnCount ?? 500;
+  }
+
+  /** Return the cached result if available, or `undefined` if not cached. */
+  protected abstract getCachedValue(request: TRequest): TResult | undefined;
+
+  /** Return the result from cache. Called after the batch observable has completed - value is guaranteed to be cached. */
+  protected abstract getGuaranteedCachedValue(request: TRequest): TResult;
+
+  /**
+   * Return the portion of the request which needs to be requested (not in batch or cache).
+   * Returns `undefined` if the entire request is already in the batch.
+   * For caches without partial requests, return `undefined` if in batch, or the full request if not.
+   */
+  protected abstract getValuesToRequest(request: TRequest, batch: TBatch): TRequest | undefined;
+
+  /** Create a new empty batch. */
+  protected abstract createBatch(): TBatch;
+
+  /** Add a request to an existing batch. */
+  protected abstract addRequestToBatch(request: TRequest, batch: TBatch): void;
+
+  /** Produce the items from a batch that will be buffered and passed to `executeQuery`. */
+  protected abstract getIterable(batch: TBatch): Observable<TItem>;
+
+  /** Execute a query for a buffer of items. Returns an observable of result rows. */
+  protected abstract executeQuery(items: TItem[]): Observable<TRow>;
+
+  /** Cache a single row returned by `executeQuery`. */
+  protected abstract insertRow(row: TRow): void;
+
+  /** Ensure default/empty cache entries exist for all values in the batch (called after query completes). */
+  protected abstract ensureDefaultCacheEntries(batch: TBatch): void;
+
+  public get(request: TRequest): Observable<TResult> {
+    const cachedValue = this.getCachedValue(request);
+    if (cachedValue !== undefined) {
+      return of(cachedValue);
+    }
+
+    // Check if request is fully covered by an in-flight batch
+    let requestNotInBatch: TRequest = request;
+    for (const { values, sharedObs } of this.#requestedValues.values()) {
+      const partOfRequestNotInBatch = this.getValuesToRequest(request, values);
+      if (partOfRequestNotInBatch === undefined) {
+        return this.getResultAfterObservable(request, sharedObs);
+      }
+      requestNotInBatch = partOfRequestNotInBatch;
+    }
+
+    if (this.#valuesToRequest === undefined) {
+      const requestId = Guid.createValue();
+      const sharedObs = timer(this.#timerDelay).pipe(
+        switchMap(() => {
+          assert(this.#valuesToRequest !== undefined);
+          // After timer delay ms, assign the observable in #valuesToRequest to the #requestedValues
+          const valuesToRequest = this.#valuesToRequest;
+          this.#requestedValues.set(requestId, valuesToRequest);
+          // Clear #valuesToRequest so new requests can be collected while the query is executing
+          this.#valuesToRequest = undefined;
+          return this.executeBatchQuery(valuesToRequest.values).pipe(
+            reduce((_acc, row: TRow) => {
+              // Cache each row as it arrives, use reduce to emit one value when query completes
+              this.insertRow(row);
+              return undefined;
+            }, undefined),
+            tap(() => {
+              this.ensureDefaultCacheEntries(valuesToRequest.values);
+            }),
+          );
+        }),
+        tap({
+          finalize: () => {
+            // Remove requestedValues entry when the query completes.
+            this.#requestedValues.delete(requestId);
+          },
+        }),
+        shareReplay(1),
+      );
+      this.#valuesToRequest = { values: this.createBatch(), sharedObs };
+      this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+      return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+    }
+
+    this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+    return this.getResultAfterObservable(request, this.#valuesToRequest.sharedObs);
+  }
+
+  private executeBatchQuery(batch: TBatch): Observable<TRow> {
+    return this.getIterable(batch).pipe(
+      bufferCount(this.#bufferSize),
+      mergeMap((items: TItem[]) => this.executeQuery(items).pipe(catchBeSQLiteInterrupts)),
+      releaseMainThreadOnItemsCount(this.#releaseOnCount),
+    );
+  }
+
+  private getResultAfterObservable(request: TRequest, observable: Observable<void>): Observable<TResult> {
+    return observable.pipe(map(() => this.getGuaranteedCachedValue(request)));
+  }
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -32,14 +32,14 @@ export interface BatchingCacheProps {
  *
  * @internal
  */
-export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
+export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
   // When a new request is made:
   // - If the value is already cached, returns it immediately.
   // - If it's already in-flight (#requestedValues), subscribes to the same observable.
   // - Otherwise, adds to #valuesToRequest. After timer fires, the batch executes and caches results.
 
-  #valuesToRequest: { values: TBatch; sharedObs: Observable<void> } | undefined;
-  #requestedValues = new Map<RequestId, { values: TBatch; sharedObs: Observable<void> }>();
+  #valuesToRequest: { values: TRequest[]; sharedObs: Observable<void> } | undefined;
+  #requestedValues = new Map<RequestId, { values: TRequest[]; sharedObs: Observable<void> }>();
   #bufferSize: number;
   #timerDelay: number;
   #releaseOnCount: number;
@@ -60,17 +60,11 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
    */
   protected abstract getValuesNotInBatch(
     request: TRequest,
-    batch: TBatch,
+    batch: TRequest[],
   ): { valuesNotInBatch: TRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true };
 
-  /** Create a new empty batch. */
-  protected abstract createBatch(): TBatch;
-
-  /** Add a request to an existing batch. */
-  protected abstract addRequestToBatch(request: TRequest, batch: TBatch): void;
-
   /** Produce the items from a batch that will be buffered and passed to `executeQuery`. */
-  protected abstract getIterable(batch: TBatch): Observable<TItem>;
+  protected abstract getIterable(batch: TRequest[]): Observable<TItem>;
 
   /** Execute a query for a buffer of items. Returns an observable of result rows. */
   protected abstract executeQuery(items: TItem[]): Observable<TRow>;
@@ -79,7 +73,7 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
   protected abstract insertRow(row: TRow): void;
 
   /** Ensure default/empty cache entries exist for all values in the batch (called after query completes). */
-  protected abstract ensureDefaultCacheEntries(batch: TBatch): void;
+  protected abstract ensureDefaultCacheEntries(batch: TRequest[]): void;
 
   public get(request: TRequest): Observable<TResult> {
     const cachedValue = this.getCachedValue(request);
@@ -130,18 +124,17 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
         }),
         shareReplay(1),
       );
-      this.#valuesToRequest = { values: this.createBatch(), sharedObs };
-      this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+      this.#valuesToRequest = { values: [requestNotInBatch], sharedObs };
       // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
       return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
     }
 
-    this.addRequestToBatch(requestNotInBatch, this.#valuesToRequest.values);
+    this.#valuesToRequest.values.push(requestNotInBatch);
     // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
     return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
   }
 
-  private executeBatchQuery(batch: TBatch): Observable<TRow> {
+  private executeBatchQuery(batch: TRequest[]): Observable<TRow> {
     return this.getIterable(batch).pipe(
       bufferCount(this.#bufferSize),
       mergeMap((items: TItem[]) => this.executeQuery(items).pipe(catchBeSQLiteInterrupts)),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -25,14 +25,24 @@ export interface BatchingCacheProps {
 /**
  * Abstract base class that provides timer-based batching, deduplication, and caching.
  *
- * Subclasses define:
- * - How requests map to cached values
- * - How batches are built from requests
- * - How to produce query items from a batch, execute queries, and cache rows
+ * @template TRequest - A single logical request made by a consumer (e.g. `{ modelId, categoryId, parentElementId }`).
+ * @template TResult - The value returned to the consumer for a given request (e.g. `Id64Array`).
+ * @template TQueryData - Query data produced by decomposing a batch of requests via `getIterable`
+ *   (e.g. a WHERE clause fragment). Items are buffered (up to `bufferSize`) and passed to `executeQuery`.
+ * @template TRow - A single result row emitted by `executeQuery`, cached via `insertRow`
+ *   (e.g. `{ modelId, reqParent, reqCategory, ownCategory, count }`).
+ *
+ * Pipeline:
+ * 1. Requests arriving within `timerDelay` ms are collected into a batch (`TRequest[]`).
+ * 2. `getIterable(batch)` decomposes the batch into a stream of `TQueryData` items.
+ * 3. Items are buffered (up to `bufferSize`) and passed to `executeQuery(items)`.
+ * 4. Each `TRow` emitted by `executeQuery` is cached via `insertRow`.
+ * 5. After completion, `ensureDefaultCacheEntries` fills in empty entries for
+ *    requests that produced no rows, and `getCachedValue` returns the result.
  *
  * @internal
  */
-export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
+export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   // When a new request is made:
   // - If the value is already cached, returns it immediately.
   // - If it's already in-flight (#requestedValues), subscribes to the same observable.
@@ -63,11 +73,16 @@ export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
     batch: TRequest[],
   ): { valuesNotInBatch: TRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true };
 
-  /** Produce the items from a batch that will be buffered and passed to `executeQuery`. */
-  protected abstract getIterable(batch: TRequest[]): Observable<TItem>;
+  /**
+   * Convert batched requests into units of data which are used to execute the query.
+   * For example, TRequest might be an object containing various request values, when converted to TQueryData,
+   * those values take shape of a WHERE clause fragments.
+   * These TQueryData items are buffered and passed to `executeQuery`.
+   */
+  protected abstract getIterable(batch: TRequest[]): Observable<TQueryData>;
 
-  /** Execute a query for a buffer of items. Returns an observable of result rows. */
-  protected abstract executeQuery(items: TItem[]): Observable<TRow>;
+  /** Execute a query for the given query data buffer. Returns an observable of result rows. */
+  protected abstract executeQuery(queryData: TQueryData[]): Observable<TRow>;
 
   /** Cache a single row returned by `executeQuery`. */
   protected abstract insertRow(row: TRow): void;
@@ -137,7 +152,7 @@ export abstract class BatchingCache<TRequest, TResult, TItem, TRow> {
   private executeBatchQuery(batch: TRequest[]): Observable<TRow> {
     return this.getIterable(batch).pipe(
       bufferCount(this.#bufferSize),
-      mergeMap((items: TItem[]) => this.executeQuery(items).pipe(catchBeSQLiteInterrupts)),
+      mergeMap((queryData: TQueryData[]) => this.executeQuery(queryData).pipe(catchBeSQLiteInterrupts)),
       releaseMainThreadOnItemsCount(this.#releaseOnCount),
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -53,9 +53,6 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
   /** Return the cached result if available, or `undefined` if not cached. */
   protected abstract getCachedValue(request: TRequest): TResult | undefined;
 
-  /** Return the result from cache. Called after the batch observable has completed - value is guaranteed to be cached. */
-  protected abstract getGuaranteedCachedValue(request: TRequest): TResult;
-
   /**
    * Return the portion of the request which needs to be requested (not in batch or cache).
    * Returns `undefined` if the entire request is already in the batch.
@@ -153,6 +150,12 @@ export abstract class BatchingCache<TRequest, TBatch, TResult, TItem, TRow> {
   }
 
   private getResultAfterObservable(request: TRequest, observable: Observable<void>): Observable<TResult> {
-    return observable.pipe(map(() => this.getGuaranteedCachedValue(request)));
+    return observable.pipe(
+      map(() => {
+        const cachedValue = this.getCachedValue(request);
+        assert(cachedValue !== undefined);
+        return cachedValue;
+      }),
+    );
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -43,12 +43,11 @@ export interface BatchingCacheProps {
  * @internal
  */
 export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
-  // When a new request is made (via `get`) or stored (via `store`):
-  // - If the value is already cached, returns it immediately (get) or skips (store).
-  // - If it's already in-flight (#requestedValues), subscribes to the same observable (get) or skips (store).
-  // - Otherwise, adds to #valuesToRequest. For `get`, a timer is started if not already running;
-  //   after the timer fires, the batch executes and caches results. For `store`, the request
-  //   is only queued — the batch executes when a subsequent `get` triggers the timer.
+  // When a new request is made via `get`:
+  // - If the value is already cached, returns it immediately.
+  // - If it's already in-flight (#requestedValues), subscribes to the same observable.
+  // - Otherwise, adds to #valuesToRequest. A timer is started if not already running;
+  //   after the timer fires, the batch executes and caches results.
 
   /** Pending requests buffer. `sharedObs` is created lazily on the first `get` call. */
   #valuesToRequest: { values: TRequest[]; sharedObs?: Observable<void> } = { values: [] };
@@ -92,27 +91,6 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
 
   /** Ensure default/empty cache entries exist for all values in the batch (called after query completes). */
   protected abstract ensureDefaultCacheEntries(batch: TRequest[]): void;
-
-  /**
-   * Queues a request into the next batch without subscribing to results.
-   * Used to pre-warm the cache - the request will be included in the next batch query
-   * triggered by a subsequent `get` call.
-   */
-  public store(request: TRequest): void {
-    const cachedValue = this.getCachedValue(request);
-    if (cachedValue !== undefined) {
-      return;
-    }
-    let requestNotInBatch: TRequest = request;
-    for (const { values } of this.#requestedValues.values()) {
-      const { valuesNotInBatch } = this.getValuesNotInBatch(requestNotInBatch, values);
-      if (valuesNotInBatch === undefined) {
-        return;
-      }
-      requestNotInBatch = valuesNotInBatch;
-    }
-    this.#valuesToRequest.values.push(requestNotInBatch);
-  }
 
   /**
    * Queues a request and returns an observable that emits the result once the batch query completes.

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -117,7 +117,21 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     }
 
     if (this.#valuesToRequest.sharedObs === undefined) {
-      this.#valuesToRequest.sharedObs = this.createSharedObs();
+      const requestId = Guid.createValue();
+      this.#valuesToRequest.sharedObs = this.createSharedObs({
+        values: this.#valuesToRequest.values,
+        onStart: () => {
+          const { sharedObs } = this.#valuesToRequest;
+          assert(sharedObs !== undefined);
+          // After when start happens, assign the observable in #valuesToRequest to the #requestedValues
+          this.#requestedValues.set(requestId, { values: this.#valuesToRequest.values, sharedObs });
+          // Clear #valuesToRequest so new requests can be collected while the query is executing
+          this.#valuesToRequest = { values: [] };
+        },
+        onDone: () => {
+          this.#requestedValues.delete(requestId);
+        },
+      });
     }
 
     this.#valuesToRequest.values.push(requestNotInBatch);
@@ -125,16 +139,10 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
   }
 
-  private createSharedObs(): Observable<void> {
-    const requestId = Guid.createValue();
+  private createSharedObs({ values, onStart, onDone }: { values: TRequest[]; onStart: () => void; onDone: () => void }): Observable<void> {
     return timer(this.#timerDelay).pipe(
       switchMap(() => {
-        // After timer delay ms, assign the observable in #valuesToRequest to the #requestedValues
-        const { values, sharedObs } = this.#valuesToRequest;
-        assert(sharedObs !== undefined);
-        this.#requestedValues.set(requestId, { values, sharedObs });
-        // Clear #valuesToRequest so new requests can be collected while the query is executing
-        this.#valuesToRequest = { values: [] };
+        onStart();
         return this.executeBatchQuery(values).pipe(
           reduce((_acc, row: TRow) => {
             // Cache each row as it arrives, use reduce to emit one value when query completes
@@ -147,10 +155,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
         );
       }),
       tap({
-        finalize: () => {
-          // Remove requestedValues entry when the query completes.
-          this.#requestedValues.delete(requestId);
-        },
+        finalize: onDone,
       }),
       shareReplay(1),
     );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
@@ -3,18 +3,31 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defaultIfEmpty, defer, EMPTY, firstValueFrom, from, map, mergeMap, reduce, tap } from "rxjs";
-import { Guid, Id64 } from "@itwin/core-bentley";
-import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
-import { getOptimalBatchSize } from "../Utils.js";
+import { defer, EMPTY, from, map, mergeMap, of } from "rxjs";
+import { assert, Guid } from "@itwin/core-bentley";
+import { BatchingCache } from "./BatchingCache.js";
 
 import type { Observable } from "rxjs";
-import type { GuidString, Id64Arg, Id64Array, Id64String } from "@itwin/core-bentley";
+import type { GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
-import type { ChildrenTree } from "../Utils.js";
+import type { CategoryId, ElementId, ModelId } from "../Types.js";
 
-type ChildElementsMap = Map<Id64String, { children: Id64Array | undefined }>;
-type ChildElementsLoadingMap = Map<Id64String, Promise<void>>;
+interface ChildElementsBaseRequest {
+  modelId: ModelId;
+  childCategoryIds: CategoryId[];
+}
+
+interface ChildElementsCategoryRequest extends ChildElementsBaseRequest {
+  categoryId: CategoryId;
+  parentElementId?: ElementId; // undefined = root level
+}
+
+interface ChildElementsElementRequest extends ChildElementsBaseRequest {
+  parentElementId: ElementId;
+  categoryId?: undefined;
+}
+
+type ChildElementsRequest = ChildElementsCategoryRequest | ChildElementsElementRequest;
 
 interface ChildElementsCacheProps {
   queryExecutor: LimitingECSqlQueryExecutor;
@@ -22,177 +35,290 @@ interface ChildElementsCacheProps {
   componentId: GuidString;
 }
 
-/** @internal */
-export class ChildElementsCache {
+interface WhereClause {
+  whereClause: string;
+  type: "element" | "category";
+  childCategoryIds: Set<CategoryId>;
+}
+
+interface Row {
+  modelId: ModelId;
+  reqParent: ElementId | undefined;
+  reqCategory: CategoryId | undefined;
+  ownCategory: CategoryId;
+  id: ElementId;
+}
+
+/**
+ * Cache for retrieving descendant element IDs grouped by category.
+ *
+ * Cache makes requests in batches of 20ms.
+ * Uses incremental caching per childCategoryId: only queries child categories not yet cached/batched.
+ * @internal
+ */
+export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64Array, WhereClause, Row> {
+  #cachedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, Map<CategoryId, Id64Array>>>>();
   #queryExecutor: LimitingECSqlQueryExecutor;
-  readonly #elementClassName: string;
+  #elementClassName: string;
   #componentId: GuidString;
   #componentName: string;
-  #childElementsMap: ChildElementsMap;
-  /** Stores element ids which have children query scheduled to execute. */
-  #childElementsLoadingMap: ChildElementsLoadingMap;
 
-  constructor(props: ChildElementsCacheProps) {
+  public constructor(props: ChildElementsCacheProps) {
+    super();
     this.#queryExecutor = props.queryExecutor;
     this.#elementClassName = props.elementClassName;
     this.#componentId = props.componentId;
     this.#componentName = "ChildElementsCache";
-    this.#childElementsMap = new Map();
-    this.#childElementsLoadingMap = new Map();
   }
 
-  private queryChildren({ elementIds }: { elementIds: Id64Array }): Observable<{ id: Id64String; parentId: Id64String }> {
-    if (elementIds.length === 0) {
+  protected getCachedValue(request: ChildElementsRequest): Id64Array | undefined {
+    const { modelId, parentElementId, categoryId, childCategoryIds } = request;
+    const cachedEntry = this.#cachedValues.get(modelId)?.get(parentElementId)?.get(categoryId);
+    if (!cachedEntry) {
+      return undefined;
+    }
+    const result = new Array<Id64String>();
+    for (const childCategoryId of childCategoryIds) {
+      const ids = cachedEntry.get(childCategoryId);
+      if (!ids) {
+        return undefined;
+      }
+      result.push(...ids);
+    }
+    return result;
+  }
+
+  protected getValuesNotInBatch(
+    request: ChildElementsRequest,
+    batch: ChildElementsRequest[],
+  ): { valuesNotInBatch: ChildElementsRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true } {
+    const { modelId, parentElementId, categoryId, childCategoryIds } = request;
+    let missingIds: CategoryId[] = childCategoryIds;
+    const batchedChildCategoryIds = batch.filter((r) => r.modelId === modelId && r.parentElementId === parentElementId && r.categoryId === categoryId);
+    if (batchedChildCategoryIds.length === 0) {
+      return { valuesNotInBatch: { ...request, childCategoryIds: missingIds }, batchContainsValues: false };
+    }
+    const lengthBefore = missingIds.length;
+    missingIds = missingIds.filter((id) => !batchedChildCategoryIds.some((r) => r.childCategoryIds.includes(id)));
+    if (missingIds.length === 0) {
+      // All childCategoryIds are either cached or in-flight, so no need to request any more - just wait for the batch to complete and get from cache then
+      return { valuesNotInBatch: undefined, batchContainsValues: true };
+    }
+
+    return { valuesNotInBatch: { ...request, childCategoryIds: missingIds }, batchContainsValues: lengthBefore !== missingIds.length };
+  }
+
+  protected getQueryData(batch: ChildElementsRequest[]): Observable<WhereClause> {
+    const groupedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, Set<CategoryId>>>>();
+    for (const { modelId, parentElementId, categoryId, childCategoryIds } of batch) {
+      let modelEntry = groupedValues.get(modelId);
+      if (!modelEntry) {
+        modelEntry = new Map();
+        groupedValues.set(modelId, modelEntry);
+      }
+      let parentEntry = modelEntry.get(parentElementId);
+      if (!parentEntry) {
+        parentEntry = new Map();
+        modelEntry.set(parentElementId, parentEntry);
+      }
+      let categoryEntry = parentEntry.get(categoryId);
+      if (!categoryEntry) {
+        categoryEntry = new Set();
+        parentEntry.set(categoryId, categoryEntry);
+      }
+      for (const childCategoryId of childCategoryIds) {
+        categoryEntry.add(childCategoryId);
+      }
+    }
+
+    return from(groupedValues.entries()).pipe(
+      mergeMap(([modelId, parentMap]) =>
+        from(parentMap.entries()).pipe(
+          mergeMap(([parentElementId, categoryMap]) => {
+            const clauses: WhereClause[] = [];
+            const undefinedEntry = categoryMap.get(undefined);
+            if (undefinedEntry) {
+              assert(parentElementId !== undefined);
+              clauses.push({ whereClause: `Model.Id = ${modelId} AND Parent.Id = ${parentElementId}`, type: "element", childCategoryIds: undefinedEntry });
+            }
+            const allChildCategoryIds = new Set<CategoryId>();
+            const categoryMapKeys = new Array<Id64String>();
+            for (const [categoryId, categoryChildCategoryIds] of categoryMap) {
+              if (categoryId !== undefined) {
+                categoryMapKeys.push(categoryId);
+                for (const childCategoryId of categoryChildCategoryIds) {
+                  allChildCategoryIds.add(childCategoryId);
+                }
+              }
+            }
+            if (categoryMapKeys.length > 0) {
+              clauses.push({
+                whereClause: `Model.Id = ${modelId} AND Category.Id IN (${categoryMapKeys.join(", ")}) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
+                type: "category",
+                childCategoryIds: allChildCategoryIds,
+              });
+            }
+            return from(clauses);
+          }),
+        ),
+      ),
+    );
+  }
+
+  protected executeQuery(clauses: WhereClause[]): Observable<Row> {
+    const categoryWhereClauses = clauses.filter((c) => c.type === "category").map((c) => c.whereClause);
+    const elementWhereClauses = clauses.filter((c) => c.type === "element").map((c) => c.whereClause);
+    const allChildCategoryIds = new Set(...clauses.map(({ childCategoryIds }) => childCategoryIds));
+
+    const baseCases: string[] = [];
+
+    if (categoryWhereClauses.length > 0) {
+      baseCases.push(`
+        SELECT ECInstanceId, Model.Id, Parent.Id, Category.Id, Category.Id
+        FROM ${this.#elementClassName}
+        WHERE ${categoryWhereClauses.join(" OR ")}
+      `);
+    }
+
+    if (elementWhereClauses.length > 0) {
+      baseCases.push(`
+        SELECT ECInstanceId, Model.Id, Parent.Id, CAST(NULL AS TEXT), Category.Id
+        FROM ${this.#elementClassName}
+        WHERE ${elementWhereClauses.join(" OR ")}
+      `);
+    }
+
+    if (baseCases.length === 0) {
       return EMPTY;
     }
 
-    return defer(() => {
-      const ctes = [
-        `
-          ElementChildren(id, parentId) AS (
-            SELECT ECInstanceId id, Parent.Id parentId
-            FROM ${this.#elementClassName}
-            JOIN IdSet(?) elementIdSet ON Parent.Id = elementIdSet.id
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
+    return defer(
+      () =>
+        this.#queryExecutor.createQueryReader(
+          {
+            ctes: [
+              `
+              Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
+                ${baseCases.join(" UNION ALL ")}
 
-            UNION ALL
+                UNION ALL
 
-            SELECT c.ECInstanceId id, c.Parent.Id
-            FROM ${this.#elementClassName} c
-            JOIN ElementChildren p ON c.Parent.Id = p.id
-          )
-        `,
-      ];
-      const ecsql = `
-        SELECT id, parentId
-        FROM ElementChildren
-      `;
-      return this.#queryExecutor.createQueryReader(
-        { ecsql, ctes, bindings: [{ type: "idset", value: elementIds }] },
-        { rowFormat: "ECSqlPropertyNames", limit: "unbounded", restartToken: `${this.#componentName}/${this.#componentId}/children/${Guid.createValue()}` },
-      );
-    }).pipe(
-      catchBeSQLiteInterrupts,
-      map((row) => {
-        return { id: row.id, parentId: row.parentId };
-      }),
-    );
-  }
-
-  private getChildElementsTreeFromMap({ elementIds }: { elementIds: Id64Arg }): ChildrenTree {
-    const result: ChildrenTree = new Map();
-    if (Id64.sizeOf(elementIds) === 0 || this.#childElementsMap.size === 0) {
-      return result;
-    }
-    for (const elementId of Id64.iterable(elementIds)) {
-      const entry = this.#childElementsMap.get(elementId);
-      if (!entry?.children) {
-        continue;
-      }
-      const elementChildrenTree: ChildrenTree = new Map();
-      result.set(elementId, { children: elementChildrenTree });
-      for (const childId of entry.children) {
-        const childrenTreeOfChild = this.getChildElementsTreeFromMap({ elementIds: childId });
-        // Need to add children tree created from childId. This tree includes childId as root element
-        // If child does not have children, children tree won't be created. Need to add childId with undefined children
-        elementChildrenTree.set(childId, { children: childrenTreeOfChild.size > 0 ? childrenTreeOfChild : undefined });
-      }
-    }
-    return result;
-  }
-
-  private getChildElementsCountMap({ elementIds }: { elementIds: Id64Arg }): Map<Id64String, number> {
-    const result = new Map<Id64String, number>();
-    for (const elementId of Id64.iterable(elementIds)) {
-      const entry = this.#childElementsMap.get(elementId);
-      if (entry?.children) {
-        let totalChildrenCount = entry.children.length;
-        for (const childrenOfChildCount of this.getChildElementsCountMap({ elementIds: entry.children }).values()) {
-          totalChildrenCount += childrenOfChildCount;
-        }
-        result.set(elementId, totalChildrenCount);
-      }
-    }
-    return result;
-  }
-
-  /**
-   * Populates #childElementsLoadingMap with promises. When these promises resolve, they will populate #childElementsMap with values and delete entries from #childElementsLoadingMap.
-   */
-  private createChildElementsLoadingMapEntries({ elementsToQuery }: { elementsToQuery: Id64Array }): { loadingMapEntries: Promise<void> } {
-    const getElementsToQueryPromise = async (batchedElementsToQuery: Id64Array) =>
-      firstValueFrom(
-        this.queryChildren({ elementIds: batchedElementsToQuery }).pipe(
-          // Want to have void at the end instead of void[], so using reduce
-          reduce(
-            (acc, { parentId, id }) => {
-              let entry = this.#childElementsMap.get(parentId);
-              if (!entry) {
-                entry = { children: [] };
-                this.#childElementsMap.set(parentId, entry);
-              }
-              if (!entry.children) {
-                entry.children = [];
-              }
-              // Add child to parent's entry and add child to children map
-              entry.children.push(id);
-              if (!this.#childElementsMap.has(id)) {
-                this.#childElementsMap.set(id, { children: undefined });
-              }
-              return acc;
-            },
-            (() => {})(),
-          ),
-          tap({ complete: () => batchedElementsToQuery.forEach((elementId) => this.#childElementsLoadingMap.delete(elementId)) }),
-          defaultIfEmpty((() => {})()),
+                SELECT c.ECInstanceId, p.modelId, p.reqParent, p.reqCategory, c.Category.Id
+                FROM ${this.#elementClassName} c
+                JOIN Descendants p ON c.Parent.Id = p.id
+              )
+              `,
+            ],
+            // Note: allChildCategoryIds is joined from multiple requests in the batch, so there can be cases where counts for non-requested childCategoryIds are returned. E.g:
+            // Request1: { modelId, categoryId, parentElementId: undefined, childCategoryIds: [childCategoryId1] }
+            // Request2: { modelId, parentElementId: element1, childCategoryIds: [childCategoryId2] }
+            // Hierarchy: modelId -> undefined (root) -> categoryId -> element1 -> childCategoryId1 -> element1_1
+            //                                                                  -> childCategoryId2 -> element1_2
+            // In this case, the query will include allChildCategoryIds = [childCategoryId1, childCategoryId2], and return such rows:
+            // 1. { modelId, reqParent: undefined, reqCategory: categoryId, ownCategory: childCategoryId1, id: element1_1 } -> Request1
+            // 2. { modelId, reqParent: undefined, reqCategory: categoryId, ownCategory: childCategoryId2, id: element1_2 } -> not requested
+            // 3. { modelId, reqParent: element1, reqCategory: undefined, ownCategory: childCategoryId1, id: element1_1 } -> not requested
+            // 4. { modelId, reqParent: element1, reqCategory: undefined, ownCategory: childCategoryId2, id: element1_2 } -> Request2
+            // The saved counts will be correct, and returned results from the public functions will also be correct, but there will be additional data cached.
+            ecsql: `
+              SELECT modelId, reqParent, reqCategory, ownCategory, id
+              FROM Descendants
+              WHERE ownCategory IN (${[...allChildCategoryIds].join(", ")})
+            `,
+          },
+          {
+            rowFormat: "ECSqlPropertyNames",
+            limit: "unbounded",
+            restartToken: `${this.#componentName}/${this.#componentId}/child-elements/${Guid.createValue()}`,
+          },
         ),
-      );
-    const maximumBatchSize = 1000;
-    const totalSize = elementsToQuery.length;
-    const optimalBatchSize = getOptimalBatchSize({ totalSize, maximumBatchSize });
-    const loadingMapEntries = new Array<Promise<void>>();
-    // Don't want to slice if its not necessary
-    if (totalSize <= maximumBatchSize) {
-      loadingMapEntries.push(getElementsToQueryPromise(elementsToQuery));
-    } else {
-      for (let i = 0; i < elementsToQuery.length; i += optimalBatchSize) {
-        loadingMapEntries.push(getElementsToQueryPromise(elementsToQuery.slice(i, i + optimalBatchSize)));
-      }
+      // observable returns an ECSqlQueryRow, but the return type is known and can be cast as Row.
+    ) as Observable<Row>;
+  }
+
+  protected insertRow(row: Row): void {
+    const reqParent = row.reqParent ?? undefined;
+    const reqCategory = row.reqCategory ?? undefined;
+    let modelEntry = this.#cachedValues.get(row.modelId);
+    if (!modelEntry) {
+      modelEntry = new Map();
+      this.#cachedValues.set(row.modelId, modelEntry);
+    }
+    let parentEntry = modelEntry.get(reqParent);
+    if (!parentEntry) {
+      parentEntry = new Map();
+      modelEntry.set(reqParent, parentEntry);
+    }
+    let categoryEntry = parentEntry.get(reqCategory);
+    if (!categoryEntry) {
+      categoryEntry = new Map();
+      parentEntry.set(reqCategory, categoryEntry);
     }
 
-    elementsToQuery.forEach((elementId, index) => this.#childElementsLoadingMap.set(elementId, loadingMapEntries[Math.floor(index / optimalBatchSize)]));
-    return { loadingMapEntries: Promise.all(loadingMapEntries).then(() => {}) };
+    let ids = categoryEntry.get(row.ownCategory);
+    if (!ids) {
+      ids = [];
+      categoryEntry.set(row.ownCategory, ids);
+    }
+    ids.push(row.id);
   }
 
-  private createChildElementsMapEntries({ elementIds }: { elementIds: Id64Arg }): Observable<void[]> {
-    return from(Id64.iterable(elementIds)).pipe(
-      reduce(
-        (acc, elementId) => {
-          if (this.#childElementsMap.has(elementId)) {
-            return acc;
-          }
-          const loadingPromise = this.#childElementsLoadingMap.get(elementId);
-          if (loadingPromise) {
-            acc.existingPromises.push(loadingPromise);
-          } else {
-            acc.elementsToQuery.push(elementId);
-          }
-          return acc;
-        },
-        { existingPromises: new Array<Promise<void>>(), elementsToQuery: new Array<Id64String>() },
-      ),
-      mergeMap(async ({ elementsToQuery, existingPromises }) => {
-        existingPromises.push(this.createChildElementsLoadingMapEntries({ elementsToQuery }).loadingMapEntries);
-        return Promise.all(existingPromises);
+  protected ensureDefaultCacheEntries(batch: ChildElementsRequest[]): void {
+    for (const { modelId, categoryId, parentElementId, childCategoryIds } of batch) {
+      let modelEntry = this.#cachedValues.get(modelId);
+      if (!modelEntry) {
+        modelEntry = new Map();
+        this.#cachedValues.set(modelId, modelEntry);
+      }
+      let parentEntry = modelEntry.get(parentElementId);
+      if (!parentEntry) {
+        parentEntry = new Map();
+        modelEntry.set(parentElementId, parentEntry);
+      }
+      let categoryEntry = parentEntry.get(categoryId);
+      if (!categoryEntry) {
+        categoryEntry = new Map();
+        parentEntry.set(categoryId, categoryEntry);
+      }
+      for (const childCategoryId of childCategoryIds) {
+        if (!categoryEntry.has(childCategoryId)) {
+          categoryEntry.set(childCategoryId, []);
+        }
+      }
+    }
+  }
+
+  private getNotCachedRequestValues(request: ChildElementsRequest): { cached?: ChildElementsRequest; notCached?: ChildElementsRequest } {
+    const { modelId, parentElementId, categoryId, childCategoryIds } = request;
+    const cachedEntry = this.#cachedValues.get(modelId)?.get(parentElementId)?.get(categoryId);
+    if (!cachedEntry) {
+      return request.childCategoryIds.length > 0 ? { notCached: request } : {};
+    }
+    const missingCategories = new Array<CategoryId>();
+    const cachedCategories = new Array<CategoryId>();
+    for (const childCategoryId of childCategoryIds) {
+      if (cachedEntry.has(childCategoryId)) {
+        cachedCategories.push(childCategoryId);
+      } else {
+        missingCategories.push(childCategoryId);
+      }
+    }
+    return {
+      ...(cachedCategories.length > 0 ? { cached: { ...request, childCategoryIds: cachedCategories } } : {}),
+      ...(missingCategories.length > 0 ? { notCached: { ...request, childCategoryIds: missingCategories } } : {}),
+    };
+  }
+
+  public getChildElements(props: ChildElementsRequest): Observable<Id64Array> {
+    const { cached, notCached } = this.getNotCachedRequestValues(props);
+    const cachedResult = cached ? this.getCachedValue(cached) : undefined;
+    if (!notCached) {
+      return of(cachedResult ?? []);
+    }
+    return this.get(notCached).pipe(
+      map((notCachedValuesResult) => {
+        return [...(cachedResult ?? []), ...notCachedValuesResult];
       }),
     );
-  }
-
-  public getChildElementsTree({ elementIds }: { elementIds: Id64Arg }): Observable<ChildrenTree> {
-    return this.createChildElementsMapEntries({ elementIds }).pipe(map(() => this.getChildElementsTreeFromMap({ elementIds })));
-  }
-
-  public getAllChildElementsCount({ elementIds }: { elementIds: Id64Arg }): Observable<Map<Id64String, number>> {
-    return this.createChildElementsMapEntries({ elementIds }).pipe(map(() => this.getChildElementsCountMap({ elementIds })));
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
@@ -168,7 +168,12 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
   protected executeQuery(clauses: WhereClause[]): Observable<Row> {
     const categoryWhereClauses = clauses.filter((c) => c.type === "category").map((c) => c.whereClause);
     const elementWhereClauses = clauses.filter((c) => c.type === "element").map((c) => c.whereClause);
-    const allChildCategoryIds = new Set(...clauses.map(({ childCategoryIds }) => childCategoryIds));
+    const allChildCategoryIds = new Set<CategoryId>();
+    for (const { childCategoryIds } of clauses) {
+      for (const childCategoryId of childCategoryIds) {
+        allChildCategoryIds.add(childCategoryId);
+      }
+    }
 
     const baseCases: string[] = [];
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
@@ -226,9 +226,9 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
             // 4. { modelId, reqParent: element1, reqCategory: undefined, ownCategory: childCategoryId2, id: element1_2 } -> Request2
             // The saved counts will be correct, and returned results from the public functions will also be correct, but there will be additional data cached.
             ecsql: `
-              SELECT modelId, reqParent, reqCategory, ownCategory, id
-              FROM Descendants
-              JOIN IdSet(?) allChildCategoryIdSet ON ownCategory = allChildCategoryIdSet.id
+              SELECT d.modelId modelId, d.reqParent reqParent, d.reqCategory reqCategory, d.ownCategory ownCategory, d.id id
+              FROM Descendants d
+              JOIN IdSet(?) allChildCategoryIdSet ON d.ownCategory = allChildCategoryIdSet.id
               ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: [{ type: "idset", value: [...allChildCategoryIds] }],

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
@@ -228,8 +228,10 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
             ecsql: `
               SELECT modelId, reqParent, reqCategory, ownCategory, id
               FROM Descendants
-              WHERE ownCategory IN (${[...allChildCategoryIds].join(", ")})
+              JOIN IdSet(?) allChildCategoryIdSet ON ownCategory = allChildCategoryIdSet.id
+              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
+            bindings: [{ type: "idset", value: [...allChildCategoryIds] }],
           },
           {
             rowFormat: "ECSqlPropertyNames",

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
@@ -10,6 +10,7 @@ import { BatchingCache } from "./BatchingCache.js";
 import type { Observable } from "rxjs";
 import type { GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
+import type { ECSqlBinding } from "@itwin/presentation-shared";
 import type { CategoryId, ElementId, ModelId } from "../Types.js";
 
 interface ChildElementsBaseRequest {
@@ -39,6 +40,7 @@ interface WhereClause {
   whereClause: string;
   type: "element" | "category";
   childCategoryIds: Set<CategoryId>;
+  bindings?: ECSqlBinding[];
 }
 
 interface Row {
@@ -134,7 +136,7 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
     return from(groupedValues.entries()).pipe(
       mergeMap(([modelId, parentMap]) =>
         from(parentMap.entries()).pipe(
-          mergeMap(([parentElementId, categoryMap]) => {
+          mergeMap(([parentElementId, categoryMap], idx) => {
             const clauses: WhereClause[] = [];
             const undefinedEntry = categoryMap.get(undefined);
             if (undefinedEntry) {
@@ -153,9 +155,10 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
             }
             if (categoryMapKeys.length > 0) {
               clauses.push({
-                whereClause: `Model.Id = ${modelId} AND Category.Id IN (${categoryMapKeys.join(", ")}) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
+                whereClause: `Model.Id = ${modelId} AND Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
                 type: "category",
                 childCategoryIds: allChildCategoryIds,
+                bindings: [{ type: "idset", value: categoryMapKeys }],
               });
             }
             return from(clauses);
@@ -166,8 +169,8 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
   }
 
   protected executeQuery(clauses: WhereClause[]): Observable<Row> {
-    const categoryWhereClauses = clauses.filter((c) => c.type === "category").map((c) => c.whereClause);
-    const elementWhereClauses = clauses.filter((c) => c.type === "element").map((c) => c.whereClause);
+    const categoryClauses = clauses.filter((c) => c.type === "category");
+    const elementClauses = clauses.filter((c) => c.type === "element");
     const allChildCategoryIds = new Set<CategoryId>();
     for (const { childCategoryIds } of clauses) {
       for (const childCategoryId of childCategoryIds) {
@@ -177,19 +180,19 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
 
     const baseCases: string[] = [];
 
-    if (categoryWhereClauses.length > 0) {
+    if (categoryClauses.length > 0) {
       baseCases.push(`
         SELECT ECInstanceId, Model.Id, Parent.Id, Category.Id, Category.Id
         FROM ${this.#elementClassName}
-        WHERE ${categoryWhereClauses.join(" OR ")}
+        WHERE ${categoryClauses.map((c) => c.whereClause).join(" OR ")}
       `);
     }
 
-    if (elementWhereClauses.length > 0) {
+    if (elementClauses.length > 0) {
       baseCases.push(`
         SELECT ECInstanceId, Model.Id, Parent.Id, CAST(NULL AS TEXT), Category.Id
         FROM ${this.#elementClassName}
-        WHERE ${elementWhereClauses.join(" OR ")}
+        WHERE ${elementClauses.map((c) => c.whereClause).join(" OR ")}
       `);
     }
 
@@ -231,7 +234,11 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
               JOIN IdSet(?) allChildCategoryIdSet ON d.ownCategory = allChildCategoryIdSet.id
               ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
-            bindings: [{ type: "idset", value: [...allChildCategoryIds] }],
+            bindings: [
+              ...categoryClauses.map((c) => c.bindings ?? []).flat(),
+              ...elementClauses.map((c) => c.bindings ?? []).flat(),
+              { type: "idset", value: [...allChildCategoryIds] },
+            ],
           },
           {
             rowFormat: "ECSqlPropertyNames",

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -3,17 +3,14 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { bufferCount, defer, EMPTY, from, map, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
+import { defer, EMPTY, from, mergeMap } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
-import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
-import { releaseMainThreadOnItemsCount } from "../Utils.js";
+import { BatchingCache } from "./BatchingCache.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 import type { CategoryId, ElementId, ModelId } from "../Types.js";
-
-type RequestId = string;
 
 interface DescendantsCountBaseRequest {
   modelId: ModelId;
@@ -29,7 +26,20 @@ interface DescendantsCountElementRequest extends DescendantsCountBaseRequest {
   categoryId?: undefined;
 }
 
-type RequestEntry = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>;
+type DescendantsCountRequest = DescendantsCountCategoryRequest | DescendantsCountElementRequest;
+type DescendantsCountResult = Array<{ categoryId: CategoryId; count: number }>;
+type Batch = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>;
+interface WhereClause {
+  whereClause: string;
+  type: "element" | "category";
+}
+interface Row {
+  modelId: ModelId;
+  reqParent: ElementId | undefined | null;
+  reqCategory: CategoryId | undefined | null;
+  ownCategory: CategoryId;
+  cnt: number;
+}
 
 /**
  * Cache used to store count of descendants grouped by category.
@@ -37,52 +47,62 @@ type RequestEntry = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | und
  * Cache makes requests in batches of 20ms.
  * @internal
  */
-export class DescendantsCountCache {
-  // When a new request is made:
-  // - If the value is already cached (#cachedValues), returns it.
-  // - If it's already requested (#requestedValues), pipe through the observable. When observable emits, the cached value can be retrieved,
-  // - If the value is not requested yet, add it to the values which will be requested (#valuesToRequest).
-  // #valuesToRequest observable waits for 20ms, then adds the observable value to #requestedValues and starts the query.
-  // When the query completes the observable removes the value from #requestedValues.
-
-  #cachedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, Array<{ categoryId: CategoryId; count: number }>>>>();
-  #valuesToRequest: { values: RequestEntry; sharedObs: Observable<void> } | undefined;
-  #requestedValues = new Map<RequestId, { values: RequestEntry; sharedObs: Observable<void> }>();
+export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest, Batch, DescendantsCountResult, WhereClause, Row> {
+  #cachedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, DescendantsCountResult>>>();
   #queryExecutor: LimitingECSqlQueryExecutor;
   #elementClassName: string;
   #componentId: GuidString;
   #componentName: string;
 
   public constructor(props: { queryExecutor: LimitingECSqlQueryExecutor; elementClassName: string; componentId: GuidString }) {
+    super();
     this.#componentId = props.componentId;
     this.#queryExecutor = props.queryExecutor;
     this.#elementClassName = props.elementClassName;
     this.#componentName = "DescendantsCountCache";
   }
 
-  private getCachedValueAfterObservable({
-    modelId,
-    categoryId,
-    parentElementId,
-    observable,
-  }: {
-    observable: Observable<void>;
-  } & (DescendantsCountElementRequest | DescendantsCountCategoryRequest)): Observable<Array<{ categoryId: CategoryId; count: number }>> {
-    return observable.pipe(
-      map(() => {
-        const entry = this.#cachedValues.get(modelId)?.get(parentElementId)?.get(categoryId);
-        assert(entry !== undefined);
-        return entry;
-      }),
-    );
+  protected getCachedValue(request: DescendantsCountRequest): DescendantsCountResult | undefined {
+    return this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
   }
 
-  private executeBatchQuery(valuesToRequest: RequestEntry) {
-    return from(valuesToRequest.entries()).pipe(
+  protected getGuaranteedCachedValue(request: DescendantsCountRequest): DescendantsCountResult {
+    const entry = this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
+    assert(entry !== undefined);
+    return entry;
+  }
+
+  protected getValuesToRequest(request: DescendantsCountRequest, batch: Batch): DescendantsCountRequest | undefined {
+    if (batch.get(request.modelId)?.get(request.parentElementId)?.has(request.categoryId)) {
+      return undefined;
+    }
+    return request;
+  }
+
+  protected createBatch(): Batch {
+    return new Map();
+  }
+
+  protected addRequestToBatch(request: DescendantsCountRequest, batch: Batch): void {
+    let modelEntry = batch.get(request.modelId);
+    if (!modelEntry) {
+      modelEntry = new Map();
+      batch.set(request.modelId, modelEntry);
+    }
+    let parentEntry = modelEntry.get(request.parentElementId);
+    if (!parentEntry) {
+      parentEntry = new Set();
+      modelEntry.set(request.parentElementId, parentEntry);
+    }
+    parentEntry.add(request.categoryId);
+  }
+
+  protected getIterable(batch: Batch): Observable<WhereClause> {
+    return from(batch.entries()).pipe(
       mergeMap(([modelId, parentMap]) =>
         from(parentMap.entries()).pipe(
           mergeMap(([parentElementId, categoryIds]) => {
-            const clauses: Array<{ whereClause: string; type: "element" | "category" }> = [];
+            const clauses = new Array<WhereClause>();
             if (categoryIds.has(undefined)) {
               assert(parentElementId !== undefined);
               clauses.push({ whereClause: `Model.Id = ${modelId} AND Parent.Id = ${parentElementId}`, type: "element" });
@@ -98,163 +118,112 @@ export class DescendantsCountCache {
           }),
         ),
       ),
-      bufferCount(100),
-      mergeMap((whereClauses) => {
-        const categoryWhereClauses = whereClauses.filter((c) => c.type === "category").map((c) => c.whereClause);
-        const elementWhereClauses = whereClauses.filter((c) => c.type === "element").map((c) => c.whereClause);
-
-        const baseCases: string[] = [];
-
-        if (categoryWhereClauses.length > 0) {
-          baseCases.push(`
-            SELECT ECInstanceId, Model.Id, Parent.Id, Category.Id, Category.Id
-            FROM ${this.#elementClassName}
-            WHERE ${categoryWhereClauses.join(" OR ")}
-          `);
-        }
-
-        if (elementWhereClauses.length > 0) {
-          baseCases.push(`
-            SELECT ECInstanceId, Model.Id, Parent.Id, CAST(NULL AS TEXT), Category.Id
-            FROM ${this.#elementClassName}
-            WHERE ${elementWhereClauses.join(" OR ")}
-          `);
-        }
-
-        if (baseCases.length === 0) {
-          return EMPTY;
-        }
-
-        return defer(() =>
-          this.#queryExecutor.createQueryReader(
-            {
-              ctes: [
-                `
-                Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
-                  ${baseCases.join(" UNION ALL ")}
-
-                  UNION ALL
-
-                  SELECT c.ECInstanceId, p.modelId, p.reqParent, p.reqCategory, c.Category.Id
-                  FROM ${this.#elementClassName} c
-                  JOIN Descendants p ON c.Parent.Id = p.id
-                )
-                `,
-              ],
-              ecsql: `
-                SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
-                FROM Descendants
-                GROUP BY modelId, reqParent, reqCategory, ownCategory
-              `,
-            },
-            {
-              rowFormat: "ECSqlPropertyNames",
-              limit: "unbounded",
-              restartToken: `${this.#componentName}/${this.#componentId}/descendants-counts/${Guid.createValue()}`,
-            },
-          ),
-        ).pipe(catchBeSQLiteInterrupts);
-      }),
-      releaseMainThreadOnItemsCount(500),
     );
   }
 
-  public getDescendantsCounts(
-    props: DescendantsCountCategoryRequest | DescendantsCountElementRequest,
-  ): Observable<Array<{ categoryId: CategoryId; count: number }>> {
-    const cachedValue = this.#cachedValues.get(props.modelId)?.get(props.parentElementId)?.get(props.categoryId);
-    // Cached values can be returned immediately
-    if (cachedValue !== undefined) {
-      return of(cachedValue);
+  protected executeQuery(items: WhereClause[]): Observable<Row> {
+    const categoryWhereClauses = items.filter((c) => c.type === "category").map((c) => c.whereClause);
+    const elementWhereClauses = items.filter((c) => c.type === "element").map((c) => c.whereClause);
+
+    const baseCases: string[] = [];
+
+    if (categoryWhereClauses.length > 0) {
+      baseCases.push(`
+        SELECT ECInstanceId, Model.Id, Parent.Id, Category.Id, Category.Id
+        FROM ${this.#elementClassName}
+        WHERE ${categoryWhereClauses.join(" OR ")}
+      `);
     }
 
-    // Check if value was already requested. If it was, wait for requested observable to emit and then return the value from cache
-    for (const { values, sharedObs: obs } of this.#requestedValues.values()) {
-      if (values.get(props.modelId)?.get(props.parentElementId)?.has(props.categoryId)) {
-        return this.getCachedValueAfterObservable({ ...props, observable: obs });
+    if (elementWhereClauses.length > 0) {
+      baseCases.push(`
+        SELECT ECInstanceId, Model.Id, Parent.Id, CAST(NULL AS TEXT), Category.Id
+        FROM ${this.#elementClassName}
+        WHERE ${elementWhereClauses.join(" OR ")}
+      `);
+    }
+
+    if (baseCases.length === 0) {
+      return EMPTY;
+    }
+
+    return defer(
+      () =>
+        this.#queryExecutor.createQueryReader(
+          {
+            ctes: [
+              `
+            Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
+              ${baseCases.join(" UNION ALL ")}
+
+              UNION ALL
+
+              SELECT c.ECInstanceId, p.modelId, p.reqParent, p.reqCategory, c.Category.Id
+              FROM ${this.#elementClassName} c
+              JOIN Descendants p ON c.Parent.Id = p.id
+            )
+            `,
+            ],
+            ecsql: `
+            SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
+            FROM Descendants
+            GROUP BY modelId, reqParent, reqCategory, ownCategory
+          `,
+          },
+          {
+            rowFormat: "ECSqlPropertyNames",
+            limit: "unbounded",
+            restartToken: `${this.#componentName}/${this.#componentId}/descendants-counts/${Guid.createValue()}`,
+          },
+        ),
+      // observable returns an ECSqlQueryRow, but the return type is known and can be cast as Row.
+    ) as Observable<Row>;
+  }
+
+  protected insertRow(row: Row): void {
+    const reqParent = row.reqParent ?? undefined;
+    const reqCategory = row.reqCategory ?? undefined;
+    let modelEntry = this.#cachedValues.get(row.modelId);
+    if (!modelEntry) {
+      modelEntry = new Map();
+      this.#cachedValues.set(row.modelId, modelEntry);
+    }
+    let parentEntry = modelEntry.get(reqParent);
+    if (!parentEntry) {
+      parentEntry = new Map();
+      modelEntry.set(reqParent, parentEntry);
+    }
+    let categoryEntry = parentEntry.get(reqCategory);
+    if (!categoryEntry) {
+      categoryEntry = [];
+      parentEntry.set(reqCategory, categoryEntry);
+    }
+    categoryEntry.push({ categoryId: row.ownCategory, count: row.cnt });
+  }
+
+  protected ensureDefaultCacheEntries(batch: Batch): void {
+    for (const [entryModelId, parentMap] of batch.entries()) {
+      let modelEntry = this.#cachedValues.get(entryModelId);
+      if (!modelEntry) {
+        modelEntry = new Map();
+        this.#cachedValues.set(entryModelId, modelEntry);
+      }
+      for (const [parentElementId, categoryIds] of parentMap) {
+        let parentEntry = modelEntry.get(parentElementId);
+        if (!parentEntry) {
+          parentEntry = new Map();
+          modelEntry.set(parentElementId, parentEntry);
+        }
+        for (const entryCategoryId of categoryIds) {
+          if (!parentEntry.has(entryCategoryId)) {
+            parentEntry.set(entryCategoryId, entryCategoryId === undefined ? [] : [{ categoryId: entryCategoryId, count: 0 }]);
+          }
+        }
       }
     }
+  }
 
-    if (this.#valuesToRequest === undefined) {
-      // Store request guid so it can be deleted later.
-      const requestId = Guid.createValue();
-      const sharedObs = timer(20).pipe(
-        switchMap(() => {
-          assert(this.#valuesToRequest !== undefined);
-          // After 20 ms, assign the observable in #valuesToRequest to the #requestedValues
-          const valuesToRequest = this.#valuesToRequest;
-          this.#requestedValues.set(requestId, valuesToRequest);
-          // Clear #valuesToRequest so new requests can be collected while the query is executing
-          this.#valuesToRequest = undefined;
-          return this.executeBatchQuery(valuesToRequest.values).pipe(
-            // Cache each row as it arrives, use reduce to emit one value when query completes
-            reduce((acc, row) => {
-              const reqParent = row.reqParent ?? undefined;
-              const reqCategory = row.reqCategory ?? undefined;
-              let modelEntry = this.#cachedValues.get(row.modelId);
-              if (!modelEntry) {
-                modelEntry = new Map();
-                this.#cachedValues.set(row.modelId, modelEntry);
-              }
-              let parentEntry = modelEntry.get(reqParent);
-              if (!parentEntry) {
-                parentEntry = new Map();
-                modelEntry.set(reqParent, parentEntry);
-              }
-              let categoryEntry = parentEntry.get(reqCategory);
-              if (!categoryEntry) {
-                categoryEntry = [];
-                parentEntry.set(reqCategory, categoryEntry);
-              }
-              categoryEntry.push({ categoryId: row.ownCategory, count: row.cnt });
-              return acc;
-            }, undefined),
-            tap(() => {
-              for (const [entryModelId, parentMap] of valuesToRequest.values.entries()) {
-                let modelEntry = this.#cachedValues.get(entryModelId);
-                if (!modelEntry) {
-                  modelEntry = new Map();
-                  this.#cachedValues.set(entryModelId, modelEntry);
-                }
-                for (const [parentElementId, categoryIds] of parentMap) {
-                  let parentEntry = modelEntry.get(parentElementId);
-                  if (!parentEntry) {
-                    parentEntry = new Map();
-                    modelEntry.set(parentElementId, parentEntry);
-                  }
-                  for (const entryCategoryId of categoryIds) {
-                    if (!parentEntry.has(entryCategoryId)) {
-                      parentEntry.set(entryCategoryId, entryCategoryId === undefined ? [] : [{ categoryId: entryCategoryId, count: 0 }]);
-                    }
-                  }
-                }
-              }
-            }),
-          );
-        }),
-        tap({
-          finalize: () => {
-            // Remove requestedValues entry when the query completes.
-            this.#requestedValues.delete(requestId);
-          },
-        }),
-        shareReplay(1),
-      );
-      this.#valuesToRequest = { values: new Map([[props.modelId, new Map([[props.parentElementId, new Set([props.categoryId])]])]]), sharedObs };
-      return this.getCachedValueAfterObservable({ ...props, observable: this.#valuesToRequest.sharedObs });
-    }
-
-    let existingModelEntry = this.#valuesToRequest.values.get(props.modelId);
-    if (!existingModelEntry) {
-      existingModelEntry = new Map();
-      this.#valuesToRequest.values.set(props.modelId, existingModelEntry);
-    }
-    let existingParentEntry = existingModelEntry.get(props.parentElementId);
-    if (!existingParentEntry) {
-      existingParentEntry = new Set();
-      existingModelEntry.set(props.parentElementId, existingParentEntry);
-    }
-    existingParentEntry.add(props.categoryId);
-    return this.getCachedValueAfterObservable({ ...props, observable: this.#valuesToRequest.sharedObs });
+  public getDescendantsCounts(props: DescendantsCountRequest): Observable<DescendantsCountResult> {
+    return this.get(props);
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -113,9 +113,9 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     );
   }
 
-  protected executeQuery(items: WhereClause[]): Observable<Row> {
-    const categoryWhereClauses = items.filter((c) => c.type === "category").map((c) => c.whereClause);
-    const elementWhereClauses = items.filter((c) => c.type === "element").map((c) => c.whereClause);
+  protected executeQuery(clauses: WhereClause[]): Observable<Row> {
+    const categoryWhereClauses = clauses.filter((c) => c.type === "category").map((c) => c.whereClause);
+    const elementWhereClauses = clauses.filter((c) => c.type === "element").map((c) => c.whereClause);
 
     const baseCases: string[] = [];
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -28,7 +28,6 @@ interface DescendantsCountElementRequest extends DescendantsCountBaseRequest {
 
 type DescendantsCountRequest = DescendantsCountCategoryRequest | DescendantsCountElementRequest;
 type DescendantsCountResult = Array<{ categoryId: CategoryId; count: number }>;
-type Batch = Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>;
 interface WhereClause {
   whereClause: string;
   type: "element" | "category";
@@ -47,7 +46,7 @@ interface Row {
  * Cache makes requests in batches of 20ms.
  * @internal
  */
-export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest, Batch, DescendantsCountResult, WhereClause, Row> {
+export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest, DescendantsCountResult, WhereClause, Row> {
   #cachedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, DescendantsCountResult>>>();
   #queryExecutor: LimitingECSqlQueryExecutor;
   #elementClassName: string;
@@ -68,34 +67,30 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
 
   protected getValuesNotInBatch(
     request: DescendantsCountRequest,
-    batch: Batch,
+    batch: DescendantsCountRequest[],
   ): { valuesNotInBatch: DescendantsCountRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true } {
-    if (batch.get(request.modelId)?.get(request.parentElementId)?.has(request.categoryId)) {
+    if (batch.some((r) => r.modelId === request.modelId && r.parentElementId === request.parentElementId && r.categoryId === request.categoryId)) {
       return { valuesNotInBatch: undefined, batchContainsValues: true };
     }
     return { valuesNotInBatch: request, batchContainsValues: false };
   }
 
-  protected createBatch(): Batch {
-    return new Map();
-  }
-
-  protected addRequestToBatch(request: DescendantsCountRequest, batch: Batch): void {
-    let modelEntry = batch.get(request.modelId);
-    if (!modelEntry) {
-      modelEntry = new Map();
-      batch.set(request.modelId, modelEntry);
+  protected getIterable(batch: DescendantsCountRequest[]): Observable<WhereClause> {
+    const groupedValues = new Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>();
+    for (const { modelId, parentElementId, categoryId } of batch) {
+      let modelEntry = groupedValues.get(modelId);
+      if (!modelEntry) {
+        modelEntry = new Map();
+        groupedValues.set(modelId, modelEntry);
+      }
+      let parentEntry = modelEntry.get(parentElementId);
+      if (!parentEntry) {
+        parentEntry = new Set();
+        modelEntry.set(parentElementId, parentEntry);
+      }
+      parentEntry.add(categoryId);
     }
-    let parentEntry = modelEntry.get(request.parentElementId);
-    if (!parentEntry) {
-      parentEntry = new Set();
-      modelEntry.set(request.parentElementId, parentEntry);
-    }
-    parentEntry.add(request.categoryId);
-  }
-
-  protected getIterable(batch: Batch): Observable<WhereClause> {
-    return from(batch.entries()).pipe(
+    return from(groupedValues.entries()).pipe(
       mergeMap(([modelId, parentMap]) =>
         from(parentMap.entries()).pipe(
           mergeMap(([parentElementId, categoryIds]) => {
@@ -198,24 +193,20 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     categoryEntry.push({ categoryId: row.ownCategory, count: row.cnt });
   }
 
-  protected ensureDefaultCacheEntries(batch: Batch): void {
-    for (const [entryModelId, parentMap] of batch.entries()) {
-      let modelEntry = this.#cachedValues.get(entryModelId);
+  protected ensureDefaultCacheEntries(batch: DescendantsCountRequest[]): void {
+    for (const { modelId, categoryId, parentElementId } of batch) {
+      let modelEntry = this.#cachedValues.get(modelId);
       if (!modelEntry) {
         modelEntry = new Map();
-        this.#cachedValues.set(entryModelId, modelEntry);
+        this.#cachedValues.set(modelId, modelEntry);
       }
-      for (const [parentElementId, categoryIds] of parentMap) {
-        let parentEntry = modelEntry.get(parentElementId);
-        if (!parentEntry) {
-          parentEntry = new Map();
-          modelEntry.set(parentElementId, parentEntry);
-        }
-        for (const entryCategoryId of categoryIds) {
-          if (!parentEntry.has(entryCategoryId)) {
-            parentEntry.set(entryCategoryId, entryCategoryId === undefined ? [] : [{ categoryId: entryCategoryId, count: 0 }]);
-          }
-        }
+      let parentEntry = modelEntry.get(parentElementId);
+      if (!parentEntry) {
+        parentEntry = new Map();
+        modelEntry.set(parentElementId, parentEntry);
+      }
+      if (!parentEntry.has(categoryId)) {
+        parentEntry.set(categoryId, categoryId === undefined ? [] : [{ categoryId, count: 0 }]);
       }
     }
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defer, EMPTY, from, mergeMap } from "rxjs";
-import { assert, Guid } from "@itwin/core-bentley";
+import { defer, EMPTY, from, map, merge, mergeMap } from "rxjs";
+import { Guid } from "@itwin/core-bentley";
 import { BatchingCache } from "./BatchingCache.js";
 
 import type { Observable } from "rxjs";
@@ -76,12 +76,23 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
   }
 
   protected getQueryData(batch: DescendantsCountRequest[]): Observable<WhereClause> {
-    const groupedValues = new Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>();
-    for (const { modelId, parentElementId, categoryId } of batch) {
-      let modelEntry = groupedValues.get(modelId);
+    const groupedCategoryValues = new Map<ModelId, Map<ElementId | undefined, Set<CategoryId>>>();
+    const groupedElementValues = new Map<ModelId, Set<ElementId>>();
+    for (const batchEntry of batch) {
+      if (batchEntry.categoryId === undefined) {
+        let groupedElementsModelEntry = groupedElementValues.get(batchEntry.modelId);
+        if (!groupedElementsModelEntry) {
+          groupedElementsModelEntry = new Set();
+          groupedElementValues.set(batchEntry.modelId, groupedElementsModelEntry);
+        }
+        groupedElementsModelEntry.add(batchEntry.parentElementId);
+        continue;
+      }
+      const { modelId, parentElementId, categoryId } = batchEntry;
+      let modelEntry = groupedCategoryValues.get(modelId);
       if (!modelEntry) {
         modelEntry = new Map();
-        groupedValues.set(modelId, modelEntry);
+        groupedCategoryValues.set(modelId, modelEntry);
       }
       let parentEntry = modelEntry.get(parentElementId);
       if (!parentEntry) {
@@ -90,26 +101,31 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
       }
       parentEntry.add(categoryId);
     }
-    return from(groupedValues.entries()).pipe(
-      mergeMap(([modelId, parentMap]) =>
-        from(parentMap.entries()).pipe(
-          mergeMap(([parentElementId, categoryIds]) => {
-            const clauses = new Array<WhereClause>();
-            if (categoryIds.has(undefined)) {
-              assert(parentElementId !== undefined);
-              clauses.push({ whereClause: `Model.Id = ${modelId} AND Parent.Id = ${parentElementId}`, type: "element" });
-            }
-            const concreteCategoryIds = [...categoryIds].filter((id): id is CategoryId => id !== undefined);
-            if (concreteCategoryIds.length > 0) {
-              clauses.push({
-                whereClause: `Model.Id = ${modelId} AND Category.Id IN (${concreteCategoryIds.join(", ")}) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
-                type: "category",
-              });
-            }
-            return from(clauses);
-          }),
-        ),
-      ),
+    return merge(
+      groupedCategoryValues.size > 0
+        ? from(groupedCategoryValues.entries()).pipe(
+            mergeMap(([modelId, parentMap]) =>
+              from(parentMap.entries()).pipe(
+                map(([parentElementId, categoryIds]) => {
+                  return {
+                    whereClause: `Model.Id = ${modelId} AND Category.Id IN (${[...categoryIds].join(", ")}) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
+                    type: "category" as const,
+                  };
+                }),
+              ),
+            ),
+          )
+        : EMPTY,
+      groupedElementValues.size > 0
+        ? from(groupedElementValues.entries()).pipe(
+            map(([modelId, parentElementIds]) => {
+              return {
+                whereClause: `Model.Id = ${modelId} AND Parent.Id IN (${[...parentElementIds].join(", ")})`,
+                type: "element" as const,
+              };
+            }),
+          )
+        : EMPTY,
     );
   }
 
@@ -213,5 +229,10 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
 
   public getDescendantsCounts(props: DescendantsCountRequest): Observable<DescendantsCountResult> {
     return this.get(props);
+  }
+
+  /** Pre-warms the cache by queuing a request into the next batch without subscribing to results. */
+  public storeRequest(request: DescendantsCountRequest): void {
+    return this.store(request);
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -72,11 +72,14 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     return entry;
   }
 
-  protected getValuesToRequest(request: DescendantsCountRequest, batch: Batch): DescendantsCountRequest | undefined {
+  protected getValuesNotInBatch(
+    request: DescendantsCountRequest,
+    batch: Batch,
+  ): { valuesNotInBatch: DescendantsCountRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true } {
     if (batch.get(request.modelId)?.get(request.parentElementId)?.has(request.categoryId)) {
-      return undefined;
+      return { valuesNotInBatch: undefined, batchContainsValues: true };
     }
-    return request;
+    return { valuesNotInBatch: request, batchContainsValues: false };
   }
 
   protected createBatch(): Batch {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -66,12 +66,6 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     return this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
   }
 
-  protected getGuaranteedCachedValue(request: DescendantsCountRequest): DescendantsCountResult {
-    const entry = this.#cachedValues.get(request.modelId)?.get(request.parentElementId)?.get(request.categoryId);
-    assert(entry !== undefined);
-    return entry;
-  }
-
   protected getValuesNotInBatch(
     request: DescendantsCountRequest,
     batch: Batch,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -75,7 +75,7 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     return { valuesNotInBatch: request, batchContainsValues: false };
   }
 
-  protected getIterable(batch: DescendantsCountRequest[]): Observable<WhereClause> {
+  protected getQueryData(batch: DescendantsCountRequest[]): Observable<WhereClause> {
     const groupedValues = new Map<ModelId, Map<ElementId | undefined, Set<CategoryId | undefined>>>();
     for (const { modelId, parentElementId, categoryId } of batch) {
       let modelEntry = groupedValues.get(modelId);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -230,9 +230,4 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
   public getDescendantsCounts(props: DescendantsCountRequest): Observable<DescendantsCountResult> {
     return this.get(props);
   }
-
-  /** Pre-warms the cache by queuing a request into the next batch without subscribing to results. */
-  public storeRequest(request: DescendantsCountRequest): void {
-    return this.store(request);
-  }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -10,6 +10,7 @@ import { BatchingCache } from "./BatchingCache.js";
 import type { Observable } from "rxjs";
 import type { GuidString } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
+import type { ECSqlBinding } from "@itwin/presentation-shared";
 import type { CategoryId, ElementId, ModelId } from "../Types.js";
 
 interface DescendantsCountBaseRequest {
@@ -31,6 +32,7 @@ type DescendantsCountResult = Array<{ categoryId: CategoryId; count: number }>;
 interface WhereClause {
   whereClause: string;
   type: "element" | "category";
+  bindings?: ECSqlBinding[];
 }
 interface Row {
   modelId: ModelId;
@@ -102,58 +104,60 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
       parentEntry.add(categoryId);
     }
     return merge(
-      groupedCategoryValues.size > 0
-        ? from(groupedCategoryValues.entries()).pipe(
-            mergeMap(([modelId, parentMap]) =>
-              from(parentMap.entries()).pipe(
-                map(([parentElementId, categoryIds]) => {
-                  return {
-                    whereClause: `Model.Id = ${modelId} AND Category.Id IN (${[...categoryIds].join(", ")}) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
-                    type: "category" as const,
-                  };
-                }),
-              ),
-            ),
-          )
-        : EMPTY,
-      groupedElementValues.size > 0
-        ? from(groupedElementValues.entries()).pipe(
-            map(([modelId, parentElementIds]) => {
+      from(groupedCategoryValues.entries()).pipe(
+        mergeMap(([modelId, parentMap]) =>
+          from(parentMap.entries()).pipe(
+            map(([parentElementId, categoryIds], idx): WhereClause => {
               return {
-                whereClause: `Model.Id = ${modelId} AND Parent.Id IN (${[...parentElementIds].join(", ")})`,
-                type: "element" as const,
+                whereClause: `Model.Id = ${modelId} AND Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
+                type: "category" as const,
+                bindings: [{ type: "idset" as const, value: [...categoryIds] }],
               };
             }),
-          )
-        : EMPTY,
+          ),
+        ),
+      ),
+      from(groupedElementValues.entries()).pipe(
+        map(([modelId, parentElementIds], idx): WhereClause => {
+          return {
+            whereClause: `Model.Id = ${modelId} AND Parent.Id IN (SELECT elementIdSet${idx}.id FROM IdSet(?) elementIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES)`,
+            type: "element" as const,
+            bindings: [{ type: "idset" as const, value: [...parentElementIds] }],
+          };
+        }),
+      ),
     );
   }
 
   protected executeQuery(clauses: WhereClause[]): Observable<Row> {
-    const categoryWhereClauses = clauses.filter((c) => c.type === "category").map((c) => c.whereClause);
-    const elementWhereClauses = clauses.filter((c) => c.type === "element").map((c) => c.whereClause);
+    const categoryClauses = clauses.filter((c) => c.type === "category");
+    const elementClauses = clauses.filter((c) => c.type === "element");
 
     const baseCases: string[] = [];
 
-    if (categoryWhereClauses.length > 0) {
+    if (categoryClauses.length > 0) {
       baseCases.push(`
         SELECT ECInstanceId, Model.Id, Parent.Id, Category.Id, Category.Id
         FROM ${this.#elementClassName}
-        WHERE ${categoryWhereClauses.join(" OR ")}
+        WHERE ${categoryClauses.map((c) => c.whereClause).join(" OR ")}
       `);
     }
 
-    if (elementWhereClauses.length > 0) {
+    if (elementClauses.length > 0) {
       baseCases.push(`
         SELECT ECInstanceId, Model.Id, Parent.Id, CAST(NULL AS TEXT), Category.Id
         FROM ${this.#elementClassName}
-        WHERE ${elementWhereClauses.join(" OR ")}
+        WHERE ${elementClauses.map((c) => c.whereClause).join(" OR ")}
       `);
     }
 
     if (baseCases.length === 0) {
       return EMPTY;
     }
+    const bindings: ECSqlBinding[] = categoryClauses
+      .map((c) => c.bindings ?? [])
+      .flat()
+      .concat(elementClauses.map((c) => c.bindings ?? []).flat());
 
     return defer(
       () =>
@@ -161,22 +165,23 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
           {
             ctes: [
               `
-            Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
-              ${baseCases.join(" UNION ALL ")}
+              Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
+                ${baseCases.join(" UNION ALL ")}
 
-              UNION ALL
+                UNION ALL
 
-              SELECT c.ECInstanceId, p.modelId, p.reqParent, p.reqCategory, c.Category.Id
-              FROM ${this.#elementClassName} c
-              JOIN Descendants p ON c.Parent.Id = p.id
-            )
-            `,
+                SELECT c.ECInstanceId, p.modelId, p.reqParent, p.reqCategory, c.Category.Id
+                FROM ${this.#elementClassName} c
+                JOIN Descendants p ON c.Parent.Id = p.id
+              )
+              `,
             ],
             ecsql: `
-            SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
-            FROM Descendants
-            GROUP BY modelId, reqParent, reqCategory, ownCategory
-          `,
+              SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
+              FROM Descendants
+              GROUP BY modelId, reqParent, reqCategory, ownCategory
+            `,
+            bindings: bindings.length > 0 ? bindings : undefined,
           },
           {
             rowFormat: "ECSqlPropertyNames",

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/useTreeHooks/UseCachedVisibility.ts
@@ -296,7 +296,7 @@ export class HierarchyVisibilityHandlerImpl<TSearchTargets> implements Hierarchy
         if (!targets) {
           return EMPTY;
         }
-        return treeSpecificVisibilityHandler.getSearchTargetsVisibilityStatus(targets, node);
+        return treeSpecificVisibilityHandler.getSearchTargetsVisibilityStatus(targets);
       }),
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -315,13 +315,13 @@ export class BaseVisibilityHelper implements Disposable {
       elementIds: Id64Arg;
       modelId: Id64String;
       categoryId: Id64String;
-    } & ({ ignoreDescendants: true } | { ignoreDescendants?: false; categoryOfTopMostParentElement: CategoryId; parentElementsIdsPath: Array<Id64Arg> }),
+    } & ({ computeOnlyOwnStatus: true } | { computeOnlyOwnStatus?: false; categoryOfTopMostParentElement: CategoryId; parentElementsIdsPath: Array<Id64Arg> }),
   ): Observable<VisibilityStatus> {
     const result = defer(() => {
-      const { elementIds, modelId, categoryId, ignoreDescendants } = props;
+      const { elementIds, modelId, categoryId, computeOnlyOwnStatus } = props;
       // Compute element's own visibility
       const elementsOwnStatus = this.getElementsOwnVisibilityStatus({ elementIds, modelId, categoryId });
-      if (ignoreDescendants) {
+      if (computeOnlyOwnStatus) {
         return elementsOwnStatus;
       }
       const subModelsVisibilityStatus = this.#props.baseIdsCache.hasSubModels({ modelId }).pipe(
@@ -394,7 +394,7 @@ export class BaseVisibilityHelper implements Disposable {
     if (!this.#props.viewport.viewsModel(modelId)) {
       return of(createVisibilityStatus("hidden"));
     }
-    return from(Id64.iterable(elementIds)).pipe(
+    return fromWithRelease({ source: elementIds, releaseOnCount: 500 }).pipe(
       mergeMap((elementId) => this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId })),
       reduce(
         (acc, descendantsCounts) => {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -307,6 +307,7 @@ export class BaseVisibilityHelper implements Disposable {
    * Determines visibility status by checking:
    * - Elements in the viewports' always/never drawn lists;
    * - Related categories and models visibility status;
+   * - Descendant elements grouped by their actual categories;
    * - Sub-models that are related to the specified elements.
    */
   public getElementsVisibilityStatus(
@@ -377,9 +378,11 @@ export class BaseVisibilityHelper implements Disposable {
   }
 
   /**
-   * Computes descendant visibility per category.
-   * Groups categories by default visibility, queries always/never drawn per group,
-   * and computes per-category status.
+   * Gets visibility status of descendants by:
+   * 1. Retrieves counts of descendant elements grouped by their actual categories;
+   * 2. Groups categories into visible/hidden based on per-model category overrides and category selector;
+   * 3. For visible categories, retrieves never-drawn descendants; for hidden categories, retrieves always-drawn descendants;
+   * 4. Computes visibility status per group based on total count and number of elements in opposite set.
    */
   private getDescendantsVisibilityStatus(props: {
     elementIds: Id64Arg;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -32,7 +32,7 @@ import { changeElementStateNoChildrenOperator, getVisibilityFromAlwaysAndNeverDr
 
 import type { Observable, Subscription } from "rxjs";
 import type { Id64Arg, Id64Set, Id64String } from "@itwin/core-bentley";
-import type { ClassGroupingNodeKey, HierarchyNode, InstancesNodeKey } from "@itwin/presentation-hierarchies";
+import type { HierarchyNode } from "@itwin/presentation-hierarchies";
 import type { TreeWidgetViewport } from "../../TreeWidgetViewport.js";
 import type { HierarchyVisibilityHandlerOverridableMethod, HierarchyVisibilityOverrideHandler, VisibilityStatus } from "../../UseHierarchyVisibility.js";
 import type { AlwaysAndNeverDrawnElementInfoCache } from "../caches/AlwaysAndNeverDrawnElementInfoCache.js";
@@ -70,12 +70,7 @@ export interface BaseTreeVisibilityHandlerOverrides {
 export interface TreeSpecificVisibilityHandler<TSearchTargets> {
   getVisibilityStatus: (node: HierarchyNode) => Observable<VisibilityStatus>;
   changeVisibilityStatus: (node: HierarchyNode, on: boolean) => Observable<void>;
-  getSearchTargetsVisibilityStatus: (
-    targets: TSearchTargets,
-    node: HierarchyNode & {
-      key: ClassGroupingNodeKey | InstancesNodeKey;
-    },
-  ) => Observable<VisibilityStatus>;
+  getSearchTargetsVisibilityStatus: (targets: TSearchTargets) => Observable<VisibilityStatus>;
   changeSearchTargetsVisibilityStatus: (targets: TSearchTargets, on: boolean) => Observable<void>;
 }
 
@@ -314,34 +309,40 @@ export class BaseVisibilityHelper implements Disposable {
    * - Related categories and models visibility status;
    * - Sub-models that are related to the specified elements.
    */
-  public getElementsVisibilityStatus(props: {
-    elementIds: Id64Arg;
-    modelId: Id64String;
-    categoryId: Id64String;
-    categoryOfTopMostParentElement: CategoryId;
-    parentElementsIdsPath: Array<Id64Arg>;
-    childrenCount: number | undefined;
-  }): Observable<VisibilityStatus> {
+  public getElementsVisibilityStatus(
+    props: {
+      elementIds: Id64Arg;
+      modelId: Id64String;
+      categoryId: Id64String;
+    } & ({ ignoreDescendants: true } | { ignoreDescendants?: false; categoryOfTopMostParentElement: CategoryId; parentElementsIdsPath: Array<Id64Arg> }),
+  ): Observable<VisibilityStatus> {
     const result = defer(() => {
-      const { elementIds, modelId, categoryId, parentElementsIdsPath, childrenCount, categoryOfTopMostParentElement } = props;
-      const elementsVisibilityStatus = this.#props.viewport.viewsModel(modelId)
-        ? // For visible model need to check category and always/never drawn elements
-          this.getVisibilityFromAlwaysAndNeverDrawnElements({
-            elements: elementIds,
-            defaultStatus: this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId }),
-            parentElementsIdsPath,
-            modelId,
-            categoryOfTopMostParentElement,
-            childrenCount,
-          })
-        : of(createVisibilityStatus("hidden"));
-
-      const subModelsVisibilityStatus = fromWithRelease({ source: elementIds, releaseOnCount: 100 }).pipe(
-        mergeMap((elementId) => this.#props.baseIdsCache.getSubModelsUnderElement(elementId)),
-        mergeMap((subModelsUnderElement) => this.getModelsVisibilityStatus({ modelIds: subModelsUnderElement })),
+      const { elementIds, modelId, categoryId, ignoreDescendants } = props;
+      // Compute element's own visibility
+      const elementsOwnStatus = this.getElementsOwnVisibilityStatus({ elementIds, modelId, categoryId });
+      if (ignoreDescendants) {
+        return elementsOwnStatus;
+      }
+      const subModelsVisibilityStatus = this.#props.baseIdsCache.hasSubModels({ modelId }).pipe(
+        mergeMap((hasSubModels) =>
+          hasSubModels
+            ? fromWithRelease({ source: elementIds, releaseOnCount: 100 }).pipe(
+                mergeMap((elementId) => this.#props.baseIdsCache.getSubModelsUnderElement(elementId)),
+                mergeMap((subModelsUnderElement) => this.getModelsVisibilityStatus({ modelIds: subModelsUnderElement })),
+              )
+            : EMPTY,
+        ),
       );
 
-      return merge(elementsVisibilityStatus, subModelsVisibilityStatus).pipe(mergeVisibilityStatuses());
+      const descendantsVisibilityStatus = this.getDescendantsVisibilityStatus({
+        elementIds,
+        modelId,
+        categoryOfTopMostParentElement: props.categoryOfTopMostParentElement,
+        // For descendants path includes elementIds
+        parentElementIdsPath: [...props.parentElementsIdsPath, elementIds],
+      });
+
+      return merge(elementsOwnStatus, descendantsVisibilityStatus, subModelsVisibilityStatus).pipe(mergeVisibilityStatuses());
     });
 
     return this.#props.overrideHandler
@@ -353,19 +354,130 @@ export class BaseVisibilityHelper implements Disposable {
       : result;
   }
 
-  /** Gets visibility status of elements based on viewport's always/never drawn elements and related categories and models. */
+  /** Computes only the element's own visibility (without descendants). */
+  public getElementsOwnVisibilityStatus(props: { elementIds: Id64Arg; modelId: Id64String; categoryId: Id64String }): Observable<VisibilityStatus> {
+    const { elementIds, modelId, categoryId } = props;
+    if (!this.#props.viewport.viewsModel(modelId)) {
+      return of(createVisibilityStatus("hidden"));
+    }
+    const defaultStatus = this.#props.viewport.isAlwaysDrawnExclusive
+      ? createVisibilityStatus("hidden")
+      : this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId });
+    const oppositeSet = defaultStatus.state === "visible" ? this.#props.viewport.neverDrawn : this.#props.viewport.alwaysDrawn;
+    if (!oppositeSet?.size) {
+      return of(defaultStatus);
+    }
+    return of(
+      getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
+        defaultStatus,
+        numberOfElementsInOppositeSet: countInSet(elementIds, oppositeSet),
+        totalCount: Id64.sizeOf(elementIds),
+      }),
+    );
+  }
+
+  /**
+   * Computes descendant visibility per category.
+   * Groups categories by default visibility, queries always/never drawn per group,
+   * and computes per-category status.
+   */
+  private getDescendantsVisibilityStatus(props: {
+    elementIds: Id64Arg;
+    modelId: Id64String;
+    categoryOfTopMostParentElement: CategoryId;
+    parentElementIdsPath: Array<Id64Arg>;
+  }): Observable<VisibilityStatus> {
+    const { elementIds, modelId, categoryOfTopMostParentElement, parentElementIdsPath } = props;
+    if (!this.#props.viewport.viewsModel(modelId)) {
+      return of(createVisibilityStatus("hidden"));
+    }
+    return from(Id64.iterable(elementIds)).pipe(
+      mergeMap((elementId) => this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId })),
+      reduce(
+        (acc, descendantsCounts) => {
+          for (const categoryWithCount of descendantsCounts) {
+            if (acc.visibleCategories.has(categoryWithCount.categoryId)) {
+              acc.visibleCategoriesDescendantsCount += categoryWithCount.count;
+              continue;
+            }
+            if (acc.hiddenCategories.has(categoryWithCount.categoryId)) {
+              acc.hiddenCategoriesDescendantsCount += categoryWithCount.count;
+              continue;
+            }
+            const isCategoryVisible = this.#props.viewport.isAlwaysDrawnExclusive
+              ? false
+              : this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId: categoryWithCount.categoryId, modelId }).state === "visible";
+            if (isCategoryVisible) {
+              acc.visibleCategoriesDescendantsCount += categoryWithCount.count;
+              acc.visibleCategories.add(categoryWithCount.categoryId);
+              continue;
+            }
+            acc.hiddenCategoriesDescendantsCount += categoryWithCount.count;
+            acc.hiddenCategories.add(categoryWithCount.categoryId);
+          }
+          return acc;
+        },
+        {
+          visibleCategoriesDescendantsCount: 0,
+          hiddenCategoriesDescendantsCount: 0,
+          visibleCategories: new Set<CategoryId>(),
+          hiddenCategories: new Set<CategoryId>(),
+        },
+      ),
+      mergeMap(({ hiddenCategories, visibleCategories, visibleCategoriesDescendantsCount, hiddenCategoriesDescendantsCount }) => {
+        return merge(
+          visibleCategories.size > 0
+            ? this.#alwaysAndNeverDrawnElements
+                .getAlwaysOrNeverDrawnElements({
+                  modelId,
+                  parentElementIdsPath,
+                  categoryIds: categoryOfTopMostParentElement,
+                  setType: "never",
+                  childCategoryIds: visibleCategories,
+                })
+                .pipe(
+                  map((elementsInOppositeSet) =>
+                    getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
+                      defaultStatus: createVisibilityStatus("visible"),
+                      numberOfElementsInOppositeSet: elementsInOppositeSet.size,
+                      totalCount: visibleCategoriesDescendantsCount,
+                    }),
+                  ),
+                )
+            : EMPTY,
+          hiddenCategories.size > 0
+            ? this.#alwaysAndNeverDrawnElements
+                .getAlwaysOrNeverDrawnElements({
+                  modelId,
+                  parentElementIdsPath,
+                  categoryIds: categoryOfTopMostParentElement,
+                  setType: "always",
+                  childCategoryIds: hiddenCategories,
+                })
+                .pipe(
+                  map((elementsInOppositeSet) =>
+                    getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
+                      defaultStatus: createVisibilityStatus("hidden"),
+                      numberOfElementsInOppositeSet: elementsInOppositeSet.size,
+                      totalCount: hiddenCategoriesDescendantsCount,
+                    }),
+                  ),
+                )
+            : EMPTY,
+        );
+      }),
+    );
+  }
+
+  /** Gets visibility status of a category based on viewport's always/never drawn elements. */
   private getVisibilityFromAlwaysAndNeverDrawnElements({
     modelId,
     ...props
-  }: { defaultStatus: NonPartialVisibilityStatus; modelId: Id64String } & (
-    | {
-        elements: Id64Arg;
-        parentElementsIdsPath: Array<Id64Arg>;
-        categoryOfTopMostParentElement: Id64String;
-        childrenCount: number | undefined;
-      }
-    | { categoryId: Id64String }
-  )): Observable<VisibilityStatus> {
+  }: {
+    defaultStatus: NonPartialVisibilityStatus;
+    modelId: Id64String;
+    categoryId: Id64String;
+  }): Observable<VisibilityStatus> {
     const defaultStatus = this.#props.viewport.isAlwaysDrawnExclusive ? createVisibilityStatus("hidden") : props.defaultStatus;
     const { oppositeSet, setType } =
       defaultStatus.state === "visible"
@@ -375,38 +487,6 @@ export class BaseVisibilityHelper implements Disposable {
       return of(defaultStatus);
     }
 
-    if ("elements" in props) {
-      const { childrenCount } = props;
-      // When elements children count is 0 or undefined, no need to query for child always/never drawn elements.
-      if (!childrenCount) {
-        return of(
-          getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
-            defaultStatus,
-            numberOfElementsInOppositeSet: countInSet(props.elements, oppositeSet),
-            totalCount: Id64.sizeOf(props.elements),
-          }),
-        );
-      }
-      const parentElementIdsPath = [...props.parentElementsIdsPath, props.elements];
-      // Get child always/never drawn elements.
-      return this.#alwaysAndNeverDrawnElements
-        .getAlwaysOrNeverDrawnElements({
-          modelId,
-          categoryIds: props.categoryOfTopMostParentElement,
-          parentElementIdsPath,
-          setType,
-        })
-        .pipe(
-          map((childElementsInOppositeSet) =>
-            // Combine child always/never drawn count with the props.elements count in always/never drawn sets.
-            getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
-              defaultStatus,
-              numberOfElementsInOppositeSet: countInSet(props.elements, oppositeSet) + childElementsInOppositeSet.size,
-              totalCount: childrenCount + Id64.sizeOf(props.elements),
-            }),
-          ),
-        );
-    }
     const { categoryId } = props;
     return forkJoin({
       totalCount: this.#props.baseIdsCache.getElementsCount({ modelId, categoryId }),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -28,7 +28,7 @@ import {
 import { assert, Id64 } from "@itwin/core-bentley";
 import { createVisibilityStatus } from "../Tooltip.js";
 import { countInSet, fromWithRelease, releaseMainThreadOnItemsCount, setDifference } from "../Utils.js";
-import { changeElementStateNoChildrenOperator, getVisibilityFromAlwaysAndNeverDrawnElementsImpl, mergeVisibilityStatuses } from "../VisibilityUtils.js";
+import { changeElementStateNoChildrenOperator, getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl, mergeVisibilityStatuses } from "../VisibilityUtils.js";
 
 import type { Observable, Subscription } from "rxjs";
 import type { Id64Arg, Id64Set, Id64String } from "@itwin/core-bentley";
@@ -272,7 +272,7 @@ export class BaseVisibilityHelper implements Disposable {
   private getModelWithCategoryVisibilityStatus({ modelId, categoryId }: { modelId: Id64String; categoryId: Id64String }): Observable<VisibilityStatus> {
     const modelVisibilityStatus = this.#props.viewport.viewsModel(modelId)
       ? // For visible model need to check category and always/never drawn elements
-        this.getVisibilityFromAlwaysAndNeverDrawnElements({
+        this.getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
           modelId,
           categoryId,
           defaultStatus: this.getVisibleModelCategoryDirectVisibilityStatus({ modelId, categoryId }),
@@ -369,7 +369,7 @@ export class BaseVisibilityHelper implements Disposable {
       return of(defaultStatus);
     }
     return of(
-      getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
+      getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl({
         defaultStatus,
         numberOfElementsInOppositeSet: countInSet(elementIds, oppositeSet),
         totalCount: Id64.sizeOf(elementIds),
@@ -440,7 +440,7 @@ export class BaseVisibilityHelper implements Disposable {
                 })
                 .pipe(
                   map((elementsInOppositeSet) =>
-                    getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
+                    getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl({
                       defaultStatus: createVisibilityStatus("visible"),
                       numberOfElementsInOppositeSet: elementsInOppositeSet.size,
                       totalCount: visibleCategoriesDescendantsCount,
@@ -459,7 +459,7 @@ export class BaseVisibilityHelper implements Disposable {
                 })
                 .pipe(
                   map((elementsInOppositeSet) =>
-                    getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
+                    getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl({
                       defaultStatus: createVisibilityStatus("hidden"),
                       numberOfElementsInOppositeSet: elementsInOppositeSet.size,
                       totalCount: hiddenCategoriesDescendantsCount,
@@ -473,7 +473,7 @@ export class BaseVisibilityHelper implements Disposable {
   }
 
   /** Gets visibility status of a category based on viewport's always/never drawn elements. */
-  private getVisibilityFromAlwaysAndNeverDrawnElements({
+  private getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
     modelId,
     ...props
   }: {
@@ -508,7 +508,7 @@ export class BaseVisibilityHelper implements Disposable {
       // Result will be "partial" because CategoryB will return hidden visibility, even though all elements are visible
       // TODO fix with: https://github.com/iTwin/viewer-components-react/issues/1100
       map((state) =>
-        getVisibilityFromAlwaysAndNeverDrawnElementsImpl({
+        getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl({
           defaultStatus,
           totalCount: state.totalCount,
           numberOfElementsInOppositeSet: state.relatedElementsInOppositeSet.size,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -20,7 +20,7 @@ import {
   takeUntil,
   toArray,
 } from "rxjs";
-import { Guid } from "@itwin/core-bentley";
+import { assert, Guid } from "@itwin/core-bentley";
 import { IModel } from "@itwin/core-common";
 import { createPredicateBasedHierarchyDefinition, NodeSelectClauseColumnNames, ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
@@ -45,6 +45,7 @@ import {
   releaseMainThreadOnItemsCount,
 } from "../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../common/TreeErrors.js";
+import { ModelsTreeNode } from "./ModelsTreeNode.js";
 
 import type { Observable, ObservedValueOf, OperatorFunction } from "rxjs";
 import type { GuidString, Id64String } from "@itwin/core-bentley";
@@ -213,8 +214,25 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   };
 
   public postProcessNode: NodePostProcessor = async ({ node }) => {
+    if (ModelsTreeNode.isCategoryNode(node)) {
+      // Pre-warm descendants count cache for category nodes — when visibility is computed,
+      // descendant counts per category will already be batched.
+      for (const modelId of node.extendedData.modelIds) {
+        for (const { id } of node.key.instanceKeys) {
+          this.#idsCache.storeRequest({ modelId, categoryId: id });
+        }
+      }
+    }
+
     if (ProcessedHierarchyNode.isGroupingNode(node)) {
       const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
+      // Pre-warm descendants count cache for grouped element nodes
+      for (const child of node.children) {
+        assert(ModelsTreeNode.isElementNode(child));
+        for (const { id } of child.key.instanceKeys) {
+          this.#idsCache.storeRequest({ modelId: child.extendedData.modelId, parentElementId: id });
+        }
+      }
       return {
         ...node,
         label: this.#hierarchyConfig.elementClassGrouping === "enableWithCounts" ? `${node.label} (${node.children.length})` : node.label,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -214,7 +214,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
 
   public postProcessNode: NodePostProcessor = async ({ node }) => {
     if (ProcessedHierarchyNode.isGroupingNode(node)) {
-      const { hasSearchTargetAncestor, hasDirectNonSearchTargets, childrenCount, searchTargets } = groupingNodeDataFromChildren(node.children);
+      const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
       return {
         ...node,
         label: this.#hierarchyConfig.elementClassGrouping === "enableWithCounts" ? `${node.label} (${node.children.length})` : node.label,
@@ -225,8 +225,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
           modelId: node.children[0].extendedData?.modelId,
           categoryOfTopMostParentElement: node.children[0].extendedData?.categoryOfTopMostParentElement,
           topMostParentElementId: node.children[0].extendedData?.topMostParentElementId,
-          childrenCount,
-          ...(!!searchTargets?.size ? { searchTargets } : {}),
           ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
           ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
           // `imageId` is assigned to instance nodes at query time, but grouping ones need to
@@ -459,23 +457,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     ];
   }
 
-  private createElementChildrenCountSelector(props: { elementIdSelector: string }): string {
-    return `(
-      WITH RECURSIVE
-        ElementWithParent(id) AS (
-          SELECT e.ECInstanceId
-          FROM ${this.#hierarchyConfig.elementClassSpecification} e
-          WHERE e.ECInstanceId = ${props.elementIdSelector}
-          UNION ALL
-          SELECT c.ECInstanceId
-          FROM ${this.#hierarchyConfig.elementClassSpecification} c
-          JOIN ElementWithParent p ON p.id = c.Parent.Id
-        )
-      SELECT COUNT(1) - 1
-      FROM ElementWithParent
-    )`;
-  }
-
   private async createSpatialCategoryChildrenQuery({
     parentNodeInstanceIds: categoryIds,
     parentNode,
@@ -539,7 +520,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   modelId: { selector: "IdToHex(this.Model.Id)" },
                   categoryId: { selector: "IdToHex(this.Category.Id)" },
                   imageId: "icon-item",
-                  childrenCount: { selector: this.createElementChildrenCountSelector({ elementIdSelector: "this.ECInstanceId" }) },
                   categoryOfTopMostParentElement: { selector: "IdToHex(this.Category.Id)" },
                   topMostParentElementId: { selector: "IdToHex(this.ECInstanceId)" },
                 },
@@ -609,7 +589,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                   modelId: { selector: "IdToHex(this.Model.Id)" },
                   categoryId: { selector: "IdToHex(this.Category.Id)" },
                   imageId: "icon-item",
-                  childrenCount: { selector: this.createElementChildrenCountSelector({ elementIdSelector: "this.ECInstanceId" }) },
                   categoryOfTopMostParentElement: {
                     selector: `IdToHex(${parentNode.extendedData?.categoryOfTopMostParentElement})`,
                   },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -20,7 +20,7 @@ import {
   takeUntil,
   toArray,
 } from "rxjs";
-import { assert, Guid } from "@itwin/core-bentley";
+import { Guid } from "@itwin/core-bentley";
 import { IModel } from "@itwin/core-common";
 import { createPredicateBasedHierarchyDefinition, NodeSelectClauseColumnNames, ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
@@ -45,7 +45,6 @@ import {
   releaseMainThreadOnItemsCount,
 } from "../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../common/TreeErrors.js";
-import { ModelsTreeNode } from "./ModelsTreeNode.js";
 
 import type { Observable, ObservedValueOf, OperatorFunction } from "rxjs";
 import type { GuidString, Id64String } from "@itwin/core-bentley";
@@ -214,25 +213,8 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   };
 
   public postProcessNode: NodePostProcessor = async ({ node }) => {
-    if (ModelsTreeNode.isCategoryNode(node)) {
-      // Pre-warm descendants count cache for category nodes — when visibility is computed,
-      // descendant counts per category will already be batched.
-      for (const modelId of node.extendedData.modelIds) {
-        for (const { id } of node.key.instanceKeys) {
-          this.#idsCache.storeRequest({ modelId, categoryId: id });
-        }
-      }
-    }
-
     if (ProcessedHierarchyNode.isGroupingNode(node)) {
       const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
-      // Pre-warm descendants count cache for grouped element nodes
-      for (const child of node.children) {
-        assert(ModelsTreeNode.isElementNode(child));
-        for (const { id } of child.key.instanceKeys) {
-          this.#idsCache.storeRequest({ modelId: child.extendedData.modelId, parentElementId: id });
-        }
-      }
       return {
         ...node,
         label: this.#hierarchyConfig.elementClassGrouping === "enableWithCounts" ? `${node.label} (${node.children.length})` : node.label,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeNodeInternal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeNodeInternal.ts
@@ -29,7 +29,6 @@ export namespace ModelsTreeNodeInternal {
     extendedData: {
       modelId: Id64String;
       categoryId: Id64String;
-      childrenCount: number;
       categoryOfTopMostParentElement: CategoryId;
       topMostParentElementId: Id64String;
     };
@@ -41,8 +40,6 @@ export namespace ModelsTreeNodeInternal {
     extendedData: {
       modelId: Id64String;
       categoryId: Id64String;
-      childrenCount: number;
-      searchTargets?: Map<Id64String, { childrenCount: number }>;
       categoryOfTopMostParentElement: CategoryId;
       topMostParentElementId?: Id64String;
     };

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject } from "rxjs";
+import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject, toArray } from "rxjs";
 import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
@@ -296,10 +296,8 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
         mergeMap(({ elementId, childCategoryIds }) =>
           this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId: node.extendedData.modelId, childCategoryIds }),
         ),
-        reduce((acc, childElements) => {
-          acc.push(...childElements);
-          return acc;
-        }, new Array<ElementId>()),
+        toArray(),
+        map((childElements) => ([] as ElementId[]).concat(...childElements)),
         mergeMap((children) =>
           this.#visibilityHelper.changeElementsVisibilityStatus({
             elementIds,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -369,7 +369,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
                       elementIds: searchTargetIds,
                       parentElementsIdsPath,
                       // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
-                      // or at the root, categoryId can be used here here.
+                      // or at the root, categoryId can be used here.
                       categoryOfTopMostParentElement: categoryId,
                     })
                   : EMPTY,
@@ -379,7 +379,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
                       modelId,
                       categoryId,
                       elementIds: nonSearchTargetIds,
-                      ignoreDescendants: true,
+                      computeOnlyOwnStatus: true,
                     })
                   : EMPTY,
               );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -3,19 +3,19 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { concat, defer, EMPTY, from, map, merge, mergeAll, mergeMap, of, Subject } from "rxjs";
-import { assert, Guid } from "@itwin/core-bentley";
+import { concat, defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, Subject } from "rxjs";
+import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
 import { HierarchyVisibilityHandlerImpl } from "../../../common/internal/useTreeHooks/UseCachedVisibility.js";
-import { fromWithRelease, getIdsFromChildrenTree, getParentElementsIdsPath, setDifference, setIntersection } from "../../../common/internal/Utils.js";
+import { fromWithRelease, getParentElementsIdsPath, setDifference } from "../../../common/internal/Utils.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
 import { ModelsTreeNodeInternal } from "../ModelsTreeNodeInternal.js";
 import { ModelsTreeVisibilityHelper } from "./ModelsTreeVisibilityHelper.js";
 import { createModelsSearchResultsTree } from "./SearchResultsTree.js";
 
 import type { Observable } from "rxjs";
-import type { Id64Arg, Id64Set, Id64String } from "@itwin/core-bentley";
+import type { Id64Arg, Id64String } from "@itwin/core-bentley";
 import type { ClassGroupingNodeKey, GroupingHierarchyNode, HierarchyNode, HierarchySearchTree, InstancesNodeKey } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
 import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
@@ -111,7 +111,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
       }
 
       if (elements?.length) {
-        const searchTargetElements = new Array<Id64String>();
+        const searchTargetElements = new Array<{ modelId: Id64String; elementId: Id64String }>();
         const elementIdsSet = new Set<Id64String>();
         const modelCategoryElementMap = new Map<`${ModelId}-${CategoryId}`, Array<ElementId>>();
         // elements is an array that stores elements grouped by:
@@ -130,40 +130,44 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
             mapEntry.push(elementId);
             elementIdsSet.add(elementId);
             if (isSearchTarget) {
-              searchTargetElements.push(elementId);
+              searchTargetElements.push({ modelId, elementId });
             }
           }
         }
         observables.push(
           // Get children for search targets, since non search targets don't have all the children present in the hierarchy.
-          this.#props.idsCache.getChildElementsTree({ elementIds: searchTargetElements }).pipe(
+          from(searchTargetElements).pipe(
+            mergeMap(({ modelId, elementId }) =>
+              forkJoin({
+                modelId: of(modelId),
+                elementId: of(elementId),
+                childCategoryIds: this.#props.idsCache
+                  .getDescendantsCounts({ parentElementId: elementId, modelId })
+                  .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
+              }),
+            ),
+            mergeMap(({ modelId, elementId, childCategoryIds }) =>
+              this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds }),
+            ),
+            reduce((acc, childElements) => {
+              acc.push(...childElements);
+              return acc;
+            }, new Array<ElementId>()),
             // Need to filter out and keep only those children ids that are not part of elements that are present in search paths.
             // Elements in search paths will have their visibility changed directly: they will be provided as elementIds to changeElementsVisibilityStatus.
-            map((childrenTree) => ({
-              childrenNotInSearchPaths: setDifference(getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 }), elementIdsSet),
-              childrenTree,
+            map((childElements) => ({
+              childrenNotInSearchPaths: setDifference(new Set(childElements), elementIdsSet),
             })),
-            mergeMap(({ childrenNotInSearchPaths, childrenTree }) =>
+            mergeMap(({ childrenNotInSearchPaths }) =>
               fromWithRelease({ source: modelCategoryElementMap.entries(), size: modelCategoryElementMap.size, releaseOnCount: 50 }).pipe(
                 mergeMap(([key, elementsInSearchPathsGroupedByModelAndCategory]) => {
                   const [modelId, categoryId] = key.split("-");
-                  const childrenIds = new Set<Id64String>();
-                  // A shared children tree was created, need to get the children for each element in the group.
-                  for (const elementId of elementsInSearchPathsGroupedByModelAndCategory) {
-                    const elementChildrenTree = childrenTree.get(elementId)?.children;
-                    if (!elementChildrenTree) {
-                      continue;
-                    }
-                    for (const childId of getIdsFromChildrenTree({ tree: elementChildrenTree })) {
-                      childrenIds.add(childId);
-                    }
-                  }
                   return this.#visibilityHelper.changeElementsVisibilityStatus({
                     modelId,
                     categoryId,
                     elementIds: elementsInSearchPathsGroupedByModelAndCategory,
                     // Pass only those children that are not part of search paths.
-                    children: setIntersection(childrenIds, childrenNotInSearchPaths),
+                    children: childrenNotInSearchPaths,
                     on,
                   });
                 }),
@@ -271,17 +275,28 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
 
       assert(ModelsTreeNodeInternal.isElementNode(node));
       const elementIds = node.key.instanceKeys.map(({ id }) => id);
-      return this.#props.idsCache.getChildElementsTree({ elementIds }).pipe(
-        map((childrenTree): Id64Set => {
-          // Children tree contains provided elementIds, they are at the root of this tree.
-          // We want to skip them and only get ids of children.
-          return getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 });
-        }),
+
+      return from(Id64.iterable(elementIds)).pipe(
+        mergeMap((elementId) =>
+          forkJoin({
+            elementId: of(elementId),
+            childCategoryIds: this.#props.idsCache
+              .getDescendantsCounts({ parentElementId: elementId, modelId: node.extendedData.modelId })
+              .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
+          }),
+        ),
+        mergeMap(({ elementId, childCategoryIds }) =>
+          this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId: node.extendedData.modelId, childCategoryIds }),
+        ),
+        reduce((acc, childElements) => {
+          acc.push(...childElements);
+          return acc;
+        }, new Array<ElementId>()),
         mergeMap((children) =>
           this.#visibilityHelper.changeElementsVisibilityStatus({
             elementIds,
             modelId: node.extendedData.modelId,
-            children: children.size > 0 ? children : undefined,
+            children: children.length > 0 ? children : undefined,
             categoryId: node.extendedData.categoryId,
             on,
           }),
@@ -329,30 +344,44 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
       }
 
       if (elements?.length) {
-        const searchTargetElements = new Array<Id64String>();
-        for (const { elements: elementsMap } of elements) {
+        const searchTargetElements = new Array<{ elementId: Id64String; modelId: Id64String }>();
+        for (const { elements: elementsMap, modelId } of elements) {
           for (const [elementId, { isSearchTarget }] of elementsMap) {
             if (isSearchTarget) {
-              searchTargetElements.push(elementId);
+              searchTargetElements.push({ elementId, modelId });
             }
           }
         }
         let childrenCountMapObs: Observable<Map<Id64String, number>>;
         if (ModelsTreeNodeInternal.isElementClassGroupingNode(node)) {
           const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData.searchTargets;
-          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget));
+          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
           // Only need to request children count for indirect children search targets.
-          childrenCountMapObs = this.#props.idsCache.getAllChildElementsCount({ elementIds: nestedSearchTargetElements }).pipe(
-            map((elementCountMap) => {
-              // Direct children search targets already have children count stored in grouping nodes extended data.
-              for (const [key, value] of node.extendedData.searchTargets ?? []) {
-                elementCountMap.set(key, value.childrenCount);
-              }
-              return elementCountMap;
-            }),
+          childrenCountMapObs = from(nestedSearchTargetElements).pipe(
+            mergeMap(({ elementId, modelId }) =>
+              forkJoin({
+                elementId: of(elementId),
+                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
+              }),
+            ),
+            reduce((acc, { elementId, childrenCount }) => {
+              acc.set(elementId, childrenCount);
+              return acc;
+            }, new Map<Id64String, number>()),
           );
         } else {
-          childrenCountMapObs = this.#props.idsCache.getAllChildElementsCount({ elementIds: searchTargetElements });
+          childrenCountMapObs = from(searchTargetElements).pipe(
+            mergeMap(({ elementId, modelId }) =>
+              forkJoin({
+                elementId: of(elementId),
+                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
+              }),
+            ),
+            reduce((acc, { elementId, childrenCount }) => {
+              acc.set(elementId, childrenCount);
+              return acc;
+            }, new Map<Id64String, number>()),
+          );
         }
         observables.push(
           childrenCountMapObs.pipe(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -16,7 +16,7 @@ import { createModelsSearchResultsTree } from "./SearchResultsTree.js";
 
 import type { Observable } from "rxjs";
 import type { Id64Arg, Id64String } from "@itwin/core-bentley";
-import type { ClassGroupingNodeKey, GroupingHierarchyNode, HierarchyNode, HierarchySearchTree, InstancesNodeKey } from "@itwin/presentation-hierarchies";
+import type { GroupingHierarchyNode, HierarchyNode, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import type { ECClassHierarchyInspector } from "@itwin/presentation-shared";
 import type { AlwaysAndNeverDrawnElementInfoCache } from "../../../common/internal/caches/AlwaysAndNeverDrawnElementInfoCache.js";
 import type { CategoryId, ElementId, ModelId } from "../../../common/internal/Types.js";
@@ -200,7 +200,6 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
         modelId: node.extendedData.modelId,
         elementIds: node.groupedInstanceKeys.map((key) => key.id),
         parentKeys: node.parentKeys,
-        childrenCount: node.extendedData.childrenCount,
         categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
         topMostParentElementId: node.extendedData.topMostParentElementId,
       });
@@ -237,7 +236,6 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
       modelId: node.extendedData.modelId,
       categoryId: node.extendedData.categoryId,
       parentElementsIdsPath,
-      childrenCount: node.extendedData?.childrenCount,
       categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
     });
   }
@@ -316,12 +314,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
     return changeObs;
   }
 
-  public getSearchTargetsVisibilityStatus(
-    targets: ModelsTreeSearchTargets,
-    node: HierarchyNode & {
-      key: ClassGroupingNodeKey | InstancesNodeKey;
-    },
-  ): Observable<VisibilityStatus> {
+  public getSearchTargetsVisibilityStatus(targets: ModelsTreeSearchTargets): Observable<VisibilityStatus> {
     if (this.#props.viewport.viewType !== "3d") {
       return of(createVisibilityStatus("disabled"));
     }
@@ -350,103 +343,47 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
       }
 
       if (elements?.length) {
-        const searchTargetElements = new Array<{ elementId: Id64String; modelId: Id64String }>();
-        for (const { elements: elementsMap, modelId } of elements) {
-          for (const [elementId, { isSearchTarget }] of elementsMap) {
-            if (isSearchTarget) {
-              searchTargetElements.push({ elementId, modelId });
-            }
-          }
-        }
-        let childrenCountMapObs: Observable<Map<Id64String, number>>;
-        const getChildrenCountMapObs = (elementsWithModels: Array<{ elementId: Id64String; modelId: Id64String }>) => {
-          return from(elementsWithModels).pipe(
-            mergeMap(({ elementId, modelId }) =>
-              forkJoin({
-                elementId: of(elementId),
-                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
-              }),
-            ),
-            reduce((acc, { elementId, childrenCount }) => {
-              acc.set(elementId, childrenCount);
-              return acc;
-            }, new Map<Id64String, number>()),
-          );
-        };
-
-        if (ModelsTreeNodeInternal.isElementClassGroupingNode(node)) {
-          const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData.searchTargets;
-          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
-          // Only need to request children count for indirect children search targets.
-          childrenCountMapObs = getChildrenCountMapObs(nestedSearchTargetElements).pipe(
-            map((elementCountMap) => {
-              // Direct children search targets already have children count stored in grouping nodes extended data.
-              for (const [key, value] of node.extendedData.searchTargets ?? []) {
-                elementCountMap.set(key, value.childrenCount);
-              }
-              return elementCountMap;
-            }),
-          );
-        } else {
-          childrenCountMapObs = getChildrenCountMapObs(searchTargetElements);
-        }
         observables.push(
-          childrenCountMapObs.pipe(
-            mergeMap((elementsChildrenCountMap) =>
-              fromWithRelease({ source: elements, releaseOnCount: 50 }).pipe(
-                mergeMap(({ modelId, elements: elementsMap, categoryId, pathToElements, topMostParentElementId }) => {
-                  const parentElementsIdsPath = topMostParentElementId
-                    ? getParentElementsIdsPath({
-                        parentInstanceKeys: pathToElements.map((instanceKey) => [instanceKey]),
-                        topMostParentElementId,
-                      })
-                    : [];
-                  let totalSearchTargetsChildrenCount = 0;
-                  const nonSearchTargetIds = new Array<Id64String>();
-                  const searchTargetIds = new Array<Id64String>();
-                  for (const [elementId, { isSearchTarget }] of elementsMap) {
-                    if (!isSearchTarget) {
-                      nonSearchTargetIds.push(elementId);
-                      continue;
-                    }
-                    searchTargetIds.push(elementId);
-                    const childCount = elementsChildrenCountMap.get(elementId);
-                    if (childCount) {
-                      totalSearchTargetsChildrenCount += childCount;
-                    }
-                  }
-                  return merge(
-                    searchTargetIds.length > 0
-                      ? this.#visibilityHelper.getElementsVisibilityStatus({
-                          modelId,
-                          categoryId,
-                          elementIds: searchTargetIds,
-                          parentElementsIdsPath,
-                          childrenCount: totalSearchTargetsChildrenCount,
-                          // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
-                          // or at the root, categoryId can be used here here.
-                          categoryOfTopMostParentElement: categoryId,
-                        })
-                      : EMPTY,
-                    // Set childrenCount to undefined for non search targets, as some of their child elements might be filtered out.
-                    // Since childrenCount is set to undefined, these elements won't check child always/never drawn child elements status.
-                    // Child always/never drawn elements will be in search paths, and their visibility status will be handled separately.
-                    nonSearchTargetIds.length > 0
-                      ? this.#visibilityHelper.getElementsVisibilityStatus({
-                          modelId,
-                          categoryId,
-                          elementIds: nonSearchTargetIds,
-                          parentElementsIdsPath,
-                          childrenCount: undefined,
-                          // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
-                          // or at the root, categoryId can be used here here.
-                          categoryOfTopMostParentElement: categoryId,
-                        })
-                      : EMPTY,
-                  ).pipe(mergeVisibilityStatuses());
-                }),
-              ),
-            ),
+          fromWithRelease({ source: elements, releaseOnCount: 50 }).pipe(
+            mergeMap(({ modelId, elements: elementsMap, categoryId, pathToElements, topMostParentElementId }) => {
+              const parentElementsIdsPath = topMostParentElementId
+                ? getParentElementsIdsPath({
+                    parentInstanceKeys: pathToElements.map((instanceKey) => [instanceKey]),
+                    topMostParentElementId,
+                  })
+                : [];
+              const nonSearchTargetIds = new Array<Id64String>();
+              const searchTargetIds = new Array<Id64String>();
+              for (const [elementId, { isSearchTarget }] of elementsMap) {
+                if (!isSearchTarget) {
+                  nonSearchTargetIds.push(elementId);
+                  continue;
+                }
+                searchTargetIds.push(elementId);
+              }
+              return merge(
+                searchTargetIds.length > 0
+                  ? this.#visibilityHelper.getElementsVisibilityStatus({
+                      modelId,
+                      categoryId,
+                      elementIds: searchTargetIds,
+                      parentElementsIdsPath,
+                      // Search results tree is created on search paths. Since search paths contain only categories that are directly under models
+                      // or at the root, categoryId can be used here here.
+                      categoryOfTopMostParentElement: categoryId,
+                    })
+                  : EMPTY,
+                // Child always/never drawn elements will be in search paths, and their visibility status will be handled separately.
+                nonSearchTargetIds.length > 0
+                  ? this.#visibilityHelper.getElementsVisibilityStatus({
+                      modelId,
+                      categoryId,
+                      elementIds: nonSearchTargetIds,
+                      ignoreDescendants: true,
+                    })
+                  : EMPTY,
+              );
+            }),
           ),
         );
       }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -359,11 +359,8 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
           }
         }
         let childrenCountMapObs: Observable<Map<Id64String, number>>;
-        if (ModelsTreeNodeInternal.isElementClassGroupingNode(node)) {
-          const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData.searchTargets;
-          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
-          // Only need to request children count for indirect children search targets.
-          childrenCountMapObs = from(nestedSearchTargetElements).pipe(
+        const getChildrenCountMapObs = (elementsWithModels: Array<{ elementId: Id64String; modelId: Id64String }>) => {
+          return from(elementsWithModels).pipe(
             mergeMap(({ elementId, modelId }) =>
               forkJoin({
                 elementId: of(elementId),
@@ -374,6 +371,14 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
               acc.set(elementId, childrenCount);
               return acc;
             }, new Map<Id64String, number>()),
+          );
+        };
+
+        if (ModelsTreeNodeInternal.isElementClassGroupingNode(node)) {
+          const groupingNodesSearchTargets: Map<Id64String, { childrenCount: number }> | undefined = node.extendedData.searchTargets;
+          const nestedSearchTargetElements = searchTargetElements.filter((searchTarget) => !groupingNodesSearchTargets?.has(searchTarget.elementId));
+          // Only need to request children count for indirect children search targets.
+          childrenCountMapObs = getChildrenCountMapObs(nestedSearchTargetElements).pipe(
             map((elementCountMap) => {
               // Direct children search targets already have children count stored in grouping nodes extended data.
               for (const [key, value] of node.extendedData.searchTargets ?? []) {
@@ -383,18 +388,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
             }),
           );
         } else {
-          childrenCountMapObs = from(searchTargetElements).pipe(
-            mergeMap(({ elementId, modelId }) =>
-              forkJoin({
-                elementId: of(elementId),
-                childrenCount: this.#props.idsCache.getElementsCount({ parentElementId: elementId, modelId }),
-              }),
-            ),
-            reduce((acc, { elementId, childrenCount }) => {
-              acc.set(elementId, childrenCount);
-              return acc;
-            }, new Map<Id64String, number>()),
-          );
+          childrenCountMapObs = getChildrenCountMapObs(searchTargetElements);
         }
         observables.push(
           childrenCountMapObs.pipe(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -376,6 +376,13 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
               acc.set(elementId, childrenCount);
               return acc;
             }, new Map<Id64String, number>()),
+            map((elementCountMap) => {
+              // Direct children search targets already have children count stored in grouping nodes extended data.
+              for (const [key, value] of node.extendedData.searchTargets ?? []) {
+                elementCountMap.set(key, value.childrenCount);
+              }
+              return elementCountMap;
+            }),
           );
         } else {
           childrenCountMapObs = from(searchTargetElements).pipe(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -139,35 +139,43 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
           from(searchTargetElements).pipe(
             mergeMap(({ modelId, elementId }) =>
               forkJoin({
-                modelId: of(modelId),
                 elementId: of(elementId),
                 childCategoryIds: this.#props.idsCache
                   .getDescendantsCounts({ parentElementId: elementId, modelId })
                   .pipe(map((countsArr) => countsArr.map(({ categoryId }) => categoryId))),
-              }),
+              }).pipe(
+                mergeMap(({ elementId: eid, childCategoryIds }) =>
+                  this.#props.idsCache
+                    .getChildElements({ parentElementId: eid, modelId, childCategoryIds })
+                    .pipe(map((children) => ({ elementId: eid, children }))),
+                ),
+              ),
             ),
-            mergeMap(({ modelId, elementId, childCategoryIds }) =>
-              this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds }),
-            ),
-            reduce((acc, childElements) => {
-              acc.push(...childElements);
+            reduce((acc, { elementId, children }) => {
+              acc.set(elementId, children);
               return acc;
-            }, new Array<ElementId>()),
-            // Need to filter out and keep only those children ids that are not part of elements that are present in search paths.
-            // Elements in search paths will have their visibility changed directly: they will be provided as elementIds to changeElementsVisibilityStatus.
-            map((childElements) => ({
-              childrenNotInSearchPaths: setDifference(new Set(childElements), elementIdsSet),
-            })),
-            mergeMap(({ childrenNotInSearchPaths }) =>
+            }, new Map<ElementId, Array<ElementId>>()),
+            mergeMap((childrenByElement) =>
               fromWithRelease({ source: modelCategoryElementMap.entries(), size: modelCategoryElementMap.size, releaseOnCount: 50 }).pipe(
                 mergeMap(([key, elementsInSearchPathsGroupedByModelAndCategory]) => {
                   const [modelId, categoryId] = key.split("-");
+                  // Union only the children of elements that belong to this group.
+                  const childrenIds = new Set<Id64String>();
+                  for (const elementId of elementsInSearchPathsGroupedByModelAndCategory) {
+                    const elementChildren = childrenByElement.get(elementId);
+                    if (!elementChildren) {
+                      continue;
+                    }
+                    for (const childId of elementChildren) {
+                      childrenIds.add(childId);
+                    }
+                  }
                   return this.#visibilityHelper.changeElementsVisibilityStatus({
                     modelId,
                     categoryId,
                     elementIds: elementsInSearchPathsGroupedByModelAndCategory,
                     // Pass only those children that are not part of search paths.
-                    children: childrenNotInSearchPaths,
+                    children: setDifference(childrenIds, elementIdsSet),
                     on,
                   });
                 }),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHelper.ts
@@ -3,10 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defaultIfEmpty, defer, map, mergeMap } from "rxjs";
+import { defaultIfEmpty, defer, forkJoin, from, map, mergeMap, of, reduce } from "rxjs";
+import { Id64 } from "@itwin/core-bentley";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
-import { getIdsFromChildrenTree, getParentElementsIdsPath } from "../../../common/internal/Utils.js";
+import { getParentElementsIdsPath } from "../../../common/internal/Utils.js";
 import { BaseVisibilityHelper } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
 
@@ -110,8 +111,20 @@ export class ModelsTreeVisibilityHelper extends BaseVisibilityHelper {
   /** Changes visibility of grouped elements. */
   public changeGroupedElementsVisibilityStatus(props: { modelId: Id64String; categoryId: Id64String; elementIds: Id64Arg; on: boolean }): Observable<void> {
     const { modelId, categoryId, elementIds, on } = props;
-    return this.#props.idsCache.getChildElementsTree({ elementIds }).pipe(
-      map((childrenTree) => getIdsFromChildrenTree({ tree: childrenTree, predicate: ({ depth }) => depth > 0 })),
+    return from(Id64.iterable(elementIds)).pipe(
+      mergeMap((elementId) =>
+        forkJoin({
+          elementId: of(elementId),
+          childCategoryIds: this.#props.idsCache
+            .getDescendantsCounts({ parentElementId: elementId, modelId })
+            .pipe(map((counts) => counts.map((entry) => entry.categoryId))),
+        }),
+      ),
+      mergeMap(({ elementId, childCategoryIds }) => this.#props.idsCache.getChildElements({ parentElementId: elementId, modelId, childCategoryIds })),
+      reduce((acc, childElements) => {
+        acc.push(...childElements);
+        return acc;
+      }, new Array<ElementId>()),
       mergeMap((children) => this.changeElementsVisibilityStatus({ modelId, elementIds, categoryId, on, children })),
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHelper.ts
@@ -68,11 +68,10 @@ export class ModelsTreeVisibilityHelper extends BaseVisibilityHelper {
     categoryId: Id64String;
     elementIds: Id64Arg;
     parentKeys: HierarchyNodeKey[];
-    childrenCount: number;
     categoryOfTopMostParentElement: CategoryId;
     topMostParentElementId?: ElementId;
   }): Observable<VisibilityStatus> {
-    const { modelId, categoryId, elementIds, parentKeys, categoryOfTopMostParentElement, childrenCount, topMostParentElementId } = props;
+    const { modelId, categoryId, elementIds, parentKeys, categoryOfTopMostParentElement, topMostParentElementId } = props;
     const parentElementsIdsPath = topMostParentElementId
       ? getParentElementsIdsPath({
           parentInstanceKeys: parentKeys.filter((key) => HierarchyNodeKey.isInstances(key)).map((key) => key.instanceKeys),
@@ -84,7 +83,6 @@ export class ModelsTreeVisibilityHelper extends BaseVisibilityHelper {
       modelId,
       categoryId,
       parentElementsIdsPath,
-      childrenCount,
       categoryOfTopMostParentElement,
     });
   }


### PR DESCRIPTION
Phase 3a. of https://github.com/iTwin/viewer-components-react/pull/1678.

Skipping phase 2 for now, since it would add child categories (and visibilities would become confusing). Will do it after phase 3 is done. Changes:

**BaseVisibilityHelper.ts:**
- Rewrote `getElementsVisibilityStatus` to compute descendant visibility per-category using `DescendantsCountCache`
- Added `getElementsOwnVisibilityStatus` - computes element's own visibility without descendants
- Added `getDescendantsVisibilityStatus` - groups descendant categories by default visibility (visible/hidden), queries always/neverDrawn sets filtered by category, and merges statuses
- Replaced `childrenCount` parameter with `computeOnlyOwnStatus` flag
- Simplified `getVisibilityFromAlwaysAndNeverDrawnElements` now it accepts only category path (previously element and category)

**AlwaysAndNeverDrawnElementInfoCache.ts:**
- Added optional `childCategoryIds?: Id64Set` filter to `getAlwaysOrNeverDrawnElements` - returns only elements whose actual category matches the filter

**Tree handlers (models, categories, classifications):**
- Removed `childrenCount` from all `getElementsVisibilityStatus` calls
- Search results: non-search-target elements now use `computeOnlyOwnStatus: true` instead of `childrenCount: undefined`
- Removed `childrenCount`/`searchTargets` from grouping node extended data and tree definitions
- Cleaned up `groupingNodeDataFromChildren` utility