### PR TITLE
[Tree-widget]: add missing peer dependency on `next`

### DIFF
--- a/apps/performance-tests/vitest.config.ts
+++ b/apps/performance-tests/vitest.config.ts
@@ -24,9 +24,6 @@ function collectDepsFromPackage(...packageDirs: string[]): string[] {
     for (const dep of Object.keys(pkg.dependencies ?? {})) {
       deps.add(dep);
     }
-    for (const dep of Object.keys(pkg.devDependencies ?? {})) {
-      deps.add(dep);
-    }
   }
   return [...deps];
 }

--- a/apps/performance-tests/vitest.config.ts
+++ b/apps/performance-tests/vitest.config.ts
@@ -9,9 +9,8 @@ import { fileURLToPath } from "url";
 import { defineConfig } from "vitest/config";
 import TestReporter from "./src/util/TestReporter.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const treeWidgetRoot = path.resolve(__dirname, "../../packages/itwin/tree-widget");
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+const treeWidgetRoot = path.resolve(rootDir, "../../packages/itwin/tree-widget");
 const treeWidgetSrc = path.resolve(treeWidgetRoot, "src");
 
 function collectDepsFromPackage(...packageDirs: string[]): string[] {
@@ -35,7 +34,7 @@ export default defineConfig({
     ],
     // Dedupe ensures that shared dependencies (e.g. @itwin/core-frontend) resolve from this app's
     // node_modules rather than the tree-widget package's node_modules, preventing duplicate package errors.
-    dedupe: collectDepsFromPackage(treeWidgetRoot, __dirname),
+    dedupe: collectDepsFromPackage(treeWidgetRoot, rootDir),
   },
   test: {
     environment: "happy-dom",

--- a/apps/performance-tests/vitest.config.ts
+++ b/apps/performance-tests/vitest.config.ts
@@ -21,9 +21,6 @@ function collectDepsFromPackage(...packageDirs: string[]): string[] {
     for (const dep of Object.keys(pkg.peerDependencies ?? {})) {
       deps.add(dep);
     }
-    for (const dep of Object.keys(pkg.dependencies ?? {})) {
-      deps.add(dep);
-    }
   }
   return [...deps];
 }

--- a/apps/test-viewer/vite.config.mts
+++ b/apps/test-viewer/vite.config.mts
@@ -3,12 +3,32 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 import { defineConfig, loadEnv } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import react from "@vitejs/plugin-react";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ENV_PREFIX = "IMJS_";
 
+const treeWidgetRoot = path.resolve(__dirname, "../../packages/itwin/tree-widget");
+const treeWidgetSrc = path.resolve(__dirname, "../../packages/itwin/tree-widget/src");
+
+function collectDepsFromPackage(...packageDirs: string[]): string[] {
+  const deps = new Set<string>();
+  for (const dir of packageDirs) {
+    const pkg = JSON.parse(fs.readFileSync(path.resolve(dir, "package.json"), "utf-8"));
+    for (const dep of Object.keys(pkg.peerDependencies ?? {})) {
+      deps.add(dep);
+    }
+    for (const dep of Object.keys(pkg.dependencies ?? {})) {
+      deps.add(dep);
+    }
+  }
+  return [...deps];
+}
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), ENV_PREFIX);
@@ -50,22 +70,29 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: [
+        // Resolve tree-widget to source for debugging (breakpoints + source maps).
+        { find: "@itwin/tree-widget-react", replacement: path.resolve(treeWidgetSrc, "tree-widget-react.ts") },
         {
           // Resolve SASS tilde imports.
           find: /^~(.*)$/,
           replacement: "$1",
         },
       ],
+      // Dedupe only tree-widget's deps so its source imports resolve from this app's node_modules
+      // rather than tree-widget's own node_modules, preventing duplicate package instances.
+      dedupe: collectDepsFromPackage(treeWidgetRoot),
     },
     envPrefix: ENV_PREFIX,
     define: {
       "process.env.IMJS_URL_PREFIX": env.IMJS_URL_PREFIX ? `"${env.IMJS_URL_PREFIX}"` : `""`,
     },
