### PR TITLE
[Tree widget]: change how categories handle their visibility on `next`

### DIFF
--- a/.github/workflows/benchmark-tree-widget-shared.yml
+++ b/.github/workflows/benchmark-tree-widget-shared.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: "pnpm"
 
       - run: pnpm install
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - run: pnpm install
@@ -58,7 +58,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - run: pnpm install
@@ -79,7 +79,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - run: pnpm install
@@ -109,7 +109,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - run: pnpm install

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -81,7 +81,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -125,7 +125,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/extract-api.yml
+++ b/.github/workflows/extract-api.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15.0
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -150,6 +150,7 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
     getChildElements: vi.fn(() => {
       return of([]);
     }),
+    categoryHasIndirectChildren: vi.fn(() => of(false)),
     getSubModelsUnderElement: vi.fn(() => of([])),
     getSubModels: vi.fn(() => EMPTY),
     hasSubModels: vi.fn(() => of(false)),
@@ -273,6 +274,7 @@ export function createClassGroupingHierarchyNode({
   hasDirectNonSearchTargets?: boolean;
   hasSearchTargetAncestor?: boolean;
   topMostParentElementId?: Id64String;
+  childrenWhichAreParents?: Set<Id64String>;
 }): GroupingHierarchyNode & { key: ClassGroupingNodeKey } {
   const className = props.className ?? CLASS_NAME_Element;
   return {
@@ -289,6 +291,7 @@ export function createClassGroupingHierarchyNode({
       modelId,
       categoryOfTopMostParentElement: categoryId,
       topMostParentElementId: props.topMostParentElementId,
+      childrenWhichAreParents: props.childrenWhichAreParents ?? new Set(),
       ...(props.hasDirectNonSearchTargets ? { hasDirectNonSearchTargets: props.hasDirectNonSearchTargets } : {}),
       ...(props.hasSearchTargetAncestor ? { hasSearchTargetAncestor: props.hasSearchTargetAncestor } : {}),
     },

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -128,7 +128,23 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
       }
       return of(0);
     }),
-    getDescendantsCounts: vi.fn(() => {
+    getDescendantsCounts: vi.fn(({ categoryId, parentElementId }: { modelId: Id64String; categoryId?: Id64String; parentElementId?: Id64String }) => {
+      if (parentElementId) {
+        const children = props?.elementChildren?.get(parentElementId) ?? [];
+        if (children.length === 0) {
+          return of(categoryId ? [{ categoryId, count: 0 }] : []);
+        }
+        // When querying by parentElementId, return all children grouped under the parent's category
+        const parentCategory = [...(props?.categoryElements?.entries() ?? [])].find(([, elements]) => elements.includes(parentElementId))?.[0];
+        return of([{ categoryId: parentCategory ?? categoryId ?? "0x0", count: children.length }]);
+      }
+      if (categoryId) {
+        const count = props?.categoryElements?.get(categoryId)?.length ?? 0;
+        if (count === 0) {
+          return of([{ categoryId, count: 0 }]);
+        }
+        return of([{ categoryId, count }]);
+      }
       return of([]);
     }),
     getChildElements: vi.fn(() => {

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -150,7 +150,7 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
     getChildElements: vi.fn(() => {
       return of([]);
     }),
-    categoryHasIndirectChildren: vi.fn(() => of(false)),
+    categoryHasParentElements: vi.fn(() => of(false)),
     getSubModelsUnderElement: vi.fn(() => of([])),
     getSubModels: vi.fn(() => EMPTY),
     hasSubModels: vi.fn(() => of(false)),

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
@@ -2886,7 +2886,7 @@ describe("ModelsTreeVisibilityHandler", () => {
             };
           }),
         );
-        const { imodelConnection, modelId, parentCategoryId, parentElementId, childElementWithDifferentCategoryId } = buildIModelResult;
+        const { imodelConnection, modelId, parentCategoryId } = buildIModelResult;
         using visibilityTestData = createVisibilityTestData({ imodelConnection });
         const { handler, viewport, ...props } = visibilityTestData;
         const parentCategoryNode = createCategoryHierarchyNode({
@@ -2899,16 +2899,7 @@ describe("ModelsTreeVisibilityHandler", () => {
           ...props,
           handler,
           viewport,
-          // prettier-ignore
-          expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                // Only categories of elements without parents are shown in the tree
-                [`${modelId}-${parentCategoryId}`]: "visible",
-                  [parentElementId]: "partial",
-                    [childElementWithDifferentCategoryId]: "hidden",
-
-          },
+          expectations: "all-visible",
         });
       });
 
@@ -2936,7 +2927,7 @@ describe("ModelsTreeVisibilityHandler", () => {
             };
           }),
         );
-        const { imodelConnection, modelId, parentCategoryId, parentElementId, childElementId, childElementWithDifferentCategoryId } = buildIModelResult;
+        const { imodelConnection, modelId, parentCategoryId, parentElementId } = buildIModelResult;
         using visibilityTestData = createVisibilityTestData({ imodelConnection });
         const { handler, viewport, ...props } = visibilityTestData;
         const parentCategoryNode = createCategoryHierarchyNode({ modelId, categoryId: parentCategoryId, hasChildren: true });
@@ -2946,15 +2937,7 @@ describe("ModelsTreeVisibilityHandler", () => {
           ...props,
           handler,
           viewport,
-          // prettier-ignore
-          expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                [`${modelId}-${parentCategoryId}`]: "visible",
-                  [parentElementId]: "partial",
-                    [childElementId]: "visible",
-                    [childElementWithDifferentCategoryId]: "hidden",
-          },
+          expectations: "all-visible",
         });
       });
 
