### PR TITLE
[property-grid]: Remove deprecated APIs

### DIFF
--- a/apps/learning-snippets/src/test/property-grid/Usage.test.tsx
+++ b/apps/learning-snippets/src/test/property-grid/Usage.test.tsx
@@ -25,6 +25,9 @@ import type { IModelConnection } from "@itwin/core-frontend";
 // __PUBLISH_EXTRACT_END__
 import { PropertyGridTestUtils } from "../../utils/PropertyGridTestUtils.js";
 
+const selectionStorage = createStorage();
+const getGlobalSelectionStorage = () => selectionStorage;
+
 describe("Property grid", () => {
   describe("Learning snippets", () => {
     describe("Usage", () => {
@@ -40,7 +43,7 @@ describe("Property grid", () => {
 
       it("registers property grid", async () => {
         // __PUBLISH_EXTRACT_START__ PropertyGrid.RegisterPropertyGridWidget
-        UiItemsManager.register({ id: "property-grid-provider", getWidgets: () => [createPropertyGrid({})] });
+        UiItemsManager.register({ id: "property-grid-provider", getWidgets: () => [createPropertyGrid({ selectionStorage: getGlobalSelectionStorage() })] });
         // __PUBLISH_EXTRACT_END__
 
         expect(UiItemsManager.getWidgets("", StageUsage.General, StagePanelLocation.Right, StagePanelSection.End)).not.toHaveLength(0);
@@ -48,9 +51,6 @@ describe("Property grid", () => {
 
       it("registers customizable property grid", async () => {
         const MY_CUSTOM_RULESET = undefined;
-
-        const selectionStorage = createStorage();
-        const getGlobalSelectionStorage = () => selectionStorage;
 
         // __PUBLISH_EXTRACT_START__ PropertyGrid.RegisterCustomPropertyGridWidget
         UiItemsManager.register({

--- a/change/@itwin-property-grid-react-b271e2d2-3c47-4842-9ee9-87d43614b111.json
+++ b/change/@itwin-property-grid-react-b271e2d2-3c47-4842-9ee9-87d43614b111.json
@@ -1,6 +1,6 @@
 {
   "type": "major",
-  "comment": "Removed deprecated `PropertyGridUiItemsProvider` API.",
+  "comment": "Removed deprecated `PropertyGridUiItemsProvider` API. Removed `shouldShow` callback using `Readonly<KeySet>` from `createPropertyGrid` API. `createPropertyGrid` now requires `selectionStorage` to be passed in.",
   "packageName": "@itwin/property-grid-react",
   "email": "24278440+saskliutas@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@itwin-property-grid-react-b271e2d2-3c47-4842-9ee9-87d43614b111.json
+++ b/change/@itwin-property-grid-react-b271e2d2-3c47-4842-9ee9-87d43614b111.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Removed deprecated `PropertyGridUiItemsProvider` API.",
+  "packageName": "@itwin/property-grid-react",
+  "email": "24278440+saskliutas@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/property-grid/README.md
+++ b/packages/itwin/property-grid/README.md
@@ -33,7 +33,7 @@ In [AppUI](https://github.com/iTwin/appui/tree/master/ui/appui-react) based appl
 import { createPropertyGrid } from "@itwin/property-grid-react";
 import { UiItemsManager } from "@itwin/appui-react";
 
-UiItemsManager.register({ id: "property-grid-provider", getWidgets: () => [createPropertyGrid({})] });
+UiItemsManager.register({ id: "property-grid-provider", getWidgets: () => [createPropertyGrid({ selectionStorage: getGlobalSelectionStorage() })] });
 ```
 
 <!-- END EXTRACTION -->

--- a/packages/itwin/property-grid/api/property-grid-react.api.md
+++ b/packages/itwin/property-grid/api/property-grid-react.api.md
@@ -13,7 +13,6 @@ import type { InstanceKey } from '@itwin/presentation-common';
 import type { IPresentationPropertyDataProvider } from '@itwin/presentation-components';
 import type { IPropertyDataFilterer } from '@itwin/components-react';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
-import { KeySet } from '@itwin/presentation-common';
 import type { Localization } from '@itwin/core-common';
 import type { OmitOverUnion } from '@itwin/presentation-shared';
 import type { PropertyCategory } from '@itwin/components-react';
@@ -24,10 +23,7 @@ import type { ReactNode } from 'react';
 import { Ref } from 'react';
 import { Selectables } from '@itwin/unified-selection';
 import type { SelectionStorage } from '@itwin/unified-selection';
-import { StagePanelLocation } from '@itwin/appui-react';
-import { StagePanelSection } from '@itwin/appui-react';
 import type { TranslationOptions } from '@itwin/core-common';
-import type { UiItemsProvider } from '@itwin/appui-react';
 import { VirtualizedPropertyGridWithDataProvider } from '@itwin/components-react';
 import type { Widget } from '@itwin/appui-react';
 
@@ -192,36 +188,15 @@ export interface PropertyGridSettingsMenuItemProps {
     title?: string;
 }
 
-// @public @deprecated
-export class PropertyGridUiItemsProvider implements UiItemsProvider {
-    constructor(props?: PropertyGridUiItemsProviderProps);
-    // (undocumented)
-    readonly id = "PropertyGridUiItemsProvider";
-    // (undocumented)
-    provideWidgets(_stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection): ReadonlyArray<Widget>;
-}
-
-// @public @deprecated
-export interface PropertyGridUiItemsProviderProps {
-    defaultPanelLocation?: StagePanelLocation;
-    defaultPanelSection?: StagePanelSection;
-    defaultPanelWidgetPriority?: number;
-    propertyGridProps?: PropertyGridWidgetProps;
-}
-
 // @public
 export const PropertyGridWidgetId = "vcr:PropertyGridComponent";
 
 // @public (undocumented)
-type PropertyGridWidgetOwnProps = {
-    widgetId?: string;
-} & ({
-    shouldShow?: (selection: Readonly<KeySet>) => boolean;
-    selectionStorage?: never;
-} | {
-    shouldShow?: (selection: Selectables) => Promise<boolean>;
+interface PropertyGridWidgetOwnProps {
     selectionStorage: SelectionStorage_2;
-});
+    shouldShow?: (selection: Selectables) => Promise<boolean>;
+    widgetId?: string;
+}
 
 // @public
 export type PropertyGridWidgetProps = PropertyGridComponentProps & PropertyGridWidgetOwnProps;

--- a/packages/itwin/property-grid/api/property-grid-react.exports.csv
+++ b/packages/itwin/property-grid/api/property-grid-react.exports.csv
@@ -29,10 +29,6 @@ public;type;PropertyGridPropertyUpdatedArgs
 public;type;PropertyGridProps
 public;function;PropertyGridSettingsMenuItem
 public;interface;PropertyGridSettingsMenuItemProps
-public;class;PropertyGridUiItemsProvider
-deprecated;class;PropertyGridUiItemsProvider
-public;interface;PropertyGridUiItemsProviderProps
-deprecated;interface;PropertyGridUiItemsProviderProps
 public;const;PropertyGridWidgetId
 public;type;PropertyGridWidgetProps
 public;function;RemoveFavoritePropertyContextMenuItem

--- a/packages/itwin/property-grid/src/property-grid-react.ts
+++ b/packages/itwin/property-grid/src/property-grid-react.ts
@@ -6,15 +6,7 @@
 export * from "./property-grid-react/PropertyGridManager.js";
 export * from "./property-grid-react/PropertyGridComponent.js";
 export * from "./property-grid-react/api/PreferencesStorage.js";
-export {
-  PropertyGridWidgetId,
-  PropertyGridWidgetProps,
-  createPropertyGrid,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  PropertyGridUiItemsProvider,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  PropertyGridUiItemsProviderProps,
-} from "./property-grid-react/PropertyGridUiItemsProvider.js";
+export { PropertyGridWidgetId, PropertyGridWidgetProps, createPropertyGrid } from "./property-grid-react/PropertyGridUiItemsProvider.js";
 
 export * from "./property-grid-react/components/PropertyGrid.js";
 export * from "./property-grid-react/components/MultiElementPropertyGrid.js";

--- a/packages/itwin/property-grid/src/property-grid-react/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/property-grid-react/PropertyGridUiItemsProvider.tsx
@@ -7,22 +7,21 @@ import "./PropertyGridUiItemsProvider.scss";
 
 import { useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
-import { StagePanelLocation, StagePanelSection, StageUsage, useActiveIModelConnection, useSpecificWidgetDef, WidgetState } from "@itwin/appui-react";
+import { StagePanelLocation, StagePanelSection, useActiveIModelConnection, useSpecificWidgetDef, WidgetState } from "@itwin/appui-react";
 import { Id64 } from "@itwin/core-bentley";
 import { SvgInfoCircular } from "@itwin/itwinui-icons-react";
 import { SvgError } from "@itwin/itwinui-illustrations-react";
 import { Button, NonIdealState } from "@itwin/itwinui-react";
-import { KeySet } from "@itwin/presentation-common";
 import { createIModelKey } from "@itwin/presentation-core-interop";
 import { Selectable, Selectables } from "@itwin/unified-selection";
 import { usePropertyGridTransientState } from "./hooks/UsePropertyGridTransientState.js";
-import { createKeysFromSelectable, useSelectionHandler } from "./hooks/UseUnifiedSelectionHandler.js";
+import { useSelectionHandler } from "./hooks/UseUnifiedSelectionHandler.js";
 import { PropertyGridComponent } from "./PropertyGridComponent.js";
 import { PropertyGridManager } from "./PropertyGridManager.js";
 
 import type { ReactNode } from "react";
 import type { FallbackProps } from "react-error-boundary";
-import type { UiItemsProvider, Widget, WidgetDef } from "@itwin/appui-react";
+import type { Widget, WidgetDef } from "@itwin/appui-react";
 import type { SelectionStorage } from "./hooks/UseUnifiedSelectionHandler.js";
 import type { PropertyGridComponentProps } from "./PropertyGridComponent.js";
 
@@ -31,7 +30,6 @@ import type { PropertyGridComponentProps } from "./PropertyGridComponent.js";
  * @public
  */
 export function createPropertyGrid(propertyGridProps: PropertyGridWidgetProps): Widget {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const { widgetId: widgetIdProp, selectionStorage, shouldShow, ...propertyGridComponentProps } = propertyGridProps;
   const widgetId = widgetIdProp ?? PropertyGridWidgetId;
   const widgetProps = {
@@ -63,57 +61,8 @@ export function createPropertyGrid(propertyGridProps: PropertyGridWidgetProps): 
  */
 export const PropertyGridWidgetId = "vcr:PropertyGridComponent";
 
-/**
- * Props for creating `PropertyGridUiItemsProvider`.
- * @public
- * @deprecated in 1.13.0. Use `createPropertyGrid` instead.
- */
-export interface PropertyGridUiItemsProviderProps {
-  /** The stage panel to place the widget in. Defaults to `StagePanelLocation.Right`. */
-  defaultPanelLocation?: StagePanelLocation;
-  /** The stage panel section to place the widget in. Defaults to `StagePanelSection.End`. */
-  defaultPanelSection?: StagePanelSection;
-  /** Widget priority in the stage panel. */
-  defaultPanelWidgetPriority?: number;
-  /** Props for configuring `PropertyGridComponent` shown in the widget. */
-  propertyGridProps?: PropertyGridWidgetProps;
-}
-
-/**
- * A `UiItemsProvider` implementation that provides a `PropertyGridComponent` into a stage panel.
- * @public
- * @deprecated in 1.13.0. Use `createPropertyGrid` instead.
- */
-export class PropertyGridUiItemsProvider implements UiItemsProvider {
-  public readonly id = "PropertyGridUiItemsProvider";
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  #props: PropertyGridUiItemsProviderProps = {};
-
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  constructor(props: PropertyGridUiItemsProviderProps = {}) {
-    this.#props = props;
-  }
-
-  public provideWidgets(_stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection): ReadonlyArray<Widget> {
-    const { defaultPanelLocation, defaultPanelSection, defaultPanelWidgetPriority, propertyGridProps } = this.#props;
-
-    const preferredLocation = defaultPanelLocation ?? StagePanelLocation.Right;
-    const preferredPanelSection = defaultPanelSection ?? StagePanelSection.End;
-    if (stageUsage !== StageUsage.General.valueOf() || location !== preferredLocation || section !== preferredPanelSection) {
-      return [];
-    }
-
-    return [
-      {
-        ...createPropertyGrid({ ...propertyGridProps }),
-        priority: defaultPanelWidgetPriority,
-      },
-    ];
-  }
-}
-
 /** @public */
-type PropertyGridWidgetOwnProps = {
+interface PropertyGridWidgetOwnProps {
   /**
    * A custom id to use for the created widget. Should be supplied when creating multiple property grid widgets to
    * make sure they don't conflict with each other in AppUI system.
@@ -121,28 +70,14 @@ type PropertyGridWidgetOwnProps = {
    * Defaults to `PropertyGridWidgetId`.
    */
   widgetId?: string;
-} & (
-  | {
-      /**
-       * Predicate indicating if the widget should be shown for the current selection set.
-       * @deprecated in 1.16. Use the overload taking `Selectables` instead.
-       */
-      shouldShow?: (selection: Readonly<KeySet>) => boolean;
-      selectionStorage?: never;
-    }
-  | {
-      /** Predicate indicating if the widget should be shown for the current selection set. */
-      shouldShow?: (selection: Selectables) => Promise<boolean>;
+  /** Predicate indicating if the widget should be shown for the current selection set. */
+  shouldShow?: (selection: Selectables) => Promise<boolean>;
 
-      /**
-       * Unified selection storage to use for listening and getting active selection.
-       *
-       * When not specified, the deprecated `SelectionManager` from `@itwin/presentation-frontend` package
-       * is used.
-       */
-      selectionStorage: SelectionStorage;
-    }
-);
+  /**
+   * Unified selection storage to use for listening and getting active selection.
+   */
+  selectionStorage: SelectionStorage;
+}
 
 /**
  * Props for `createPropertyGrid`.
@@ -164,7 +99,7 @@ type PropertyWidgetInternalProps = PropertyGridWidgetOwnProps & {
 export function PropertyGridWidget({
   widgetId,
   widgetDef: widgetDefOverride,
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
+
   shouldShow,
   selectionStorage,
   propertyGridComponent,
@@ -182,14 +117,7 @@ export function PropertyGridWidget({
     }
 
     let isDisposed = false;
-    const predicate = shouldShow
-      ? selectionStorage
-        ? // if selection storage is provided, `shouldShow` takes `Selectables` as an argument
-          shouldShow
-        : // else, it takes a `KeySet`, so we have to do the conversion
-          async (selectables: Selectables) => shouldShow(await createKeySetFromSelectables(selectables))
-      : // finally, if `shouldShow` is not provided, we default to showing the widget if there are any non-transient instances selected
-        defaultWidgetShowPredicate;
+    const predicate = shouldShow ? shouldShow : defaultWidgetShowPredicate;
 
     const toggleWidget = async (selectables: Selectables) => {
       const predicateResult = await predicate(selectables);
@@ -248,17 +176,4 @@ function defaultWidgetShowPredicate(selectables: Selectables) {
     return true;
   }
   return Selectables.some(selectables, (s) => Selectable.isInstanceKey(s) && !Id64.isTransient(s.id));
-}
-
-async function createKeySetFromSelectables(selectables: Selectables) {
-  const keys = new KeySet();
-  for (const [className, ids] of selectables.instanceKeys) {
-    for (const id of ids) {
-      keys.add({ id, className });
-    }
-  }
-  for (const [_, selectable] of selectables.custom) {
-    keys.add(await createKeysFromSelectable(selectable));
-  }
-  return keys;
 }

--- a/packages/itwin/property-grid/src/property-grid-react/PropertyGridUiItemsProvider.tsx
+++ b/packages/itwin/property-grid/src/property-grid-react/PropertyGridUiItemsProvider.tsx
@@ -117,7 +117,7 @@ export function PropertyGridWidget({
     }
 
     let isDisposed = false;
-    const predicate = shouldShow ? shouldShow : defaultWidgetShowPredicate;
+    const predicate = shouldShow ?? defaultWidgetShowPredicate;
 
     const toggleWidget = async (selectables: Selectables) => {
       const predicateResult = await predicate(selectables);

--- a/packages/itwin/property-grid/src/test/PropertyGridUiItemsProvider.test.tsx
+++ b/packages/itwin/property-grid/src/test/PropertyGridUiItemsProvider.test.tsx
@@ -12,12 +12,7 @@ import { Presentation } from "@itwin/presentation-frontend";
 import { Selectables, TRANSIENT_ELEMENT_CLASSNAME } from "@itwin/unified-selection";
 import { createKeysFromSelectable } from "../property-grid-react/hooks/UseUnifiedSelectionHandler.js";
 import { PropertyGridManager } from "../property-grid-react/PropertyGridManager.js";
-import {
-  createPropertyGrid,
-  PropertyGridUiItemsProvider,
-  PropertyGridWidget,
-  PropertyGridWidgetId,
-} from "../property-grid-react/PropertyGridUiItemsProvider.js";
+import { createPropertyGrid, PropertyGridWidget, PropertyGridWidgetId } from "../property-grid-react/PropertyGridUiItemsProvider.js";
 import { act, render, stubSelectionManager, stubSelectionStorage, waitFor } from "./TestUtils.js";
 
 import type { ReactElement } from "react";
@@ -27,49 +22,6 @@ import type { ECClassGroupingNodeKey } from "@itwin/presentation-common";
 import type { EventArgs, Props } from "@itwin/presentation-shared";
 import type { Selectable } from "@itwin/unified-selection";
 import type { PropertyGridWidgetProps } from "../property-grid-react/PropertyGridUiItemsProvider.js";
-
-/* eslint-disable @typescript-eslint/no-deprecated */
-describe("PropertyGridUiItemsProvider", () => {
-  beforeAll(async () => {
-    await PropertyGridManager.initialize(new EmptyLocalization());
-  });
-
-  afterAll(() => {
-    PropertyGridManager.terminate();
-  });
-
-  it("provides widgets to default location", () => {
-    const provider = new PropertyGridUiItemsProvider();
-
-    expect(
-      provider.provideWidgets("", appuiReactModule.StageUsage.General, appuiReactModule.StagePanelLocation.Right, appuiReactModule.StagePanelSection.End),
-    ).not.toHaveLength(0);
-    expect(
-      provider.provideWidgets("", appuiReactModule.StageUsage.General, appuiReactModule.StagePanelLocation.Right, appuiReactModule.StagePanelSection.Start),
-    ).toHaveLength(0);
-    expect(
-      provider.provideWidgets("", appuiReactModule.StageUsage.General, appuiReactModule.StagePanelLocation.Left, appuiReactModule.StagePanelSection.Start),
-    ).toHaveLength(0);
-  });
-
-  it("provides widgets to preferred location", () => {
-    const provider = new PropertyGridUiItemsProvider({
-      defaultPanelLocation: appuiReactModule.StagePanelLocation.Left,
-      defaultPanelSection: appuiReactModule.StagePanelSection.End,
-    });
-
-    expect(
-      provider.provideWidgets("", appuiReactModule.StageUsage.General, appuiReactModule.StagePanelLocation.Right, appuiReactModule.StagePanelSection.End),
-    ).toHaveLength(0);
-    expect(
-      provider.provideWidgets("", appuiReactModule.StageUsage.General, appuiReactModule.StagePanelLocation.Left, appuiReactModule.StagePanelSection.End),
-    ).not.toHaveLength(0);
-    expect(
-      provider.provideWidgets("", appuiReactModule.StageUsage.General, appuiReactModule.StagePanelLocation.Left, appuiReactModule.StagePanelSection.Start),
-    ).toHaveLength(0);
-  });
-});
-/* eslint-enable @typescript-eslint/no-deprecated */
 
 describe("createPropertyGrid", () => {
   function TestPropertyGridComponent() {
@@ -93,12 +45,12 @@ describe("createPropertyGrid", () => {
   });
 
   it("creates a basic widget", async () => {
-    const widget = createPropertyGrid({});
+    const widget = createPropertyGrid({ selectionStorage });
     expect(widget.content).toBeDefined();
   });
 
   it("renders property grid component", async () => {
-    const { getByText } = render(<PropertyGridWidget widgetId="x" propertyGridComponent={<TestPropertyGridComponent />} />);
+    const { getByText } = render(<PropertyGridWidget widgetId="x" selectionStorage={selectionStorage} propertyGridComponent={<TestPropertyGridComponent />} />);
     await waitFor(() => getByText("Test PropertyGridComponent"));
   });
 
@@ -107,7 +59,7 @@ describe("createPropertyGrid", () => {
     function ThrowingComponent(): ReactElement | null {
       throw new Error("Test error");
     }
-    const { getByText } = render(<PropertyGridWidget widgetId="x" propertyGridComponent={<ThrowingComponent />} />);
+    const { getByText } = render(<PropertyGridWidget widgetId="x" selectionStorage={selectionStorage} propertyGridComponent={<ThrowingComponent />} />);
     await waitFor(() => getByText("error"));
     errorStub.mockRestore();
   });
@@ -156,7 +108,7 @@ describe("createPropertyGrid", () => {
         },
       },
     ].forEach(({ name, getProps, setupSelection, triggerSelectionChange }) => {
-      function renderWidget(widgetProps?: PropertyGridWidgetProps) {
+      function renderWidget(widgetProps?: Partial<PropertyGridWidgetProps>) {
         const props = {
           widgetId: "test",
           widgetDef: widgetDef as unknown as WidgetDef,
@@ -259,7 +211,7 @@ describe("createPropertyGrid", () => {
 
         it("opens widget if unified selection non-empty with instance keys and `shouldShow` return true", async () => {
           await setupSelection([{ id: "0x1", className: "TestSchema.TestClass" }]);
-          renderWidget({ shouldShow: () => true });
+          renderWidget({ shouldShow: async () => true });
 
           await waitFor(() => {
             expect(widgetDef.setWidgetState).toHaveBeenCalled();
@@ -278,7 +230,7 @@ describe("createPropertyGrid", () => {
             version: 2,
           };
           await setupSelection([{ identifier: "class grouping node", data: key, async *loadInstanceKeys() {} }]);
-          renderWidget({ shouldShow: () => true });
+          renderWidget({ shouldShow: async () => true });
 
           await waitFor(() => {
             expect(widgetDef.setWidgetState).toHaveBeenCalled();
@@ -289,7 +241,7 @@ describe("createPropertyGrid", () => {
         it("hides widget if unified selection changes non-empty and `shouldShow` returns false", async () => {
           widgetDef.state = appuiReactModule.WidgetState.Open;
           await setupSelection([{ id: "0x1", className: "TestSchema.TestClass" }]);
-          renderWidget({ shouldShow: () => false });
+          renderWidget({ shouldShow: async () => false });
 
           await waitFor(() => {
             expect(widgetDef.setWidgetState).toHaveBeenCalled();


### PR DESCRIPTION
Part of https://github.com/iTwin/viewer-components-react/issues/1669

Removed deprecated APIs:
- `PropertyGridUiItemsProvider`
- `shouldShow` callback in `createPropertyGrid` that work with deprecated selection system.