+
     build: {
       assetsInlineLimit: (filePath) => {
         if (filePath.includes("@itwin/itwinui-icons/")) return false;
         return undefined;
       },
+      sourcemap: true,
     },
     css: {
       preprocessorOptions: {

--- a/apps/test-viewer/vite.config.mts
+++ b/apps/test-viewer/vite.config.mts
@@ -86,13 +86,11 @@ export default defineConfig(({ mode }) => {
     define: {
       "process.env.IMJS_URL_PREFIX": env.IMJS_URL_PREFIX ? `"${env.IMJS_URL_PREFIX}"` : `""`,
     },
-
     build: {
       assetsInlineLimit: (filePath) => {
         if (filePath.includes("@itwin/itwinui-icons/")) return false;
         return undefined;
       },
-      sourcemap: true,
     },
     css: {
       preprocessorOptions: {

--- a/apps/test-viewer/vite.config.mts
+++ b/apps/test-viewer/vite.config.mts
@@ -10,11 +10,11 @@ import { defineConfig, loadEnv } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import react from "@vitejs/plugin-react";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
 const ENV_PREFIX = "IMJS_";
 
-const treeWidgetRoot = path.resolve(__dirname, "../../packages/itwin/tree-widget");
-const treeWidgetSrc = path.resolve(__dirname, "../../packages/itwin/tree-widget/src");
+const treeWidgetRoot = path.resolve(rootDir, "../../packages/itwin/tree-widget");
+const treeWidgetSrc = path.resolve(rootDir, "../../packages/itwin/tree-widget/src");
 
 function collectDepsFromPackage(...packageDirs: string[]): string[] {
   const deps = new Set<string>();

--- a/apps/test-viewer/vite.config.mts
+++ b/apps/test-viewer/vite.config.mts
@@ -23,9 +23,6 @@ function collectDepsFromPackage(...packageDirs: string[]): string[] {
     for (const dep of Object.keys(pkg.peerDependencies ?? {})) {
       deps.add(dep);
     }
-    for (const dep of Object.keys(pkg.dependencies ?? {})) {
-      deps.add(dep);
-    }
   }
   return [...deps];
 }
@@ -70,7 +67,8 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: [
-        // Resolve tree-widget to source for debugging (breakpoints + source maps).
+        // Debugging dependencies (in this case tree-widget) is not easy since source maps don't seem to work.
+        // Adding these aliases allows adding breakpoints straight into the source code and it does not need to be built.
         { find: "@itwin/tree-widget-react", replacement: path.resolve(treeWidgetSrc, "tree-widget-react.ts") },
         {
           // Resolve SASS tilde imports.

--- a/change/@itwin-tree-widget-react-652156f6-3bb9-48b4-8f25-eee76982b008.json
+++ b/change/@itwin-tree-widget-react-652156f6-3bb9-48b4-8f25-eee76982b008.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Add missing `@itwin/presentation-frontend` peerDependency",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/package.json
+++ b/packages/itwin/tree-widget/package.json
@@ -58,6 +58,7 @@
     "@itwin/ecschema-metadata": "^5.8.0",
     "@itwin/presentation-common": "^5.8.0",
     "@itwin/presentation-components": "^5.12.0",
+    "@itwin/presentation-frontend": "^5.8.0",
     "@stratakit/bricks": "^0.5.4",
     "@stratakit/foundations": "^0.4.7",
     "@stratakit/icons": "^0.3.1",


### PR DESCRIPTION
- Add missing `@itwin/presentation-frontend` peerDependency - it is used by `UseHierarchyFiltering.tsx`.
- Remove `devDependencies` and `dependencies` from dedupe list in performance tests - Only `peerDependencies` are relevant for runtime deduplication.
- Alias `@itwin/tree-widget-react` to source in test-viewer - The test-viewer's Vite config now resolves `@itwin/tree-widget-react` directly to the TypeScript source under `src`. This enables setting breakpoints in the original source files and provides hot-reload without rebuilding the tree-widget package.