### PR TITLE
Fix map layers select dropdown menu state to reset when Map Layers switch is toggled

### DIFF
--- a/change/@itwin-map-layers-450debab-e24a-42a0-9785-ce0c8157dbe7.json
+++ b/change/@itwin-map-layers-450debab-e24a-42a0-9785-ce0c8157dbe7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add key prop to Select component for responsive dropdown menu on disabled state change",
+  "packageName": "@itwin/map-layers",
+  "email": "wil.maier@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/map-layers/src/ui/widget/BasemapPanel.tsx
+++ b/packages/itwin/map-layers/src/ui/widget/BasemapPanel.tsx
@@ -408,6 +408,8 @@ export function BasemapPanel(props: BasemapPanelProps) {
           onChange={handleBaseMapSelection}
           size="small"
           disabled={props.disabled}
+          // Use key to reset internal state of Select when disabled changes, ensuring the dropdown menu is responsive.
+          key={String(props.disabled)}
         />
         {baseIsColor && (
           <Popover


### PR DESCRIPTION
Fixed map layers dropdown selection menu by adding key property to Select component to reset internal state when disabled changes, ensuring the dropdown menu is responsive.

### Steps to test:
- Enable Map layers toggle.
- Click on drop down to look for the available layers.
- Now switch Off the toggle.
- Press on disabled layers dropdown field.
- Re-enable the Map Layers toggle.
- Click on the drop down to look for available layers one more time.
- Check that the dropdown is working and that user can select a map layer from the dropdown.