@@ -3009,8 +2992,8 @@ describe("ModelsTreeVisibilityHandler", () => {
             [IModel.rootSubjectId]: "partial",
               [modelId]: "partial",
                 [`${modelId}-${category1Id}`]: "visible",
-                  [parentElementId]: "partial",
-                    [childElementWithDifferentCategoryId]: "hidden",
+                  [parentElementId]: "visible",
+                    [childElementWithDifferentCategoryId]: "visible",
 
                 [`${modelId}-${category2Id}`]: "hidden",
                   [element2Id]: "hidden",
@@ -3074,7 +3057,7 @@ describe("ModelsTreeVisibilityHandler", () => {
                 [`${modelId}-${sharedCategoryId}`]: "visible",
                   [elementWithSharedCategoryId]: "visible",
 
-                [`${modelId}-${parentCategoryId}`]: "hidden",
+                [`${modelId}-${parentCategoryId}`]: "partial",
                   [parentElementId]: "partial",
                     [childElementWithSharedCategoryId]: "visible",
           },
@@ -3173,7 +3156,7 @@ describe("ModelsTreeVisibilityHandler", () => {
           expectations: {
             [IModel.rootSubjectId]: "partial",
               [modelId]: "partial",
-                [`${modelId}-${parentCategoryId}`]: "hidden",
+                [`${modelId}-${parentCategoryId}`]: "partial",
                   [parentElementId]: "partial",
                     [childElementWithDifferentCategoryId]: "visible",
           },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -153,19 +153,33 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
 
   public postProcessNode: NodePostProcessor = async ({ node }) => {
     if (ProcessedHierarchyNode.isGroupingNode(node)) {
-      const modelElementsMap = new Map<ModelId, { elementIds: Set<ElementId>; categoryOfTopMostParentElement: CategoryId }>();
+      const modelElementsMap = new Map<
+        ModelId,
+        {
+          elementIds: Set<ElementId>;
+          categoryOfTopMostParentElement: CategoryId;
+          childrenWhichAreParents: Set<ElementId>;
+        }
+      >();
       for (const child of node.children) {
         let modelEntry = modelElementsMap.get(child.extendedData?.modelId);
         if (!modelEntry) {
           modelEntry = {
             elementIds: new Set(),
             categoryOfTopMostParentElement: child.extendedData?.categoryOfTopMostParentElement,
+            childrenWhichAreParents: new Set<ElementId>(),
           };
           modelElementsMap.set(child.extendedData?.modelId, modelEntry);
         }
         assert(CategoriesTreeNode.isElementNode(child));
+        const addId = child.children
+          ? (id: Id64String) => {
+              modelEntry.elementIds.add(id);
+              modelEntry.childrenWhichAreParents.add(id);
+            }
+          : (id: Id64String) => modelEntry.elementIds.add(id);
         for (const { id } of child.key.instanceKeys) {
-          modelEntry.elementIds.add(id);
+          addId(id);
         }
       }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeNodeInternal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeNodeInternal.ts
@@ -7,6 +7,7 @@ import { CategoriesTreeNode } from "../CategoriesTreeNode.js";
 
 import type { Id64Array, Id64String } from "@itwin/core-bentley";
 import type { ClassGroupingNodeKey, GroupingHierarchyNode, HierarchyNode, InstancesNodeKey, NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
+import type { ElementId } from "../../common/internal/Types.js";
 
 /**
  * Contains utility functions for working with Models Tree nodes.
@@ -55,7 +56,7 @@ export namespace CategoriesTreeNodeInternal {
     extendedData: {
       categoryId: Id64String;
       topMostParentElementId?: Id64String;
-      modelElementsMap: Map<Id64String, { elementIds: Set<Id64String>; categoryOfTopMostParentElement: Id64String }>;
+      modelElementsMap: Map<Id64String, { elementIds: Set<Id64String>; categoryOfTopMostParentElement: Id64String; childrenWhichAreParents: Set<ElementId> }>;
     };
   } => CategoriesTreeNode.isElementClassGroupingNode(node);
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -191,6 +191,7 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       categoryId: node.extendedData.categoryId,
       parentElementsIdsPath,
       categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
+      computeOnlyOwnStatus: node.children ? undefined : true,
     });
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -64,14 +64,14 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
 
   /** Gets grouped elements visibility status. */
   public getGroupedElementsVisibilityStatus(props: {
-    modelElementsMap: Map<ModelId, { elementIds: Set<ElementId>; categoryOfTopMostParentElement: CategoryId }>;
+    modelElementsMap: Map<ModelId, { elementIds: Set<ElementId>; categoryOfTopMostParentElement: CategoryId; childrenWhichAreParents: Set<ElementId> }>;
     categoryId: Id64String;
     parentKeys: HierarchyNodeKey[];
     topMostParentElementId?: ElementId;
   }): Observable<VisibilityStatus> {
     const { modelElementsMap, categoryId, topMostParentElementId } = props;
     return from(modelElementsMap).pipe(
-      mergeMap(([modelId, { elementIds, categoryOfTopMostParentElement }]) =>
+      mergeMap(([modelId, { elementIds, categoryOfTopMostParentElement, childrenWhichAreParents }]) =>
         this.getElementsVisibilityStatus({
           elementIds,
           modelId,
@@ -83,6 +83,7 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
               })
             : [],
           categoryOfTopMostParentElement,
+          computeOnlyOwnStatus: childrenWhichAreParents.size ? (elementId) => !childrenWhichAreParents.has(elementId) : undefined,
         }),
       ),
       mergeVisibilityStatuses(),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -83,7 +83,7 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
               })
             : [],
           categoryOfTopMostParentElement,
-          computeOnlyOwnStatus: childrenWhichAreParents.size ? (elementId) => !childrenWhichAreParents.has(elementId) : undefined,
+          computeOnlyOwnStatus: childrenWhichAreParents.size ? (elementId) => !childrenWhichAreParents.has(elementId) : true,
         }),
       ),
       mergeVisibilityStatuses(),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHandler.ts
@@ -156,6 +156,7 @@ export class ClassificationsTreeVisibilityHandler implements Disposable, TreeSpe
       categoryId: node.extendedData.categoryId,
       parentElementsIdsPath,
       categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
+      computeOnlyOwnStatus: node.children ? undefined : true,
     });
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Rxjs.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Rxjs.ts
@@ -3,9 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defaultIfEmpty, from, last, scan, takeWhile } from "rxjs";
+import { bufferCount, concatMap, defaultIfEmpty, delay, from, last, mergeMap, Observable, of, scan, takeWhile } from "rxjs";
+import { Id64 } from "@itwin/core-bentley";
+import { getOptimalBatchSize } from "./Utils.js";
 
-import type { Observable, ObservableInput, OperatorFunction } from "rxjs";
+import type { ObservableInput, OperatorFunction, Subscription } from "rxjs";
+import type { Id64Arg, Id64String } from "@itwin/core-bentley";
 
 /**
  * Applies reduce function and "returns" early if the predicate returns `false` for the accumulator.
@@ -53,5 +56,69 @@ export async function collect<T>(obs: ObservableInput<T>): Promise<T[]> {
         reject(reason);
       },
     });
+  });
+}
+
+/**
+ * Subscribes to observables for each ID and emits `{ sourceId, result }` for each value.
+ * If the total number of IDs exceeds `batchSize`, subscriptions are split into batches
+ * processed sequentially via `concatMap` with a main-thread yield between them.
+ * Uses a plain array for subscription tracking instead of RxJS's parent-child mechanism,
+ * avoiding O(n^2) `arrRemove` overhead when many inner observables complete simultaneously.
+ * @internal
+ */
+export function subscribeAll<TResult>({
+  ids,
+  getObservable,
+  batchSize = 10_000,
+}: {
+  ids: Id64Arg;
+  getObservable: (id: Id64String) => Observable<TResult>;
+  batchSize?: number;
+}): Observable<{ sourceId: Id64String; result: TResult }> {
+  const totalSize = Id64.sizeOf(ids);
+  if (totalSize < batchSize) {
+    return subscribeAllBatch({ ids, getObservable });
+  }
+  return from(Id64.iterable(ids)).pipe(
+    bufferCount(getOptimalBatchSize({ totalSize, maximumBatchSize: batchSize })),
+    concatMap((batch) => {
+      return of(undefined).pipe(
+        delay(0),
+        mergeMap(() => subscribeAllBatch({ ids: batch, getObservable })),
+      );
+    }),
+  );
+}
+
+function subscribeAllBatch<TResult>({
+  ids,
+  getObservable,
+}: {
+  ids: Id64Arg;
+  getObservable: (id: Id64String) => Observable<TResult>;
+}): Observable<{ sourceId: Id64String; result: TResult }> {
+  return new Observable((subscriber) => {
+    let completed = 0;
+    const total = Id64.sizeOf(ids);
+    const subscriptions: Subscription[] = [];
+    for (const id of Id64.iterable(ids)) {
+      const sub = getObservable(id).subscribe({
+        next: (result) => subscriber.next({ sourceId: id, result }),
+        error: (e) => subscriber.error(e),
+        complete: () => {
+          ++completed;
+          if (completed === total) {
+            subscriber.complete();
+          }
+        },
+      });
+      subscriptions.push(sub);
+    }
+    return () => {
+      for (const sub of subscriptions) {
+        sub.unsubscribe();
+      }
+    };
   });
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Rxjs.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Rxjs.ts
@@ -101,6 +101,10 @@ function subscribeAllBatch<TResult>({
   return new Observable((subscriber) => {
     let completed = 0;
     const total = Id64.sizeOf(ids);
+    if (total === 0) {
+      subscriber.complete();
+      return;
+    }
     const subscriptions: Subscription[] = [];
     for (const id of Id64.iterable(ids)) {
       const sub = getObservable(id).subscribe({

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -125,6 +125,12 @@ export class BaseIdsCache {
     return this.#elementModelCategoriesCache.getCategoriesOfModelsTopMostElements(props);
   }
 
+  public categoryHasIndirectChildren(
+    props: Parameters<ElementModelCategoriesCache["categoryHasIndirectChildren"]>[0],
+  ): ReturnType<ElementModelCategoriesCache["categoryHasIndirectChildren"]> {
+    return this.#elementModelCategoriesCache.categoryHasIndirectChildren(props);
+  }
+
   // DescendantsCountCache methods
 
   public getDescendantsCounts(props: Props<DescendantsCountCache["getDescendantsCounts"]>): ReturnType<DescendantsCountCache["getDescendantsCounts"]> {
@@ -216,6 +222,12 @@ export class BaseIdsCacheImpl {
 
   public getModels(props: Props<ElementModelCategoriesCache["getCategoryElementModels"]>): ReturnType<ElementModelCategoriesCache["getCategoryElementModels"]> {
     return this.#baseIdsCache.getModels(props);
+  }
+
+  public categoryHasIndirectChildren(
+    props: Parameters<ElementModelCategoriesCache["categoryHasIndirectChildren"]>[0],
+  ): ReturnType<ElementModelCategoriesCache["categoryHasIndirectChildren"]> {
+    return this.#baseIdsCache.categoryHasIndirectChildren(props);
   }
 
   public getAllCategoriesOfElements(): ReturnType<ElementModelCategoriesCache["getAllCategoriesOfElements"]> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -125,10 +125,10 @@ export class BaseIdsCache {
     return this.#elementModelCategoriesCache.getCategoriesOfModelsTopMostElements(props);
   }
 
-  public categoryHasIndirectChildren(
-    props: Parameters<ElementModelCategoriesCache["categoryHasIndirectChildren"]>[0],
-  ): ReturnType<ElementModelCategoriesCache["categoryHasIndirectChildren"]> {
-    return this.#elementModelCategoriesCache.categoryHasIndirectChildren(props);
+  public categoryHasParentElements(
+    props: Parameters<ElementModelCategoriesCache["categoryHasParentElements"]>[0],
+  ): ReturnType<ElementModelCategoriesCache["categoryHasParentElements"]> {
+    return this.#elementModelCategoriesCache.categoryHasParentElements(props);
   }
 
   // DescendantsCountCache methods
@@ -224,10 +224,10 @@ export class BaseIdsCacheImpl {
     return this.#baseIdsCache.getModels(props);
   }
 
-  public categoryHasIndirectChildren(
-    props: Parameters<ElementModelCategoriesCache["categoryHasIndirectChildren"]>[0],
-  ): ReturnType<ElementModelCategoriesCache["categoryHasIndirectChildren"]> {
-    return this.#baseIdsCache.categoryHasIndirectChildren(props);
+  public categoryHasParentElements(
+    props: Parameters<ElementModelCategoriesCache["categoryHasParentElements"]>[0],
+  ): ReturnType<ElementModelCategoriesCache["categoryHasParentElements"]> {
+    return this.#baseIdsCache.categoryHasParentElements(props);
   }
 
   public getAllCategoriesOfElements(): ReturnType<ElementModelCategoriesCache["getAllCategoriesOfElements"]> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -4,21 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { bufferCount, forkJoin, fromEventPattern, map, mergeMap, of, reduce, switchMap, take, tap, timer } from "rxjs";
-import { assert, BeEvent, Guid } from "@itwin/core-bentley";
+import { assert, Guid } from "@itwin/core-bentley";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
 import { releaseMainThreadOnItemsCount } from "../Utils.js";
 
 import type { Observable } from "rxjs";
-import type { Listener } from "@itwin/core-bentley";
 
 type RequestId = string;
 
 /**
- * A BeEvent that fires at most once and replays to late listeners.
+ * A single-fire event that replays to late listeners.
  * If `addOnce` is called after the event has already been raised,
  * the listener is invoked immediately with the stored arguments.
  */
-class OneShotEvent<T extends Listener> extends BeEvent<T> {
+class OneShotEvent<T extends (...args: any[]) => void> {
+  #listeners: Set<T> = new Set();
   #firedWithArgs?:
     | {
         fired: true;
@@ -26,17 +26,29 @@ class OneShotEvent<T extends Listener> extends BeEvent<T> {
       }
     | { fired: false };
 
-  public override raiseEvent(...props: Parameters<T>): ReturnType<BeEvent<T>["raiseEvent"]> {
-    this.#firedWithArgs = { fired: true, args: props };
-    return super.raiseEvent(...props);
+  public raiseEvent(...args: Parameters<T>): void {
+    this.#firedWithArgs = { fired: true, args };
+    const listeners = this.#listeners;
+    this.#listeners = new Set();
+    for (const listener of listeners) {
+      listener(...args);
+    }
+    listeners.clear();
   }
 
-  public override addOnce(listener: T, scope?: any): ReturnType<BeEvent<T>["addOnce"]> {
+  public addOnce(listener: T): () => void {
     if (this.#firedWithArgs?.fired) {
       listener(...this.#firedWithArgs.args);
       return () => {};
     }
-    return super.addOnce(listener, scope);
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  public clear(): void {
+    this.#listeners = new Set();
   }
 }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { bufferCount, last, map, merge, mergeMap, of, reduce, shareReplay, switchMap, tap, timer } from "rxjs";
-import { assert, Guid } from "@itwin/core-bentley";
+import { bufferCount, forkJoin, fromEventPattern, map, mergeMap, of, reduce, switchMap, take, tap, timer } from "rxjs";
+import { assert, BeEvent, Guid } from "@itwin/core-bentley";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
 import { releaseMainThreadOnItemsCount } from "../Utils.js";
 
@@ -45,13 +45,13 @@ export interface BatchingCacheProps {
 export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   // When a new request is made via `get`:
   // - If the value is already cached, returns it immediately.
-  // - If it's already in-flight (#requestedValues), subscribes to the same observable.
+  // - If it's already in-flight (#requestedValues), subscribes to the same completion event.
   // - Otherwise, adds to #valuesToRequest. A timer is started if not already running;
   //   after the timer fires, the batch executes and caches results.
 
-  /** Pending requests buffer. `sharedObs` is created lazily on the first `get` call. */
-  #valuesToRequest: { values: TRequest[]; sharedObs?: Observable<void> } = { values: [] };
-  #requestedValues = new Map<RequestId, { values: TRequest[]; sharedObs: Observable<void> }>();
+  /** Pending requests buffer. `event` is created lazily on the first `get` call of each batch cycle. */
+  #valuesToRequest: { values: TRequest[]; event?: BeEvent<() => void> } = { values: [] };
+  #requestedValues = new Map<RequestId, { values: TRequest[]; event: BeEvent<() => void> }>();
   #bufferSize: number;
   #timerDelay: number;
   #releaseOnCount: number;
@@ -66,9 +66,9 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   protected abstract getCachedValue(request: TRequest): TResult | undefined;
 
   /**
-   * Return the portion of the request which needs to be requested (not in batch or cache).
-   * Returns `undefined` if the entire request is already in the batch.
-   * For caches without partial requests, return `undefined` if in batch, or the full request if not.
+   * Return the portion of the request not already covered by the given set of values.
+   * Returns `undefined` for `valuesNotInBatch` if the request is fully covered.
+   * For caches without partial requests, return `undefined` if covered, or the full request otherwise.
    */
   protected abstract getValuesNotInBatch(
     request: TRequest,
@@ -76,10 +76,10 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   ): { valuesNotInBatch: TRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true };
 
   /**
-   * Convert batched requests into units of data which are used to execute the query.
-   * For example, TRequest might be an object containing various request values, when converted to TQueryData,
-   * those values take shape of a WHERE clause fragments.
-   * These TQueryData items are buffered and passed to `executeQuery`.
+   * Convert batched requests into query data items.
+   * For example, TRequest might be an object containing various request values; when converted to TQueryData,
+   * those values take the shape of WHERE clause fragments.
+   * The resulting items are buffered (up to `bufferSize`) and passed to `executeQuery`.
    */
   protected abstract getQueryData(batch: TRequest[]): Observable<TQueryData>;
 
@@ -104,61 +104,67 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
 
     // Check if request is fully covered by an in-flight batch
     let requestNotInBatch: TRequest = request;
-    const sharedObsArray: Array<Observable<void>> = [];
-    for (const { values, sharedObs } of this.#requestedValues.values()) {
+    const events: Array<BeEvent<() => void>> = [];
+    for (const { values, event } of this.#requestedValues.values()) {
       const { valuesNotInBatch, batchContainsValues } = this.getValuesNotInBatch(requestNotInBatch, values);
       if (batchContainsValues) {
-        sharedObsArray.push(sharedObs);
+        events.push(event);
       }
       if (valuesNotInBatch === undefined) {
-        return this.getResultAfterObservable(request, merge(...sharedObsArray).pipe(last()));
+        return this.getResultAfterEvents(request, events);
       }
       requestNotInBatch = valuesNotInBatch;
     }
 
-    if (this.#valuesToRequest.sharedObs === undefined) {
+    if (this.#valuesToRequest.event === undefined) {
       const requestId = Guid.createValue();
-      this.#valuesToRequest.sharedObs = this.createSharedObs({
+      const newEvent = new BeEvent<() => void>();
+      this.#valuesToRequest.event = newEvent;
+      this.scheduleBatchExecution({
         values: this.#valuesToRequest.values,
         onStart: () => {
-          const { sharedObs } = this.#valuesToRequest;
-          assert(sharedObs !== undefined);
-          // After when start happens, assign the observable in #valuesToRequest to the #requestedValues
-          this.#requestedValues.set(requestId, { values: this.#valuesToRequest.values, sharedObs });
-          // Clear #valuesToRequest so new requests can be collected while the query is executing
+          // Move the pending buffer into #requestedValues so in-flight lookups find it
+          this.#requestedValues.set(requestId, { values: this.#valuesToRequest.values, event: newEvent });
+          // Reset #valuesToRequest so new requests can be collected while the query is executing
           this.#valuesToRequest = { values: [] };
         },
         onDone: () => {
+          newEvent.raiseEvent();
+          newEvent.clear();
           this.#requestedValues.delete(requestId);
         },
       });
     }
 
     this.#valuesToRequest.values.push(requestNotInBatch);
-    // Some values might be requested in sharedObsArray while waiting for the timer, so merge those in as well
-    return this.getResultAfterObservable(request, merge(...[...sharedObsArray, this.#valuesToRequest.sharedObs]).pipe(last()));
+    return this.getResultAfterEvents(request, [...events, this.#valuesToRequest.event]);
   }
 
-  private createSharedObs({ values, onStart, onDone }: { values: TRequest[]; onStart: () => void; onDone: () => void }): Observable<void> {
-    return timer(this.#timerDelay).pipe(
-      switchMap(() => {
-        onStart();
-        return this.executeBatchQuery(values).pipe(
-          reduce((_acc, row: TRow) => {
-            // Cache each row as it arrives, use reduce to emit one value when query completes
-            this.insertRow(row);
-            return undefined;
-          }, undefined),
-          tap(() => {
-            this.ensureDefaultCacheEntries(values);
-          }),
-        );
-      }),
-      tap({
-        finalize: onDone,
-      }),
-      shareReplay(1),
-    );
+  private scheduleBatchExecution({ values, onStart, onDone }: { values: TRequest[]; onStart: () => void; onDone: () => void }): void {
+    timer(this.#timerDelay)
+      .pipe(
+        switchMap(() => {
+          onStart();
+          return this.executeBatchQuery(values).pipe(
+            reduce((_acc, row: TRow) => {
+              // Cache each row inside the reducer; reduce emits a single value once the query completes
+              this.insertRow(row);
+              return undefined;
+            }, undefined),
+            tap(() => {
+              this.ensureDefaultCacheEntries(values);
+            }),
+          );
+        }),
+        tap({
+          finalize: onDone,
+        }),
+      )
+      .subscribe({
+        error: () => {
+          onDone();
+        },
+      });
   }
 
   private executeBatchQuery(batch: TRequest[]): Observable<TRow> {
@@ -169,8 +175,14 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     );
   }
 
-  private getResultAfterObservable(request: TRequest, observable: Observable<void>): Observable<TResult> {
-    return observable.pipe(
+  private getResultAfterEvents(request: TRequest, events: Array<BeEvent<() => void>>): Observable<TResult> {
+    return forkJoin(
+      events.map((event) =>
+        fromEventPattern((handler) => {
+          event.addOnce(handler);
+        }).pipe(take(1)),
+      ),
+    ).pipe(
       map(() => {
         const cachedValue = this.getCachedValue(request);
         assert(cachedValue !== undefined);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -77,9 +77,9 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   // - Otherwise, adds to #valuesToRequest. A timer is started if not already running;
   //   after the timer fires, the batch executes and caches results.
 
-  /** Pending requests buffer. `event` is created lazily on the first `get` call of each batch cycle. */
-  #valuesToRequest: { values: TRequest[]; event?: OneShotEvent<(error?: Error) => void> } = { values: [] };
-  #requestedValues = new Map<RequestId, { values: TRequest[]; event: OneShotEvent<(error?: Error) => void> }>();
+  /** Pending requests buffer. `batchCompleted` is created lazily on the first `get` call of each batch cycle. */
+  #valuesToRequest: { values: TRequest[]; batchCompleted?: OneShotEvent<(error?: Error) => void> } = { values: [] };
+  #requestedValues = new Map<RequestId, { values: TRequest[]; batchCompleted: OneShotEvent<(error?: Error) => void> }>();
   #bufferSize: number;
   #timerDelay: number;
   #releaseOnCount: number;
@@ -133,10 +133,10 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     // Check if request is fully covered by an in-flight batch
     let requestNotInBatch: TRequest = request;
     const events: Array<OneShotEvent<(error?: Error) => void>> = [];
-    for (const { values, event } of this.#requestedValues.values()) {
+    for (const { values, batchCompleted } of this.#requestedValues.values()) {
       const { valuesNotInBatch, batchContainsValues } = this.getValuesNotInBatch(requestNotInBatch, values);
       if (batchContainsValues) {
-        events.push(event);
+        events.push(batchCompleted);
       }
       if (valuesNotInBatch === undefined) {
         return this.getResultAfterEvents(request, events);
@@ -144,15 +144,15 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
       requestNotInBatch = valuesNotInBatch;
     }
 
-    if (this.#valuesToRequest.event === undefined) {
+    if (this.#valuesToRequest.batchCompleted === undefined) {
       const requestId = Guid.createValue();
       const newEvent = new OneShotEvent<(error?: Error) => void>();
-      this.#valuesToRequest.event = newEvent;
+      this.#valuesToRequest.batchCompleted = newEvent;
       this.scheduleBatchExecution({
         values: this.#valuesToRequest.values,
         onStart: () => {
           // Move the pending buffer into #requestedValues so in-flight lookups find it
-          this.#requestedValues.set(requestId, { values: this.#valuesToRequest.values, event: newEvent });
+          this.#requestedValues.set(requestId, { values: this.#valuesToRequest.values, batchCompleted: newEvent });
           // Reset #valuesToRequest so new requests can be collected while the query is executing
           this.#valuesToRequest = { values: [] };
         },
@@ -165,7 +165,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     }
 
     this.#valuesToRequest.values.push(requestNotInBatch);
-    return this.getResultAfterEvents(request, [...events, this.#valuesToRequest.event]);
+    return this.getResultAfterEvents(request, [...events, this.#valuesToRequest.batchCompleted]);
   }
 
   private scheduleBatchExecution({ values, onStart, onDone }: { values: TRequest[]; onStart: () => void; onDone: (error?: Error) => void }): void {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -50,8 +50,8 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   //   after the timer fires, the batch executes and caches results.
 
   /** Pending requests buffer. `event` is created lazily on the first `get` call of each batch cycle. */
-  #valuesToRequest: { values: TRequest[]; event?: BeEvent<() => void> } = { values: [] };
-  #requestedValues = new Map<RequestId, { values: TRequest[]; event: BeEvent<() => void> }>();
+  #valuesToRequest: { values: TRequest[]; event?: BeEvent<(error?: Error) => void> } = { values: [] };
+  #requestedValues = new Map<RequestId, { values: TRequest[]; event: BeEvent<(error?: Error) => void> }>();
   #bufferSize: number;
   #timerDelay: number;
   #releaseOnCount: number;
@@ -104,7 +104,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
 
     // Check if request is fully covered by an in-flight batch
     let requestNotInBatch: TRequest = request;
-    const events: Array<BeEvent<() => void>> = [];
+    const events: Array<BeEvent<(error?: Error) => void>> = [];
     for (const { values, event } of this.#requestedValues.values()) {
       const { valuesNotInBatch, batchContainsValues } = this.getValuesNotInBatch(requestNotInBatch, values);
       if (batchContainsValues) {
@@ -118,7 +118,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
 
     if (this.#valuesToRequest.event === undefined) {
       const requestId = Guid.createValue();
-      const newEvent = new BeEvent<() => void>();
+      const newEvent = new BeEvent<(error?: Error) => void>();
       this.#valuesToRequest.event = newEvent;
       this.scheduleBatchExecution({
         values: this.#valuesToRequest.values,
@@ -128,8 +128,8 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
           // Reset #valuesToRequest so new requests can be collected while the query is executing
           this.#valuesToRequest = { values: [] };
         },
-        onDone: () => {
-          newEvent.raiseEvent();
+        onDone: (error?: Error) => {
+          newEvent.raiseEvent(error);
           newEvent.clear();
           this.#requestedValues.delete(requestId);
         },
@@ -140,7 +140,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     return this.getResultAfterEvents(request, [...events, this.#valuesToRequest.event]);
   }
 
-  private scheduleBatchExecution({ values, onStart, onDone }: { values: TRequest[]; onStart: () => void; onDone: () => void }): void {
+  private scheduleBatchExecution({ values, onStart, onDone }: { values: TRequest[]; onStart: () => void; onDone: (error?: Error) => void }): void {
     timer(this.#timerDelay)
       .pipe(
         switchMap(() => {
@@ -156,14 +156,10 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
             }),
           );
         }),
-        tap({
-          finalize: onDone,
-        }),
       )
       .subscribe({
-        error: () => {
-          onDone();
-        },
+        complete: () => onDone(),
+        error: (e) => (e instanceof Error ? onDone(e) : onDone(new Error(JSON.stringify(e)))),
       });
   }
 
@@ -175,15 +171,19 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     );
   }
 
-  private getResultAfterEvents(request: TRequest, events: Array<BeEvent<() => void>>): Observable<TResult> {
+  private getResultAfterEvents(request: TRequest, events: Array<BeEvent<(error?: Error) => void>>): Observable<TResult> {
     return forkJoin(
       events.map((event) =>
-        fromEventPattern((handler) => {
+        fromEventPattern<Error | undefined>((handler) => {
           event.addOnce(handler);
         }).pipe(take(1)),
       ),
     ).pipe(
-      map(() => {
+      map((results) => {
+        const error = results.find((r) => r !== undefined);
+        if (error !== undefined) {
+          throw error;
+        }
         const cachedValue = this.getCachedValue(request);
         assert(cachedValue !== undefined);
         return cachedValue;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BatchingCache.ts
@@ -9,8 +9,36 @@ import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
 import { releaseMainThreadOnItemsCount } from "../Utils.js";
 
 import type { Observable } from "rxjs";
+import type { Listener } from "@itwin/core-bentley";
 
 type RequestId = string;
+
+/**
+ * A BeEvent that fires at most once and replays to late listeners.
+ * If `addOnce` is called after the event has already been raised,
+ * the listener is invoked immediately with the stored arguments.
+ */
+class OneShotEvent<T extends Listener> extends BeEvent<T> {
+  #firedWithArgs?:
+    | {
+        fired: true;
+        args: Parameters<T>;
+      }
+    | { fired: false };
+
+  public override raiseEvent(...props: Parameters<T>): ReturnType<BeEvent<T>["raiseEvent"]> {
+    this.#firedWithArgs = { fired: true, args: props };
+    return super.raiseEvent(...props);
+  }
+
+  public override addOnce(listener: T, scope?: any): ReturnType<BeEvent<T>["addOnce"]> {
+    if (this.#firedWithArgs?.fired) {
+      listener(...this.#firedWithArgs.args);
+      return () => {};
+    }
+    return super.addOnce(listener, scope);
+  }
+}
 
 /** @internal */
 export interface BatchingCacheProps {
@@ -50,8 +78,8 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
   //   after the timer fires, the batch executes and caches results.
 
   /** Pending requests buffer. `event` is created lazily on the first `get` call of each batch cycle. */
-  #valuesToRequest: { values: TRequest[]; event?: BeEvent<(error?: Error) => void> } = { values: [] };
-  #requestedValues = new Map<RequestId, { values: TRequest[]; event: BeEvent<(error?: Error) => void> }>();
+  #valuesToRequest: { values: TRequest[]; event?: OneShotEvent<(error?: Error) => void> } = { values: [] };
+  #requestedValues = new Map<RequestId, { values: TRequest[]; event: OneShotEvent<(error?: Error) => void> }>();
   #bufferSize: number;
   #timerDelay: number;
   #releaseOnCount: number;
@@ -104,7 +132,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
 
     // Check if request is fully covered by an in-flight batch
     let requestNotInBatch: TRequest = request;
-    const events: Array<BeEvent<(error?: Error) => void>> = [];
+    const events: Array<OneShotEvent<(error?: Error) => void>> = [];
     for (const { values, event } of this.#requestedValues.values()) {
       const { valuesNotInBatch, batchContainsValues } = this.getValuesNotInBatch(requestNotInBatch, values);
       if (batchContainsValues) {
@@ -118,7 +146,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
 
     if (this.#valuesToRequest.event === undefined) {
       const requestId = Guid.createValue();
-      const newEvent = new BeEvent<(error?: Error) => void>();
+      const newEvent = new OneShotEvent<(error?: Error) => void>();
       this.#valuesToRequest.event = newEvent;
       this.scheduleBatchExecution({
         values: this.#valuesToRequest.values,
@@ -171,7 +199,7 @@ export abstract class BatchingCache<TRequest, TResult, TQueryData, TRow> {
     );
   }
 
-  private getResultAfterEvents(request: TRequest, events: Array<BeEvent<(error?: Error) => void>>): Observable<TResult> {
+  private getResultAfterEvents(request: TRequest, events: Array<OneShotEvent<(error?: Error) => void>>): Observable<TResult> {
     return forkJoin(
       events.map((event) =>
         fromEventPattern<Error | undefined>((handler) => {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
@@ -28,8 +28,11 @@ export class ElementModelCategoriesCache {
   #componentName: string;
   #elementClassName: string;
   #modeledElementsCache: ModeledElementsCache;
-  #modelsCategoriesInfo:
-    | Observable<Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>>
+  #cachedData:
+    | Observable<{
+        modelsCategoriesInfo: Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>;
+        categoriesWithIndirectChildren: Set<CategoryId>;
+      }>
     | undefined;
 
   constructor(props: ElementModelCategoriesCacheProps) {
@@ -44,19 +47,19 @@ export class ElementModelCategoriesCache {
     modelId: Id64String;
     categoryId: Id64String;
     isTopMostElementCategory: boolean;
+    hasIndirectChildren: boolean;
   }> {
     return defer(() => {
       const query = `
-          SELECT * FROM (
-            SELECT
-              this.Model.Id modelId,
-              this.Category.Id categoryId,
-              MAX(IIF(this.Parent.Id IS NULL, 1, 0)) isTopMostElementCategory
-            FROM ${CLASS_NAME_Model} m
-            JOIN ${this.#elementClassName} this ON m.ECInstanceId = this.Model.Id
-            WHERE m.IsPrivate = false
-            GROUP BY modelId, categoryId
-          )
+          SELECT
+            this.Model.Id modelId,
+            this.Category.Id categoryId,
+            MAX(IIF(this.Parent.Id IS NULL, 1, 0)) isTopMostElementCategory,
+            MAX(IIF((SELECT 1 FROM ${this.#elementClassName} ce WHERE ce.Parent.Id = this.ECInstanceId LIMIT 1), 1, 0)) hasIndirectChildren
+          FROM ${CLASS_NAME_Model} m
+          JOIN ${this.#elementClassName} this ON m.ECInstanceId = this.Model.Id
+          WHERE m.IsPrivate = false
+          GROUP BY modelId, categoryId
         `;
       return this.#queryExecutor.createQueryReader(
         { ecsql: query },
@@ -65,45 +68,59 @@ export class ElementModelCategoriesCache {
     }).pipe(
       catchBeSQLiteInterrupts,
       map((row) => {
-        return { modelId: row.modelId, categoryId: row.categoryId, isTopMostElementCategory: !!row.isTopMostElementCategory };
+        return {
+          modelId: row.modelId,
+          categoryId: row.categoryId,
+          isTopMostElementCategory: !!row.isTopMostElementCategory,
+          hasIndirectChildren: !!row.hasIndirectChildren,
+        };
       }),
     );
   }
 
-  private getModelsCategoriesInfo() {
-    this.#modelsCategoriesInfo ??= forkJoin({
+  private getCachedData() {
+    this.#cachedData ??= forkJoin({
       modelCategories: this.queryElementModelCategories().pipe(
-        reduce((acc, queriedCategory) => {
-          let modelEntry = acc.get(queriedCategory.modelId);
-          if (modelEntry === undefined) {
-            modelEntry = { categoriesOfTopMostElements: new Set(), allCategories: new Set() };
-            acc.set(queriedCategory.modelId, modelEntry);
-          }
-          modelEntry.allCategories.add(queriedCategory.categoryId);
-          if (queriedCategory.isTopMostElementCategory) {
-            modelEntry.categoriesOfTopMostElements.add(queriedCategory.categoryId);
-          }
-          return acc;
-        }, new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId> }>()),
+        reduce(
+          (acc, queriedCategory) => {
+            let modelEntry = acc.modelsCategoriesInfo.get(queriedCategory.modelId);
+            if (modelEntry === undefined) {
+              modelEntry = { categoriesOfTopMostElements: new Set(), allCategories: new Set() };
+              acc.modelsCategoriesInfo.set(queriedCategory.modelId, modelEntry);
+            }
+            modelEntry.allCategories.add(queriedCategory.categoryId);
+            if (queriedCategory.isTopMostElementCategory) {
+              modelEntry.categoriesOfTopMostElements.add(queriedCategory.categoryId);
+            }
+            if (queriedCategory.hasIndirectChildren) {
+              acc.categoriesWithIndirectChildren.add(queriedCategory.categoryId);
+            }
+            return acc;
+          },
+          {
+            modelsCategoriesInfo: new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId> }>(),
+            categoriesWithIndirectChildren: new Set<CategoryId>(),
+          },
+        ),
       ),
       allSubModels: this.#modeledElementsCache.getModeledElementsInfo().pipe(map(({ allSubModels }) => allSubModels)),
     }).pipe(
       releaseMainThreadOnItemsCount(1),
       map(({ modelCategories, allSubModels }) => {
-        const result = new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>();
-        for (const [modelId, { categoriesOfTopMostElements, allCategories }] of modelCategories) {
+        const modelsCategoriesInfo = new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>();
+        for (const [modelId, { categoriesOfTopMostElements, allCategories }] of modelCategories.modelsCategoriesInfo) {
           const isSubModel = allSubModels.has(modelId);
-          result.set(modelId, {
+          modelsCategoriesInfo.set(modelId, {
             categoriesOfTopMostElements,
             allCategories,
             isSubModel,
           });
         }
-        return result;
+        return { modelsCategoriesInfo, categoriesWithIndirectChildren: modelCategories.categoriesWithIndirectChildren };
       }),
       shareReplay(),
     );
-    return this.#modelsCategoriesInfo;
+    return this.#cachedData;
   }
 
   public getCategoryElementModels(props: {
@@ -112,10 +129,10 @@ export class ElementModelCategoriesCache {
     includeOnlyIfCategoryOfTopMostElement?: boolean;
   }): Observable<Array<ModelId>> {
     const { categoryId, subModels } = props;
-    return this.getModelsCategoriesInfo().pipe(
-      map((modelCategories) => {
+    return this.getCachedData().pipe(
+      map(({ modelsCategoriesInfo }) => {
         const categoryModels = new Array<ModelId>();
-        for (const [modelId, { allCategories, categoriesOfTopMostElements, isSubModel }] of modelCategories) {
+        for (const [modelId, { allCategories, categoriesOfTopMostElements, isSubModel }] of modelsCategoriesInfo) {
           if (
             (subModels === "include" || (subModels === "only" && isSubModel) || (subModels === "exclude" && !isSubModel)) &&
             (props.includeOnlyIfCategoryOfTopMostElement ? categoriesOfTopMostElements.has(categoryId) : allCategories.has(categoryId))
@@ -135,18 +152,19 @@ export class ElementModelCategoriesCache {
     modelId: Id64String;
     includeOnlyIfCategoryOfTopMostElement?: boolean;
   }): Observable<Id64Set> {
-    return this.getModelsCategoriesInfo().pipe(
+    return this.getCachedData().pipe(
       map(
-        (modelCategories) =>
-          (includeOnlyIfCategoryOfTopMostElement ? modelCategories.get(modelId)?.categoriesOfTopMostElements : modelCategories.get(modelId)?.allCategories) ??
-          new Set(),
+        ({ modelsCategoriesInfo }) =>
+          (includeOnlyIfCategoryOfTopMostElement
+            ? modelsCategoriesInfo.get(modelId)?.categoriesOfTopMostElements
+            : modelsCategoriesInfo.get(modelId)?.allCategories) ?? new Set(),
       ),
     );
   }
 
   public getCategoriesOfModelsTopMostElements(modelIds: Id64Array): Observable<Id64Set> {
-    return this.getModelsCategoriesInfo().pipe(
-      mergeMap((modelCategories) => from(modelIds).pipe(mergeMap((modelId) => modelCategories.get(modelId)?.categoriesOfTopMostElements ?? []))),
+    return this.getCachedData().pipe(
+      mergeMap(({ modelsCategoriesInfo }) => from(modelIds).pipe(mergeMap((modelId) => modelsCategoriesInfo.get(modelId)?.categoriesOfTopMostElements ?? []))),
       reduce((acc, categoryId) => {
         acc.add(categoryId);
         return acc;
@@ -155,8 +173,8 @@ export class ElementModelCategoriesCache {
   }
 
   public getAllCategoriesOfElements(): Observable<Id64Set> {
-    return this.getModelsCategoriesInfo().pipe(
-      mergeMap((modelCategories) => modelCategories.values()),
+    return this.getCachedData().pipe(
+      mergeMap(({ modelsCategoriesInfo }) => from(modelsCategoriesInfo.values())),
       reduce((acc, { allCategories }) => {
         for (const categoryId of allCategories) {
           acc.add(categoryId);
@@ -167,6 +185,10 @@ export class ElementModelCategoriesCache {
   }
 
   public getAllModels(): Observable<Array<ModelId>> {
-    return this.getModelsCategoriesInfo().pipe(map((modelCategories) => [...modelCategories.keys()]));
+    return this.getCachedData().pipe(map(({ modelsCategoriesInfo }) => [...modelsCategoriesInfo.keys()]));
+  }
+
+  public categoryHasIndirectChildren(categoryId: Id64String): Observable<boolean> {
+    return this.getCachedData().pipe(map(({ categoriesWithIndirectChildren }) => categoriesWithIndirectChildren.has(categoryId)));
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
@@ -31,7 +31,7 @@ export class ElementModelCategoriesCache {
   #cachedData:
     | Observable<{
         modelsCategoriesInfo: Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>;
-        categoriesWithIndirectChildren: Set<CategoryId>;
+        categoriesWithParentElements: Set<CategoryId>;
       }>
     | undefined;
 
@@ -47,7 +47,7 @@ export class ElementModelCategoriesCache {
     modelId: Id64String;
     categoryId: Id64String;
     isTopMostElementCategory: boolean;
-    hasIndirectChildren: boolean;
+    hasParentElements: boolean;
   }> {
     return defer(() => {
       const query = `
@@ -55,7 +55,7 @@ export class ElementModelCategoriesCache {
             this.Model.Id modelId,
             this.Category.Id categoryId,
             MAX(IIF(this.Parent.Id IS NULL, 1, 0)) isTopMostElementCategory,
-            MAX(IIF((SELECT 1 FROM ${this.#elementClassName} ce WHERE ce.Parent.Id = this.ECInstanceId LIMIT 1), 1, 0)) hasIndirectChildren
+            MAX(IIF((SELECT 1 FROM ${this.#elementClassName} ce WHERE ce.Parent.Id = this.ECInstanceId LIMIT 1), 1, 0)) hasParentElements
           FROM ${CLASS_NAME_Model} m
           JOIN ${this.#elementClassName} this ON m.ECInstanceId = this.Model.Id
           WHERE m.IsPrivate = false
@@ -72,7 +72,7 @@ export class ElementModelCategoriesCache {
           modelId: row.modelId,
           categoryId: row.categoryId,
           isTopMostElementCategory: !!row.isTopMostElementCategory,
-          hasIndirectChildren: !!row.hasIndirectChildren,
+          hasParentElements: !!row.hasParentElements,
         };
       }),
     );
@@ -92,14 +92,14 @@ export class ElementModelCategoriesCache {
             if (queriedCategory.isTopMostElementCategory) {
               modelEntry.categoriesOfTopMostElements.add(queriedCategory.categoryId);
             }
-            if (queriedCategory.hasIndirectChildren) {
-              acc.categoriesWithIndirectChildren.add(queriedCategory.categoryId);
+            if (queriedCategory.hasParentElements) {
+              acc.categoriesWithParentElements.add(queriedCategory.categoryId);
             }
             return acc;
           },
           {
             modelsCategoriesInfo: new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId> }>(),
-            categoriesWithIndirectChildren: new Set<CategoryId>(),
+            categoriesWithParentElements: new Set<CategoryId>(),
           },
         ),
       ),
@@ -116,7 +116,7 @@ export class ElementModelCategoriesCache {
             isSubModel,
           });
         }
-        return { modelsCategoriesInfo, categoriesWithIndirectChildren: modelCategories.categoriesWithIndirectChildren };
+        return { modelsCategoriesInfo, categoriesWithParentElements: modelCategories.categoriesWithParentElements };
       }),
       shareReplay(),
     );
@@ -188,7 +188,7 @@ export class ElementModelCategoriesCache {
     return this.getCachedData().pipe(map(({ modelsCategoriesInfo }) => [...modelsCategoriesInfo.keys()]));
   }
 
-  public categoryHasIndirectChildren(categoryId: Id64String): Observable<boolean> {
-    return this.getCachedData().pipe(map(({ categoriesWithIndirectChildren }) => categoriesWithIndirectChildren.has(categoryId)));
+  public categoryHasParentElements(categoryId: Id64String): Observable<boolean> {
+    return this.getCachedData().pipe(map(({ categoriesWithParentElements }) => categoriesWithParentElements.has(categoryId)));
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -807,11 +807,10 @@ export class BaseVisibilityHelper implements Disposable {
         if (!hasSubModels) {
           return EMPTY;
         }
-        return fromWithRelease({ source: categoryIds, releaseOnCount: 200 }).pipe(
-          mergeMap((categoryId) => this.#props.baseIdsCache.getSubModels({ categoryId, modelId })),
-          mergeMap((subModels) => this.changeModelsVisibilityStatus({ modelIds: subModels, on })),
-        );
+        return fromWithRelease({ source: categoryIds, releaseOnCount: 200 });
       }),
+      mergeMap((categoryId) => this.#props.baseIdsCache.getSubModels({ categoryId, modelId })),
+      mergeMap((subModels) => this.changeModelsVisibilityStatus({ modelIds: subModels, on })),
     );
     return merge(
       changeModelsVisibilityStatusObs.pipe(
@@ -900,18 +899,14 @@ export class BaseVisibilityHelper implements Disposable {
             if (!hasSubModels) {
               return EMPTY;
             }
-            return fromWithRelease({ source: elementIds, releaseOnCount: 100 }).pipe(
-              mergeMap((elementId) =>
-                this.#props.baseIdsCache.getSubModelsUnderElement(elementId).pipe(
-                  mergeMap((subModelsUnderElement) => {
-                    if (subModelsUnderElement.length > 0) {
-                      return this.changeModelsVisibilityStatus({ modelIds: subModelsUnderElement, on });
-                    }
-                    return EMPTY;
-                  }),
-                ),
-              ),
-            );
+            return fromWithRelease({ source: elementIds, releaseOnCount: 100 });
+          }),
+          mergeMap((elementId) => this.#props.baseIdsCache.getSubModelsUnderElement(elementId)),
+          mergeMap((subModelsUnderElement) => {
+            if (subModelsUnderElement.length > 0) {
+              return this.changeModelsVisibilityStatus({ modelIds: subModelsUnderElement, on });
+            }
+            return EMPTY;
           }),
         ),
       );

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -151,9 +151,8 @@ export class BaseVisibilityHelper implements Disposable {
           }
           // For visible models we need to check all categories.
           // getCategoriesVisibilityStatus already checks subModels, no need to do that
-          // Take top most element categories when always drawn exclusive mode is on, because only top most categories are used to get always/never drawn elements.
-          // This means that non top most categories should not affect visibility in any way until https://github.com/iTwin/viewer-components-react/issues/1100 is resolved.
-          return this.#props.baseIdsCache.getCategories({ modelId, includeOnlyIfCategoryOfTopMostElement: this.#props.viewport.isAlwaysDrawnExclusive }).pipe(
+          // Only need to take top-most categories, they take into account all descendants.
+          return this.#props.baseIdsCache.getCategories({ modelId, includeOnlyIfCategoryOfTopMostElement: true }).pipe(
             mergeMap((categories) => this.getCategoriesVisibilityStatus({ modelId, categoryIds: categories })),
             defaultIfEmpty(createVisibilityStatus("visible")),
           );
@@ -268,7 +267,6 @@ export class BaseVisibilityHelper implements Disposable {
         this.getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
           modelId,
           categoryId,
-          defaultStatus: this.getVisibleModelCategoryDirectVisibilityStatus({ modelId, categoryId }),
         })
       : of(createVisibilityStatus("hidden"));
 
@@ -285,8 +283,12 @@ export class BaseVisibilityHelper implements Disposable {
    * Determines visibility status by checking:
    * - Per model category visibility overrides;
    * - Category selector visibility in the viewport.
+   * - Always drawn exclusive flag.
    */
   public getVisibleModelCategoryDirectVisibilityStatus({ modelId, categoryId }: { categoryId: Id64String; modelId: Id64String }): NonPartialVisibilityStatus {
+    if (this.#props.viewport.isAlwaysDrawnExclusive) {
+      return createVisibilityStatus("hidden");
+    }
     const override = this.#props.viewport.getPerModelCategoryOverride({ modelId, categoryId });
     if (override === "show" || (override === "none" && this.#props.viewport.viewsCategory(categoryId))) {
       return createVisibilityStatus("visible");
@@ -355,9 +357,7 @@ export class BaseVisibilityHelper implements Disposable {
     if (!this.#props.viewport.viewsModel(modelId)) {
       return of(createVisibilityStatus("hidden"));
     }
-    const defaultStatus = this.#props.viewport.isAlwaysDrawnExclusive
-      ? createVisibilityStatus("hidden")
-      : this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId });
+    const defaultStatus = this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId });
     const oppositeSet = defaultStatus.state === "visible" ? this.#props.viewport.neverDrawn : this.#props.viewport.alwaysDrawn;
     if (!oppositeSet?.size) {
       return of(defaultStatus);
@@ -388,29 +388,63 @@ export class BaseVisibilityHelper implements Disposable {
     if (!this.#props.viewport.viewsModel(modelId)) {
       return of(createVisibilityStatus("hidden"));
     }
-    return fromWithRelease({ source: elementIds, releaseOnCount: 500 }).pipe(
+    const descendantsCounts = fromWithRelease({ source: elementIds, releaseOnCount: 500 }).pipe(
       mergeMap((elementId) => this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId })),
+    );
+    return this.getVisibilityFromGroupedDescendants({
+      modelId,
+      descendantsCounts,
+      categoryIds: categoryOfTopMostParentElement,
+      parentElementIdsPath,
+    });
+  }
+
+  /**
+   * Gets visibility status of a category based on viewport's always/never drawn elements.
+   * Groups descendant elements by their actual categories, checks which categories are
+   * visible/hidden, then queries always/never drawn per group to compute overall status.
+   */
+  private getCategoryVisibilityFromAlwaysAndNeverDrawnElements(props: { modelId: Id64String; categoryId: Id64String }): Observable<VisibilityStatus> {
+    const descendantsCounts = this.#props.baseIdsCache.getDescendantsCounts({ modelId: props.modelId, categoryId: props.categoryId });
+    return this.getVisibilityFromGroupedDescendants({
+      modelId: props.modelId,
+      descendantsCounts,
+      categoryIds: props.categoryId,
+    });
+  }
+
+  /**
+   * Shared logic for computing visibility from per-category descendant counts.
+   * 1. Accumulates counts grouped into visible/hidden categories;
+   * 2. For visible categories, retrieves never-drawn descendants; for hidden, retrieves always-drawn;
+   * 3. Computes visibility status per group and emits each.
+   */
+  private getVisibilityFromGroupedDescendants(props: {
+    modelId: Id64String;
+    descendantsCounts: Observable<Array<{ categoryId: CategoryId; count: number }>>;
+    categoryIds: Id64Arg;
+    parentElementIdsPath?: Array<Id64Arg>;
+  }): Observable<VisibilityStatus> {
+    const { modelId, categoryIds, parentElementIdsPath } = props;
+    return props.descendantsCounts.pipe(
       reduce(
         (acc, descendantsCounts) => {
-          for (const categoryWithCount of descendantsCounts) {
-            if (acc.visibleCategories.has(categoryWithCount.categoryId)) {
-              acc.visibleCategoriesDescendantsCount += categoryWithCount.count;
+          for (const { categoryId, count } of descendantsCounts) {
+            if (acc.visibleCategories.has(categoryId)) {
+              acc.visibleCategoriesDescendantsCount += count;
               continue;
             }
-            if (acc.hiddenCategories.has(categoryWithCount.categoryId)) {
-              acc.hiddenCategoriesDescendantsCount += categoryWithCount.count;
+            if (acc.hiddenCategories.has(categoryId)) {
+              acc.hiddenCategoriesDescendantsCount += count;
               continue;
             }
-            const isCategoryVisible = this.#props.viewport.isAlwaysDrawnExclusive
-              ? false
-              : this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId: categoryWithCount.categoryId, modelId }).state === "visible";
-            if (isCategoryVisible) {
-              acc.visibleCategoriesDescendantsCount += categoryWithCount.count;
-              acc.visibleCategories.add(categoryWithCount.categoryId);
-              continue;
+            if (this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId }).state === "visible") {
+              acc.visibleCategoriesDescendantsCount += count;
+              acc.visibleCategories.add(categoryId);
+            } else {
+              acc.hiddenCategoriesDescendantsCount += count;
+              acc.hiddenCategories.add(categoryId);
             }
-            acc.hiddenCategoriesDescendantsCount += categoryWithCount.count;
-            acc.hiddenCategories.add(categoryWithCount.categoryId);
           }
           return acc;
         },
@@ -428,7 +462,7 @@ export class BaseVisibilityHelper implements Disposable {
                 .getAlwaysOrNeverDrawnElements({
                   modelId,
                   parentElementIdsPath,
-                  categoryIds: categoryOfTopMostParentElement,
+                  categoryIds,
                   setType: "never",
                   childCategoryIds: visibleCategories,
                 })
@@ -447,7 +481,7 @@ export class BaseVisibilityHelper implements Disposable {
                 .getAlwaysOrNeverDrawnElements({
                   modelId,
                   parentElementIdsPath,
-                  categoryIds: categoryOfTopMostParentElement,
+                  categoryIds,
                   setType: "always",
                   childCategoryIds: hiddenCategories,
                 })
@@ -463,51 +497,6 @@ export class BaseVisibilityHelper implements Disposable {
             : EMPTY,
         );
       }),
-    );
-  }
-
-  /** Gets visibility status of a category based on viewport's always/never drawn elements. */
-  private getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
-    modelId,
-    ...props
-  }: {
-    defaultStatus: NonPartialVisibilityStatus;
-    modelId: Id64String;
-    categoryId: Id64String;
-  }): Observable<VisibilityStatus> {
-    const defaultStatus = this.#props.viewport.isAlwaysDrawnExclusive ? createVisibilityStatus("hidden") : props.defaultStatus;
-    const { oppositeSet, setType } =
-      defaultStatus.state === "visible"
-        ? { oppositeSet: this.#props.viewport.neverDrawn, setType: "never" as const }
-        : { oppositeSet: this.#props.viewport.alwaysDrawn, setType: "always" as const };
-    if (!oppositeSet?.size) {
-      return of(defaultStatus);
-    }
-
-    const { categoryId } = props;
-    return forkJoin({
-      totalCount: this.#props.baseIdsCache.getElementsCount({ modelId, categoryId }),
-      relatedElementsInOppositeSet: this.#alwaysAndNeverDrawnElements.getAlwaysOrNeverDrawnElements({
-        modelId,
-        categoryIds: categoryId,
-        setType,
-      }),
-    }).pipe(
-      // There is a known bug:
-      // Categories that don't have root elements will make visibility result incorrect
-      // E.g.:
-      // - CategoryA
-      //  - ElementA (CategoryA is visible)
-      //    - ChildElementB (CategoryB is hidden) ChildElementB is in always drawn list
-      // Result will be "partial" because CategoryB will return hidden visibility, even though all elements are visible
-      // TODO fix with: https://github.com/iTwin/viewer-components-react/issues/1100
-      map((state) =>
-        getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl({
-          defaultStatus,
-          totalCount: state.totalCount,
-          numberOfElementsInOppositeSet: state.relatedElementsInOppositeSet.size,
-        }),
-      ),
     );
   }
 
@@ -535,7 +524,9 @@ export class BaseVisibilityHelper implements Disposable {
 
       this.#props.viewport.changeModelDisplay({ modelIds, display: true });
       return from(Id64.iterable(modelIds)).pipe(
-        mergeMap((modelId) => forkJoin({ categoryIds: this.#props.baseIdsCache.getCategories({ modelId }), modelId: of(modelId) })),
+        mergeMap((modelId) =>
+          forkJoin({ categoryIds: this.#props.baseIdsCache.getCategories({ modelId, includeOnlyIfCategoryOfTopMostElement: true }), modelId: of(modelId) }),
+        ),
         mergeMap(({ categoryIds, modelId }) => this.changeCategoriesVisibilityStatus({ categoryIds, modelId, on })),
       );
     });
@@ -666,6 +657,32 @@ export class BaseVisibilityHelper implements Disposable {
         mergeMap(([modelId, modelCategories]) => this.clearAlwaysAndNeverDrawnElements({ categoryIds: modelCategories, modelId })),
       );
 
+      const changeChildElementsInDifferentCategoriesObs = categoryModelsObs.pipe(
+        mergeMap(([modelId, modelCategories]) =>
+          // Descendants need to be changed only when model is visible, if it's hidden, any changes to A/N drawn won't have any effect.
+          this.#props.viewport.viewsModel(modelId)
+            ? this.getDescendantsToChange({ modelId, categoryIds: modelCategories, on, parentElementIdsPath: [] })
+            : EMPTY,
+        ),
+        reduce(
+          (acc, { matchingDesiredState, notMatchingDesiredState }) => {
+            acc.matchingDesiredState.push(...matchingDesiredState);
+            acc.notMatchingDesiredState.push(...notMatchingDesiredState);
+            return acc;
+          },
+          { matchingDesiredState: Array<ElementId>(), notMatchingDesiredState: Array<ElementId>() },
+        ),
+        mergeMap(({ matchingDesiredState, notMatchingDesiredState }) =>
+          matchingDesiredState.length > 0 || notMatchingDesiredState.length > 0
+            ? this.queueElementsVisibilityChange({
+                elementsMatchingDesiredState: matchingDesiredState.length > 0 ? matchingDesiredState : undefined,
+                elementsNotMatchingDesiredState: notMatchingDesiredState.length > 0 ? notMatchingDesiredState : undefined,
+                on,
+              })
+            : EMPTY,
+        ),
+      );
+
       const changeSubCategoriesObs = on
         ? fromWithRelease({ source: categoryIds, releaseOnCount: 200 }).pipe(
             mergeMap((categoryId) => this.#props.baseIdsCache.getSubCategories({ categoryId })),
@@ -679,7 +696,16 @@ export class BaseVisibilityHelper implements Disposable {
           )
         : EMPTY;
 
-      return merge(changeSubModelsObs, changeModelsObs, removeCategoriesOverridesObs, changeAlwaysAndNeverDrawnElementsObs, changeSubCategoriesObs);
+      return merge(
+        changeSubModelsObs,
+        changeModelsObs.pipe(
+          defaultIfEmpty(undefined),
+          mergeMap(() => changeChildElementsInDifferentCategoriesObs),
+        ),
+        removeCategoriesOverridesObs,
+        changeAlwaysAndNeverDrawnElementsObs,
+        changeSubCategoriesObs,
+      );
     });
 
     return this.#props.overrideHandler
@@ -712,8 +738,10 @@ export class BaseVisibilityHelper implements Disposable {
    * Changes categories under specific model visibility status.
    *
    * - Turns on model without affecting it's elements or categories
-   * - sets per-model category overrides for specified categories.
-   * - Clears always and never drawn elements related to those categories
+   * - Sets per-model category overrides for specified categories.
+   * - Clears always and never drawn elements in the target category
+   * - For descendant elements in other categories: clears A/N drawn if their category matches
+   *   desired state, or adds them to A/N drawn if it doesn't.
    * - Changes sub-models visibility status that are related to specified categories in the model.
    */
   private changeCategoriesUnderModelVisibilityStatus({
@@ -740,6 +768,19 @@ export class BaseVisibilityHelper implements Disposable {
       categoryIds,
       modelId,
     });
+
+    const changeChildElementsInDifferentCategoriesObs = this.getDescendantsToChange({ modelId, categoryIds, on, parentElementIdsPath: [] }).pipe(
+      mergeMap(({ matchingDesiredState, notMatchingDesiredState }) =>
+        matchingDesiredState.size > 0 || notMatchingDesiredState.length > 0
+          ? this.queueElementsVisibilityChange({
+              elementsMatchingDesiredState: matchingDesiredState.size > 0 ? matchingDesiredState : undefined,
+              elementsNotMatchingDesiredState: notMatchingDesiredState.length > 0 ? notMatchingDesiredState : undefined,
+              on,
+            })
+          : EMPTY,
+      ),
+    );
+
     const changeSubModelsObs = this.#props.baseIdsCache.hasSubModels({ modelId }).pipe(
       mergeMap((hasSubModels) => {
         if (!hasSubModels) {
@@ -751,7 +792,15 @@ export class BaseVisibilityHelper implements Disposable {
         );
       }),
     );
-    return merge(changeModelsVisibilityStatusObs, changeAlwaysAndNeverDrawnElementsObs, changeSubModelsObs);
+    return merge(
+      changeModelsVisibilityStatusObs.pipe(
+        defaultIfEmpty(undefined),
+        // Descendants need to be changed only when model is visible, if it's hidden, any changes to A/N drawn won't have any effect.
+        mergeMap(() => (this.#props.viewport.viewsModel(modelId) ? changeChildElementsInDifferentCategoriesObs : EMPTY)),
+      ),
+      changeAlwaysAndNeverDrawnElementsObs,
+      changeSubModelsObs,
+    );
   }
 
   /**
@@ -777,11 +826,10 @@ export class BaseVisibilityHelper implements Disposable {
       if (ignoreDescendants) {
         return prepareModelObs.pipe(
           mergeMap(() => {
-            const areElementsDisplayedByDefault =
-              this.#props.viewport.isAlwaysDrawnExclusive || !this.#props.viewport.viewsModel(modelId)
-                ? false
-                : this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId }).state === "visible";
-            const elementsMatchDesiredState = areElementsDisplayedByDefault === on;
+            if (!this.#props.viewport.viewsModel(modelId)) {
+              return EMPTY;
+            }
+            const elementsMatchDesiredState = this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId }).state === (on ? "visible" : "hidden");
             return this.queueElementsVisibilityChange({
               elementsMatchingDesiredState: elementsMatchDesiredState ? elementIds : undefined,
               elementsNotMatchingDesiredState: elementsMatchDesiredState ? undefined : elementIds,
@@ -794,11 +842,10 @@ export class BaseVisibilityHelper implements Disposable {
       return merge(
         prepareModelObs.pipe(
           mergeMap(() => {
-            const areElementsDisplayedByDefault =
-              this.#props.viewport.isAlwaysDrawnExclusive || !this.#props.viewport.viewsModel(modelId)
-                ? false
-                : this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId }).state === "visible";
-            const elementsMatchDesiredState = areElementsDisplayedByDefault === on;
+            if (!this.#props.viewport.viewsModel(modelId)) {
+              return EMPTY;
+            }
+            const elementsMatchDesiredState = this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId, modelId }).state === (on ? "visible" : "hidden");
             return this.getDescendantsToChange({
               elementIds,
               modelId,
@@ -854,27 +901,62 @@ export class BaseVisibilityHelper implements Disposable {
   }
 
   /**
-   * Changes descendant visibility per category.
-   * For each child category:
-   * - If category default matches desired state → clear those elements from always/never drawn sets
-   * - If category default does NOT match → fetch child element IDs and add to appropriate set
+   * Gets descendant elements grouped by whether their category matches the desired visibility state.
+   * Can operate from either element scope (parentElementIds) or category scope (categoryIds).
+   *
+   * For each descendant category:
+   * - If category matches desired state: retrieves those elements from opposite set (to be removed from it).
+   * - If category does NOT match desired state: fetches child element IDs (to be added to the appropriate set)
    */
-  private getDescendantsToChange(props: {
-    elementIds: Id64Arg;
-    modelId: Id64String;
-    on: boolean;
-    categoryOfTopMostParentElement: CategoryId;
-    parentElementIdsPath: Array<Id64Arg>;
-  }): Observable<{ matchingDesiredState: Id64Set; notMatchingDesiredState: Id64Array }> {
-    const { elementIds, modelId, on, categoryOfTopMostParentElement, parentElementIdsPath } = props;
-    return from(Id64.iterable(elementIds)).pipe(
-      mergeMap((elementId) =>
-        forkJoin({ elementId: of(elementId), descendantsCounts: this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId }) }),
-      ),
+  private getDescendantsToChange(
+    props: {
+      modelId: Id64String;
+      on: boolean;
+
+      parentElementIdsPath: Array<Id64Arg>;
+    } & ({ elementIds: Id64Arg; categoryOfTopMostParentElement: CategoryId } | { categoryIds: Id64Arg }),
+  ): Observable<{ matchingDesiredState: Id64Set; notMatchingDesiredState: Id64Array }> {
+    const { modelId, on, parentElementIdsPath } = props;
+    const categoryIdsSet = "categoryIds" in props ? Id64.toIdSet(props.categoryIds) : new Set<CategoryId>();
+    const {
+      source,
+      isSourceElement,
+      ignoreChildCategory,
+    }: {
+      source: Observable<{ sourceId: ElementId | CategoryId; descendantsCounts: Array<{ categoryId: CategoryId; count: number }> }>;
+      isSourceElement: boolean;
+      ignoreChildCategory: (childCategoryId: CategoryId) => boolean;
+    } =
+      "elementIds" in props
+        ? {
+            source: from(Id64.iterable(props.elementIds)).pipe(
+              mergeMap((elementId) =>
+                forkJoin({
+                  sourceId: of(elementId),
+                  descendantsCounts: this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId }),
+                }),
+              ),
+            ),
+            isSourceElement: true,
+            ignoreChildCategory: () => false,
+          }
+        : {
+            source: fromWithRelease({ source: props.categoryIds, releaseOnCount: 200 }).pipe(
+              mergeMap((categoryId) =>
+                forkJoin({ sourceId: of(categoryId), descendantsCounts: this.#props.baseIdsCache.getDescendantsCounts({ modelId, categoryId }) }),
+              ),
+            ),
+            isSourceElement: false,
+            ignoreChildCategory: (childCategoryId: CategoryId) => categoryIdsSet.has(childCategoryId),
+          };
+    return source.pipe(
       reduce(
-        (acc, { elementId, descendantsCounts }) => {
+        (acc, { sourceId, descendantsCounts }) => {
           const nonMatchingCategoriesForElement = new Array<CategoryId>();
           for (const { categoryId: childCategoryId } of descendantsCounts) {
+            if (ignoreChildCategory(childCategoryId)) {
+              continue;
+            }
             if (acc.matchingCategories.has(childCategoryId)) {
               continue;
             }
@@ -882,11 +964,8 @@ export class BaseVisibilityHelper implements Disposable {
               nonMatchingCategoriesForElement.push(childCategoryId);
               continue;
             }
-            const isCategoryVisible =
-              this.#props.viewport.isAlwaysDrawnExclusive || !this.#props.viewport.viewsModel(modelId)
-                ? false
-                : this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId: childCategoryId, modelId }).state === "visible";
-            const categoryMatchesDesiredState = isCategoryVisible === on;
+            const categoryMatchesDesiredState =
+              this.getVisibleModelCategoryDirectVisibilityStatus({ categoryId: childCategoryId, modelId }).state === (on ? "visible" : "hidden");
             if (categoryMatchesDesiredState) {
               acc.matchingCategories.add(childCategoryId);
             } else {
@@ -895,34 +974,34 @@ export class BaseVisibilityHelper implements Disposable {
             }
           }
           if (nonMatchingCategoriesForElement.length > 0) {
-            acc.elementsWithNonMatchingCategories.push({ elementId, categoryIds: nonMatchingCategoriesForElement });
+            acc.sourceWithNonMatchingCategories.push({ sourceId, categoryIds: nonMatchingCategoriesForElement });
           }
           return acc;
         },
         {
           matchingCategories: new Set<CategoryId>(),
           nonMatchingCategories: new Set<CategoryId>(),
-          elementsWithNonMatchingCategories: new Array<{ elementId: Id64String; categoryIds: Id64Array }>(),
+          sourceWithNonMatchingCategories: new Array<{ sourceId: Id64String; categoryIds: Id64Array }>(),
         },
       ),
-      mergeMap(({ matchingCategories, elementsWithNonMatchingCategories }) => {
+      mergeMap(({ matchingCategories, sourceWithNonMatchingCategories }) => {
         return forkJoin({
           matchingDesiredState:
             matchingCategories.size > 0
               ? this.#alwaysAndNeverDrawnElements.getAlwaysOrNeverDrawnElements({
                   modelId,
                   parentElementIdsPath,
-                  categoryIds: categoryOfTopMostParentElement,
+                  categoryIds: "categoryIds" in props ? props.categoryIds : props.categoryOfTopMostParentElement,
                   setType: on ? "never" : "always",
                   childCategoryIds: matchingCategories,
                 })
               : of(new Set<Id64String>()),
-          notMatchingDesiredState: from(elementsWithNonMatchingCategories).pipe(
-            mergeMap(({ elementId, categoryIds }) =>
+          notMatchingDesiredState: from(sourceWithNonMatchingCategories).pipe(
+            mergeMap(({ sourceId, categoryIds }) =>
               this.#props.baseIdsCache.getChildElements({
-                parentElementId: elementId,
                 modelId,
                 childCategoryIds: categoryIds,
+                ...(isSourceElement ? { parentElementId: sourceId } : { categoryId: sourceId }),
               }),
             ),
             toArray(),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -21,11 +21,13 @@ import {
   startWith,
   Subject,
   take,
+  takeLast,
   takeUntil,
   tap,
   toArray,
 } from "rxjs";
 import { assert, Id64 } from "@itwin/core-bentley";
+import { subscribeAll } from "../Rxjs.js";
 import { createVisibilityStatus } from "../Tooltip.js";
 import { countInSet, fromWithRelease, releaseMainThreadOnItemsCount, setDifference } from "../Utils.js";
 import { changeElementStateNoChildrenOperator, getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl, mergeVisibilityStatuses } from "../VisibilityUtils.js";
@@ -310,22 +312,26 @@ export class BaseVisibilityHelper implements Disposable {
       elementIds: Id64Arg;
       modelId: Id64String;
       categoryId: Id64String;
-    } & ({ computeOnlyOwnStatus: true } | { computeOnlyOwnStatus?: false; categoryOfTopMostParentElement: CategoryId; parentElementsIdsPath: Array<Id64Arg> }),
+    } & (
+      | { computeOnlyOwnStatus: true }
+      | { computeOnlyOwnStatus?: (elementId: Id64String) => boolean; categoryOfTopMostParentElement: CategoryId; parentElementsIdsPath: Array<Id64Arg> }
+    ),
   ): Observable<VisibilityStatus> {
     const result = defer(() => {
       const { elementIds, modelId, categoryId, computeOnlyOwnStatus } = props;
       // Compute element's own visibility
       const elementsOwnStatus = this.getElementsOwnVisibilityStatus({ elementIds, modelId, categoryId });
-      if (computeOnlyOwnStatus) {
+      if (computeOnlyOwnStatus === true) {
         return elementsOwnStatus;
       }
+
       const subModelsVisibilityStatus = this.#props.baseIdsCache.hasSubModels({ modelId }).pipe(
         mergeMap((hasSubModels) => {
           if (!hasSubModels) {
             return EMPTY;
           }
           return fromWithRelease({ source: elementIds, releaseOnCount: 100 }).pipe(
-            mergeMap((elementId) => this.#props.baseIdsCache.getSubModelsUnderElement(elementId)),
+            mergeMap((elementId) => (computeOnlyOwnStatus?.(elementId) ? EMPTY : this.#props.baseIdsCache.getSubModelsUnderElement(elementId))),
             mergeMap((subModelsUnderElement) => this.getModelsVisibilityStatus({ modelIds: subModelsUnderElement })),
           );
         }),
@@ -337,6 +343,7 @@ export class BaseVisibilityHelper implements Disposable {
         categoryOfTopMostParentElement: props.categoryOfTopMostParentElement,
         // For descendants path includes elementIds
         parentElementIdsPath: [...props.parentElementsIdsPath, elementIds],
+        computeOnlyOwnStatus,
       });
 
       return merge(elementsOwnStatus, descendantsVisibilityStatus, subModelsVisibilityStatus).pipe(mergeVisibilityStatuses());
@@ -383,13 +390,16 @@ export class BaseVisibilityHelper implements Disposable {
     modelId: Id64String;
     categoryOfTopMostParentElement: CategoryId;
     parentElementIdsPath: Array<Id64Arg>;
+    computeOnlyOwnStatus?: (elementId: Id64String) => boolean;
   }): Observable<VisibilityStatus> {
     const { elementIds, modelId, categoryOfTopMostParentElement, parentElementIdsPath } = props;
     if (!this.#props.viewport.viewsModel(modelId)) {
       return of(createVisibilityStatus("hidden"));
     }
     const descendantsCounts = fromWithRelease({ source: elementIds, releaseOnCount: 500 }).pipe(
-      mergeMap((elementId) => this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId })),
+      mergeMap((elementId) =>
+        props.computeOnlyOwnStatus?.(elementId) ? EMPTY : this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId }),
+      ),
     );
     return this.getVisibilityFromGroupedDescendants({
       modelId,
@@ -405,12 +415,22 @@ export class BaseVisibilityHelper implements Disposable {
    * visible/hidden, then queries always/never drawn per group to compute overall status.
    */
   private getCategoryVisibilityFromAlwaysAndNeverDrawnElements(props: { modelId: Id64String; categoryId: Id64String }): Observable<VisibilityStatus> {
-    const descendantsCounts = this.#props.baseIdsCache.getDescendantsCounts({ modelId: props.modelId, categoryId: props.categoryId });
-    return this.getVisibilityFromGroupedDescendants({
-      modelId: props.modelId,
-      descendantsCounts,
-      categoryIds: props.categoryId,
-    });
+    return this.#props.baseIdsCache.categoryHasIndirectChildren(props.categoryId).pipe(
+      mergeMap((hasIndirectChildren) => {
+        if (!hasIndirectChildren) {
+          const categoryVisibility = this.getVisibleModelCategoryDirectVisibilityStatus({ modelId: props.modelId, categoryId: props.categoryId });
+          const oppositeSet = categoryVisibility.state === "visible" ? this.#props.viewport.neverDrawn : this.#props.viewport.alwaysDrawn;
+          if (!oppositeSet?.size) {
+            return of(categoryVisibility);
+          }
+        }
+        return this.getVisibilityFromGroupedDescendants({
+          modelId: props.modelId,
+          descendantsCounts: this.#props.baseIdsCache.getDescendantsCounts({ modelId: props.modelId, categoryId: props.categoryId }),
+          categoryIds: props.categoryId,
+        });
+      }),
+    );
   }
 
   /**
@@ -700,6 +720,7 @@ export class BaseVisibilityHelper implements Disposable {
         changeSubModelsObs,
         changeModelsObs.pipe(
           defaultIfEmpty(undefined),
+          takeLast(1),
           mergeMap(() => changeChildElementsInDifferentCategoriesObs),
         ),
         removeCategoriesOverridesObs,
@@ -770,15 +791,15 @@ export class BaseVisibilityHelper implements Disposable {
     });
 
     const changeChildElementsInDifferentCategoriesObs = this.getDescendantsToChange({ modelId, categoryIds, on, parentElementIdsPath: [] }).pipe(
-      mergeMap(({ matchingDesiredState, notMatchingDesiredState }) =>
-        matchingDesiredState.size > 0 || notMatchingDesiredState.length > 0
+      mergeMap(({ matchingDesiredState, notMatchingDesiredState }) => {
+        return matchingDesiredState.size > 0 || notMatchingDesiredState.length > 0
           ? this.queueElementsVisibilityChange({
               elementsMatchingDesiredState: matchingDesiredState.size > 0 ? matchingDesiredState : undefined,
               elementsNotMatchingDesiredState: notMatchingDesiredState.length > 0 ? notMatchingDesiredState : undefined,
               on,
             })
-          : EMPTY,
-      ),
+          : EMPTY;
+      }),
     );
 
     const changeSubModelsObs = this.#props.baseIdsCache.hasSubModels({ modelId }).pipe(
@@ -795,6 +816,7 @@ export class BaseVisibilityHelper implements Disposable {
     return merge(
       changeModelsVisibilityStatusObs.pipe(
         defaultIfEmpty(undefined),
+        takeLast(1),
         // Descendants need to be changed only when model is visible, if it's hidden, any changes to A/N drawn won't have any effect.
         mergeMap(() => (this.#props.viewport.viewsModel(modelId) ? changeChildElementsInDifferentCategoriesObs : EMPTY)),
       ),
@@ -817,13 +839,16 @@ export class BaseVisibilityHelper implements Disposable {
       modelId: Id64String;
       categoryId: Id64String;
       on: boolean;
-    } & ({ ignoreDescendants: true } | { ignoreDescendants?: false; categoryOfTopMostParentElement: CategoryId; parentElementsIdsPath: Array<Id64Arg> }),
+    } & (
+      | { ignoreDescendants: true }
+      | { ignoreDescendants?: (elementId: Id64String) => boolean; categoryOfTopMostParentElement: CategoryId; parentElementsIdsPath: Array<Id64Arg> }
+    ),
   ): Observable<void> {
     const result = defer(() => {
       const { modelId, categoryId, elementIds, on, ignoreDescendants } = props;
       // Make sure model visibility is on if elements should be turned on
       const prepareModelObs = on && !this.#props.viewport.viewsModel(modelId) ? this.showModelWithoutAnyCategoriesOrElements({ modelId }) : of(undefined);
-      if (ignoreDescendants) {
+      if (ignoreDescendants === true) {
         return prepareModelObs.pipe(
           mergeMap(() => {
             if (!this.#props.viewport.viewsModel(modelId)) {
@@ -852,6 +877,7 @@ export class BaseVisibilityHelper implements Disposable {
               on,
               categoryOfTopMostParentElement: props.categoryOfTopMostParentElement,
               parentElementIdsPath: [...props.parentElementsIdsPath, elementIds],
+              ignoreDescendants,
             }).pipe(
               mergeMap(({ matchingDesiredState: descendantsMatching, notMatchingDesiredState: descendantsNotMatching }) => {
                 const elementsMatchingDesiredState = elementsMatchDesiredState
@@ -912,9 +938,11 @@ export class BaseVisibilityHelper implements Disposable {
     props: {
       modelId: Id64String;
       on: boolean;
-
       parentElementIdsPath: Array<Id64Arg>;
-    } & ({ elementIds: Id64Arg; categoryOfTopMostParentElement: CategoryId } | { categoryIds: Id64Arg }),
+    } & (
+      | { elementIds: Id64Arg; categoryOfTopMostParentElement: CategoryId; ignoreDescendants?: (elementId: Id64String) => boolean }
+      | { categoryIds: Id64Arg }
+    ),
   ): Observable<{ matchingDesiredState: Id64Set; notMatchingDesiredState: Id64Array }> {
     const { modelId, on, parentElementIdsPath } = props;
     const categoryIdsSet = "categoryIds" in props ? Id64.toIdSet(props.categoryIds) : new Set<CategoryId>();
@@ -923,35 +951,39 @@ export class BaseVisibilityHelper implements Disposable {
       isSourceElement,
       ignoreChildCategory,
     }: {
-      source: Observable<{ sourceId: ElementId | CategoryId; descendantsCounts: Array<{ categoryId: CategoryId; count: number }> }>;
+      source: Observable<{ sourceId: ElementId | CategoryId; result: Array<{ categoryId: CategoryId; count: number }> }>;
       isSourceElement: boolean;
       ignoreChildCategory: (childCategoryId: CategoryId) => boolean;
     } =
       "elementIds" in props
         ? {
-            source: from(Id64.iterable(props.elementIds)).pipe(
-              mergeMap((elementId) =>
-                forkJoin({
-                  sourceId: of(elementId),
-                  descendantsCounts: this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId }),
-                }),
-              ),
-            ),
+            source: subscribeAll({
+              ids: props.elementIds,
+              getObservable: (elementId) =>
+                props.ignoreDescendants?.(elementId) ? of([]) : this.#props.baseIdsCache.getDescendantsCounts({ parentElementId: elementId, modelId }),
+            }),
             isSourceElement: true,
             ignoreChildCategory: () => false,
           }
         : {
-            source: fromWithRelease({ source: props.categoryIds, releaseOnCount: 200 }).pipe(
-              mergeMap((categoryId) =>
-                forkJoin({ sourceId: of(categoryId), descendantsCounts: this.#props.baseIdsCache.getDescendantsCounts({ modelId, categoryId }) }),
-              ),
-            ),
+            source: subscribeAll({
+              ids: props.categoryIds,
+              getObservable: (categoryId) =>
+                this.#props.baseIdsCache.categoryHasIndirectChildren(categoryId).pipe(
+                  mergeMap((hasIndirectChildren) => {
+                    if (!hasIndirectChildren) {
+                      return of([]);
+                    }
+                    return this.#props.baseIdsCache.getDescendantsCounts({ modelId, categoryId });
+                  }),
+                ),
+            }),
             isSourceElement: false,
             ignoreChildCategory: (childCategoryId: CategoryId) => categoryIdsSet.has(childCategoryId),
           };
     return source.pipe(
       reduce(
-        (acc, { sourceId, descendantsCounts }) => {
+        (acc, { sourceId, result: descendantsCounts }) => {
           const nonMatchingCategoriesForElement = new Array<CategoryId>();
           for (const { categoryId: childCategoryId } of descendantsCounts) {
             if (ignoreChildCategory(childCategoryId)) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -415,9 +415,9 @@ export class BaseVisibilityHelper implements Disposable {
    * visible/hidden, then queries always/never drawn per group to compute overall status.
    */
   private getCategoryVisibilityFromAlwaysAndNeverDrawnElements(props: { modelId: Id64String; categoryId: Id64String }): Observable<VisibilityStatus> {
-    return this.#props.baseIdsCache.categoryHasIndirectChildren(props.categoryId).pipe(
-      mergeMap((hasIndirectChildren) => {
-        if (!hasIndirectChildren) {
+    return this.#props.baseIdsCache.categoryHasParentElements(props.categoryId).pipe(
+      mergeMap((hasParentElements) => {
+        if (!hasParentElements) {
           const categoryVisibility = this.getVisibleModelCategoryDirectVisibilityStatus({ modelId: props.modelId, categoryId: props.categoryId });
           const oppositeSet = categoryVisibility.state === "visible" ? this.#props.viewport.neverDrawn : this.#props.viewport.alwaysDrawn;
           if (!oppositeSet?.size) {
@@ -969,9 +969,9 @@ export class BaseVisibilityHelper implements Disposable {
             source: subscribeAll({
               ids: props.categoryIds,
               getObservable: (categoryId) =>
-                this.#props.baseIdsCache.categoryHasIndirectChildren(categoryId).pipe(
-                  mergeMap((hasIndirectChildren) => {
-                    if (!hasIndirectChildren) {
+                this.#props.baseIdsCache.categoryHasParentElements(categoryId).pipe(
+                  mergeMap((hasParentElements) => {
+                    if (!hasParentElements) {
                       return of([]);
                     }
                     return this.#props.baseIdsCache.getDescendantsCounts({ modelId, categoryId });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -20,7 +20,7 @@ import {
   takeUntil,
   toArray,
 } from "rxjs";
-import { Guid } from "@itwin/core-bentley";
+import { assert, Guid } from "@itwin/core-bentley";
 import { IModel } from "@itwin/core-common";
 import { createPredicateBasedHierarchyDefinition, NodeSelectClauseColumnNames, ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
@@ -215,6 +215,16 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   public postProcessNode: NodePostProcessor = async ({ node }) => {
     if (ProcessedHierarchyNode.isGroupingNode(node)) {
       const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
+      const childrenWhichAreParents = new Set(
+        node.children
+          .filter((child) => !!child.children)
+          .map((child) => {
+            assert(!ProcessedHierarchyNode.isGroupingNode(child), "Expected only non-grouping nodes as children");
+            return child.key.instanceKeys.map(({ id }) => id);
+          })
+          .flat(),
+      );
+
       return {
         ...node,
         label: this.#hierarchyConfig.elementClassGrouping === "enableWithCounts" ? `${node.label} (${node.children.length})` : node.label,
@@ -225,6 +235,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
           modelId: node.children[0].extendedData?.modelId,
           categoryOfTopMostParentElement: node.children[0].extendedData?.categoryOfTopMostParentElement,
           topMostParentElementId: node.children[0].extendedData?.topMostParentElementId,
+          childrenWhichAreParents,
           ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
           ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
           // `imageId` is assigned to instance nodes at query time, but grouping ones need to

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeNodeInternal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeNodeInternal.ts
@@ -7,7 +7,7 @@ import { ModelsTreeNode } from "../ModelsTreeNode.js";
 
 import type { Id64String } from "@itwin/core-bentley";
 import type { ClassGroupingNodeKey, GroupingHierarchyNode, HierarchyNode, InstancesNodeKey, NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
-import type { CategoryId } from "../../common/internal/Types.js";
+import type { CategoryId, ElementId } from "../../common/internal/Types.js";
 
 /**
  * Contains utility functions for working with Models Tree nodes.
@@ -42,6 +42,7 @@ export namespace ModelsTreeNodeInternal {
       categoryId: Id64String;
       categoryOfTopMostParentElement: CategoryId;
       topMostParentElementId?: Id64String;
+      childrenWhichAreParents: Set<ElementId>;
     };
   } => ModelsTreeNode.isElementClassGroupingNode(node);
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -174,6 +174,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
         parentKeys: node.parentKeys,
         categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
         topMostParentElementId: node.extendedData.topMostParentElementId,
+        childrenWhichAreParents: node.extendedData.childrenWhichAreParents,
       });
       return this.#props.overrideHandler.createVisibilityHandlerResult({
         overrideProps: { node },
@@ -209,6 +210,7 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
       categoryId: node.extendedData.categoryId,
       parentElementsIdsPath,
       categoryOfTopMostParentElement: node.extendedData.categoryOfTopMostParentElement,
+      computeOnlyOwnStatus: node.children ? undefined : true,
     });
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHelper.ts
@@ -69,8 +69,9 @@ export class ModelsTreeVisibilityHelper extends BaseVisibilityHelper {
     parentKeys: HierarchyNodeKey[];
     categoryOfTopMostParentElement: CategoryId;
     topMostParentElementId?: ElementId;
+    childrenWhichAreParents: Set<ElementId>;
   }): Observable<VisibilityStatus> {
-    const { modelId, categoryId, elementIds, parentKeys, categoryOfTopMostParentElement, topMostParentElementId } = props;
+    const { modelId, categoryId, elementIds, parentKeys, categoryOfTopMostParentElement, topMostParentElementId, childrenWhichAreParents } = props;
     const parentElementsIdsPath = topMostParentElementId
       ? getParentElementsIdsPath({
           parentInstanceKeys: parentKeys.filter((key) => HierarchyNodeKey.isInstances(key)).map((key) => key.instanceKeys),
@@ -83,6 +84,7 @@ export class ModelsTreeVisibilityHelper extends BaseVisibilityHelper {
       categoryId,
       parentElementsIdsPath,
       categoryOfTopMostParentElement,
+      computeOnlyOwnStatus: childrenWhichAreParents.size === 0 ? true : (elementId) => !childrenWhichAreParents.has(elementId),
     });
   }
 


### PR DESCRIPTION
Phases 3b and 3d. of https://github.com/iTwin/viewer-components-react/pull/1678.
In addition: changed model visibility to always use `includeOnlyIfCategoryOfTopMostElement: true` (previously only if `isAlwaysDrawnExclusive` mode), since top-most categories now correctly determine visibility of nested children in differentcategories.