### PR TITLE
[Tree widget]: add getOrCreate on `next`

### DIFF
--- a/packages/itwin/tree-widget/src/test/trees/TreeUtils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/TreeUtils.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BeEvent, Id64 } from "@itwin/core-bentley";
+import { getOrCreate } from "../../tree-widget-react/components/trees/common/internal/Utils.js";
 
 import type { Id64Arg, Id64String } from "@itwin/core-bentley";
 import type { NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
@@ -138,11 +139,7 @@ export function createTreeWidgetTestingViewport({
     },
     setPerModelCategoryOverride: (props) => {
       for (const modelId of Id64.iterable(props.modelIds)) {
-        let entry = perModelCategoryOverrides.get(modelId);
-        if (!entry) {
-          entry = new Map();
-          perModelCategoryOverrides.set(modelId, entry);
-        }
+        const entry = getOrCreate({ map: perModelCategoryOverrides, key: modelId, createFunc: () => new Map() });
         for (const categoryId of Id64.iterable(props.categoryIds)) {
           entry.set(categoryId, { override: props.override });
         }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -39,6 +39,7 @@ import {
   createIdsSelector,
   getClassesByView,
   getOptimalBatchSize,
+  getOrCreate,
   groupingNodeDataFromChildren,
   parseIdsSelectorResult,
   releaseMainThreadOnItemsCount,
@@ -162,15 +163,15 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
         }
       >();
       for (const child of node.children) {
-        let modelEntry = modelElementsMap.get(child.extendedData?.modelId);
-        if (!modelEntry) {
-          modelEntry = {
+        const modelEntry = getOrCreate({
+          map: modelElementsMap,
+          key: child.extendedData?.modelId,
+          createFunc: () => ({
             elementIds: new Set(),
             categoryOfTopMostParentElement: child.extendedData?.categoryOfTopMostParentElement,
             childrenWhichAreParents: new Set<ElementId>(),
-          };
-          modelElementsMap.set(child.extendedData?.modelId, modelEntry);
-        }
+          }),
+        });
         assert(CategoriesTreeNode.isElementNode(child));
         const addId = child.children
           ? (id: Id64String) => {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
@@ -8,7 +8,7 @@ import { Guid, Id64 } from "@itwin/core-bentley";
 import { BaseIdsCacheImpl } from "../../common/internal/caches/BaseIdsCache.js";
 import { CLASS_NAME_DefinitionContainer, CLASS_NAME_Model, CLASS_NAME_SubCategory } from "../../common/internal/ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../../common/internal/UseErrorState.js";
-import { fromWithRelease, getClassesByView } from "../../common/internal/Utils.js";
+import { fromWithRelease, getClassesByView, getOrCreate } from "../../common/internal/Utils.js";
 import { createGeometricElementInstanceKeyPaths } from "../CategoriesTreeDefinition.js";
 
 import type { Observable } from "rxjs";
@@ -262,11 +262,14 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     this.#modelsCategoriesInfo ??= this.queryCategories()
       .pipe(
         reduce((acc, queriedCategory) => {
-          let modelCategories = acc.get(queriedCategory.modelId);
-          if (modelCategories === undefined) {
-            modelCategories = { parentDefinitionContainerExists: queriedCategory.parentDefinitionContainerExists, childCategories: [] };
-            acc.set(queriedCategory.modelId, modelCategories);
-          }
+          const modelCategories = getOrCreate({
+            map: acc,
+            key: queriedCategory.modelId,
+            createFunc: () => ({
+              parentDefinitionContainerExists: queriedCategory.parentDefinitionContainerExists,
+              childCategories: [] as { id: string; subCategoryChildCount: number; hasElements: boolean }[],
+            }),
+          });
           modelCategories.childCategories.push({
             id: queriedCategory.id,
             subCategoryChildCount: queriedCategory.subCategoryChildCount,
@@ -463,11 +466,7 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
           ),
           reduce((acc, { id, subModels }) => {
             for (const subModelId of subModels) {
-              const entry = acc.get(subModelId);
-              if (!entry) {
-                acc.set(subModelId, new Set([id]));
-                continue;
-              }
+              const entry = getOrCreate({ map: acc, key: subModelId, createFunc: () => new Set<CategoryId>() });
               entry.add(id);
             }
             return acc;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/UseSearchPaths.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/UseSearchPaths.ts
@@ -156,7 +156,7 @@ async function getCategoriesFromPaths(
 
     if (identifier.className === CLASS_NAME_SubCategory) {
       assert(!!parent);
-      const entry = getOrCreate({ map: categories, key: parent.id, createFunc: () => [] as string[] });
+      const entry = getOrCreate({ map: categories, key: parent.id, createFunc: () => new Array<SubCategoryId>() });
       entry.push(identifier.id);
       return;
     }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/UseSearchPaths.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/UseSearchPaths.ts
@@ -8,7 +8,7 @@ import { firstValueFrom } from "rxjs";
 import { assert } from "@itwin/core-bentley";
 import { HierarchyNodeIdentifier, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import { CLASS_NAME_DefinitionContainer, CLASS_NAME_SubCategory } from "../../common/internal/ClassNameDefinitions.js";
-import { getClassesByView } from "../../common/internal/Utils.js";
+import { getClassesByView, getOrCreate } from "../../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../../common/TreeErrors.js";
 import { useTelemetryContext } from "../../common/UseTelemetryContext.js";
 import { CategoriesTreeDefinition } from "../CategoriesTreeDefinition.js";
@@ -156,11 +156,7 @@ async function getCategoriesFromPaths(
 
     if (identifier.className === CLASS_NAME_SubCategory) {
       assert(!!parent);
-      let entry = categories.get(parent.id);
-      if (entry === undefined) {
-        entry = [];
-        categories.set(parent.id, entry);
-      }
+      const entry = getOrCreate({ map: categories, key: parent.id, createFunc: () => [] as string[] });
       entry.push(identifier.id);
       return;
     }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/SearchResultsTree.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/SearchResultsTree.ts
@@ -6,6 +6,7 @@
 import { firstValueFrom } from "rxjs";
 import { assert } from "@itwin/core-bentley";
 import { CLASS_NAME_DefinitionContainer, CLASS_NAME_SubCategory } from "../../../common/internal/ClassNameDefinitions.js";
+import { getOrCreate } from "../../../common/internal/Utils.js";
 import { createSearchResultsTree, SearchResultsNodesHandler } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
 
 import type { Id64Set, Id64String } from "@itwin/core-bentley";
@@ -260,20 +261,14 @@ class CategoriesTreeSearchResultsNodesHandler extends SearchResultsNodesHandler<
         (searchTargets.modelIds ??= new Set()).add(node.id);
         return;
       case "subCategory":
-        const subCategories = (searchTargets.subCategories ??= new Map()).get(node.categoryId);
-        if (subCategories) {
-          subCategories.add(node.id);
-          return;
-        }
-        searchTargets.subCategories.set(node.categoryId, new Set([node.id]));
+        searchTargets.subCategories ??= new Map();
+        const subCategories = getOrCreate({ map: searchTargets.subCategories, key: node.categoryId, createFunc: () => new Set<string>() });
+        subCategories.add(node.id);
         return;
       case "category":
-        const categories = (searchTargets.categories ??= new Map()).get(node.modelId);
-        if (!categories) {
-          categories.add(node.id);
-          return;
-        }
-        searchTargets.categories.set(node.modelId, new Set([node.id]));
+        searchTargets.categories ??= new Map();
+        const categories = getOrCreate({ map: searchTargets.categories, key: node.modelId, createFunc: () => new Set<string>() });
+        categories.add(node.id);
         return;
       case "element":
         // Internal search target elements need to have path saved in some way.
@@ -287,12 +282,7 @@ class CategoriesTreeSearchResultsNodesHandler extends SearchResultsNodesHandler<
             topMostParentElementId = node.pathToNode[i].id;
           }
           const identifierAsString = this.convertSearchResultsNodeIdentifierToString(node.pathToNode[i]);
-          let identifierEntry = entry.get(identifierAsString);
-          // create a new entry for parent node if it does not exist
-          if (!identifierEntry) {
-            identifierEntry = { topMostParentElementId };
-            entry.set(identifierAsString, identifierEntry);
-          }
+          const identifierEntry = getOrCreate({ map: entry, key: identifierAsString, createFunc: () => ({ topMostParentElementId }) });
           // last entry in the path don't need to have children
           if (i < node.pathToNode.length - 1) {
             identifierEntry.children ??= new Map();
@@ -300,13 +290,14 @@ class CategoriesTreeSearchResultsNodesHandler extends SearchResultsNodesHandler<
             continue;
           }
 
-          const elements = (identifierEntry.modelCategoryElements ??= new Map()).get(modelCategoryKey);
           // Add elements who share the same path to the modelCategoryElements map
-          if (elements) {
-            elements.set(node.id, { isSearchTarget: node.isSearchTarget });
-          } else {
-            identifierEntry.modelCategoryElements.set(modelCategoryKey, new Map([[node.id, { isSearchTarget: node.isSearchTarget }]]));
-          }
+          identifierEntry.modelCategoryElements ??= new Map();
+          const elements = getOrCreate({
+            map: identifierEntry.modelCategoryElements,
+            key: modelCategoryKey,
+            createFunc: () => new Map<ElementId, { isSearchTarget: boolean }>(),
+          });
+          elements.set(node.id, { isSearchTarget: node.isSearchTarget });
         }
     }
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/SearchResultsTree.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/SearchResultsTree.ts
@@ -262,12 +262,12 @@ class CategoriesTreeSearchResultsNodesHandler extends SearchResultsNodesHandler<
         return;
       case "subCategory":
         searchTargets.subCategories ??= new Map();
-        const subCategories = getOrCreate({ map: searchTargets.subCategories, key: node.categoryId, createFunc: () => new Set<string>() });
+        const subCategories = getOrCreate({ map: searchTargets.subCategories, key: node.categoryId, createFunc: () => new Set<SubCategoryId>() });
         subCategories.add(node.id);
         return;
       case "category":
         searchTargets.categories ??= new Map();
-        const categories = getOrCreate({ map: searchTargets.categories, key: node.modelId, createFunc: () => new Set<string>() });
+        const categories = getOrCreate({ map: searchTargets.categories, key: node.modelId, createFunc: () => new Set<CategoryId>() });
         categories.add(node.id);
         return;
       case "element":

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -16,7 +16,7 @@ import {
   CLASS_NAME_SpatialCategory,
 } from "../../common/internal/ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../../common/internal/UseErrorState.js";
-import { fromWithRelease } from "../../common/internal/Utils.js";
+import { fromWithRelease, getOrCreate } from "../../common/internal/Utils.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString, Id64Arg, Id64Array, Id64String } from "@itwin/core-bentley";
@@ -176,19 +176,18 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
     this.#classificationInfos ??= this.queryClassifications().pipe(
       reduce((acc, { id, tableId, parentId, relatedCategories }) => {
         const tableOrParentId = tableId ?? parentId;
-        let parentInfo = acc.get(tableOrParentId);
-        if (!parentInfo) {
-          parentInfo = { childClassificationIds: [], relatedCategories: [], parentClassificationOrTableId: undefined };
-          acc.set(tableOrParentId, parentInfo);
-        }
+        const parentInfo = getOrCreate({
+          map: acc,
+          key: tableOrParentId,
+          createFunc: () => ({ childClassificationIds: [], relatedCategories: [], parentClassificationOrTableId: undefined }),
+        });
         parentInfo.childClassificationIds.push(id);
-        let classificationEntry = acc.get(id);
-        if (!classificationEntry) {
-          classificationEntry = { childClassificationIds: [], relatedCategories, parentClassificationOrTableId: tableOrParentId };
-          acc.set(id, classificationEntry);
-        } else {
-          classificationEntry.parentClassificationOrTableId = tableOrParentId;
-        }
+        const classificationEntry = getOrCreate({
+          map: acc,
+          key: id,
+          createFunc: () => ({ childClassificationIds: [], relatedCategories, parentClassificationOrTableId: tableOrParentId }),
+        });
+        classificationEntry.parentClassificationOrTableId = tableOrParentId;
         return acc;
       }, new Map<ClassificationId | ClassificationTableId, ClassificationInfo>()),
       shareReplay(),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/SearchResultsTree.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/SearchResultsTree.ts
@@ -6,6 +6,7 @@
 import { firstValueFrom } from "rxjs";
 import { assert } from "@itwin/core-bentley";
 import { CLASS_NAME_Classification, CLASS_NAME_ClassificationTable, CLASS_NAME_GeometricElement3d } from "../../../common/internal/ClassNameDefinitions.js";
+import { getOrCreate } from "../../../common/internal/Utils.js";
 import { createSearchResultsTree, SearchResultsNodesHandler } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
 
 import type { Id64Set, Id64String } from "@itwin/core-bentley";
@@ -235,12 +236,7 @@ class ClassificationsTreeSearchResultsNodesHandler extends SearchResultsNodesHan
         topMostParentElementId = node.pathToNode[i].id;
       }
       const identifierAsString = this.convertSearchResultsNodeIdentifierToString(node.pathToNode[i]);
-      let identifierEntry = entry.get(identifierAsString);
-      // create a new entry for parent node if it does not exist
-      if (!identifierEntry) {
-        identifierEntry = { topMostParentElementId };
-        entry.set(identifierAsString, identifierEntry);
-      }
+      const identifierEntry = getOrCreate({ map: entry, key: identifierAsString, createFunc: () => ({ topMostParentElementId }) });
       // last entry in the path don't need to have children
       if (i < node.pathToNode.length - 1) {
         identifierEntry.children ??= new Map();
@@ -248,16 +244,17 @@ class ClassificationsTreeSearchResultsNodesHandler extends SearchResultsNodesHan
         continue;
       }
 
-      const elements = (identifierEntry.modelCategoryElements ??= new Map()).get(modelCategoryKey);
-      // Add elements who share the same path to the modelCategoryElements map
-      if (elements) {
-        elements.set(node.id, { isSearchTarget: node.isSearchTarget });
-      } else {
-        identifierEntry.modelCategoryElements.set(modelCategoryKey, {
-          elementsMap: new Map([[node.id, { isSearchTarget: node.isSearchTarget }]]),
+      identifierEntry.modelCategoryElements ??= new Map();
+      const elements = getOrCreate({
+        key: modelCategoryKey,
+        map: identifierEntry.modelCategoryElements,
+        createFunc: () => ({
+          elementsMap: new Map<ElementId, { isSearchTarget: boolean }>(),
           categoryOfTopMostParentElement: node.categoryOfTopMostParentElement,
-        });
-      }
+        }),
+      });
+      // Add elements who share the same path to the modelCategoryElements map
+      elements.elementsMap.set(node.id, { isSearchTarget: node.isSearchTarget });
     }
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/BufferingViewport.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/BufferingViewport.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Id64 } from "@itwin/core-bentley";
+import { getOrCreate } from "./Utils.js";
 
 import type { BeEvent, Id64Arg, Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -157,11 +158,7 @@ export class BufferingViewport implements TreeWidgetViewport {
 
   public setPerModelCategoryOverride(props: { modelIds: Id64Arg; categoryIds: Id64Arg; override: PerModelCategoryOverride }): void {
     for (const modelId of Id64.iterable(props.modelIds)) {
-      let modelEntry = this.#changedPerModelCategoryOverrides.get(modelId);
-      if (!modelEntry) {
-        modelEntry = new Map();
-        this.#changedPerModelCategoryOverrides.set(modelId, modelEntry);
-      }
+      const modelEntry = getOrCreate({ map: this.#changedPerModelCategoryOverrides, key: modelId, createFunc: () => new Map() });
       for (const categoryId of Id64.iterable(props.categoryIds)) {
         modelEntry.set(categoryId, props.override);
       }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/UseHierarchyFiltering.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/UseHierarchyFiltering.tsx
@@ -14,6 +14,7 @@ import { Spinner } from "@stratakit/bricks";
 import { Delayed } from "../components/Delayed.js";
 import { useTranslation } from "../components/LocalizationContext.js";
 import { useTelemetryContext } from "../UseTelemetryContext.js";
+import { getOrCreate } from "./Utils.js";
 
 import type { Id64Array, Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -166,11 +167,7 @@ async function countInstanceKeys(iterator: AsyncIterableIterator<InstanceKey>) {
 async function collectInstanceKeys(iterator: AsyncIterableIterator<InstanceKey>) {
   const idsByClassName = new Map<Id64String, Id64Array>();
   for await (const { className, id } of iterator) {
-    let idSet = idsByClassName.get(className);
-    if (!idSet) {
-      idSet = [];
-      idsByClassName.set(className, idSet);
-    }
+    const idSet = getOrCreate({ map: idsByClassName, key: className, createFunc: () => new Array<Id64String>() });
     idSet.push(id);
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Utils.ts
@@ -265,9 +265,10 @@ export function getParentElementsIdsPath({
   return [];
 }
 
+/** @internal */
 export function getOrCreate<TKey, TValue>({ map, key, createFunc }: { map: Map<TKey, TValue>; key: TKey; createFunc: () => TValue }): TValue {
   let entry = map.get(key);
-  if (!entry) {
+  if (entry === undefined) {
     entry = createFunc();
     map.set(key, entry);
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/Utils.ts
@@ -97,11 +97,7 @@ export function parseIdsSelectorResult(selectorResult: any): Id64Array {
 
 /** @internal */
 export function pushToMap<TKey, TValue>(targetMap: Map<TKey, Set<TValue>>, key: TKey, value: TValue) {
-  let set = targetMap.get(key);
-  if (!set) {
-    set = new Set();
-    targetMap.set(key, set);
-  }
+  const set = getOrCreate({ map: targetMap, key, createFunc: () => new Set<TValue>() });
   set.add(value);
 }
 
@@ -267,4 +263,13 @@ export function getParentElementsIdsPath({
     }
   }
   return [];
+}
+
+export function getOrCreate<TKey, TValue>({ map, key, createFunc }: { map: Map<TKey, TValue>; key: TKey; createFunc: () => TValue }): TValue {
+  let entry = map.get(key);
+  if (!entry) {
+    entry = createFunc();
+    map.set(key, entry);
+  }
+  return entry;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ChildElementsCache.ts
@@ -5,6 +5,7 @@
 
 import { defer, EMPTY, from, map, mergeMap, of } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
+import { getOrCreate } from "../Utils.js";
 import { BatchingCache } from "./BatchingCache.js";
 
 import type { Observable } from "rxjs";
@@ -113,21 +114,9 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
   protected getQueryData(batch: ChildElementsRequest[]): Observable<WhereClause> {
     const groupedValues = new Map<ModelId, Map<ElementId | undefined, Map<CategoryId | undefined, Set<CategoryId>>>>();
     for (const { modelId, parentElementId, categoryId, childCategoryIds } of batch) {
-      let modelEntry = groupedValues.get(modelId);
-      if (!modelEntry) {
-        modelEntry = new Map();
-        groupedValues.set(modelId, modelEntry);
-      }
-      let parentEntry = modelEntry.get(parentElementId);
-      if (!parentEntry) {
-        parentEntry = new Map();
-        modelEntry.set(parentElementId, parentEntry);
-      }
-      let categoryEntry = parentEntry.get(categoryId);
-      if (!categoryEntry) {
-        categoryEntry = new Set();
-        parentEntry.set(categoryId, categoryEntry);
-      }
+      const modelEntry = getOrCreate({ map: groupedValues, key: modelId, createFunc: () => new Map() });
+      const parentEntry = getOrCreate({ map: modelEntry, key: parentElementId, createFunc: () => new Map() });
+      const categoryEntry = getOrCreate({ map: parentEntry, key: categoryId, createFunc: () => new Set<CategoryId>() });
       for (const childCategoryId of childCategoryIds) {
         categoryEntry.add(childCategoryId);
       }
@@ -253,47 +242,18 @@ export class ChildElementsCache extends BatchingCache<ChildElementsRequest, Id64
   protected insertRow(row: Row): void {
     const reqParent = row.reqParent ?? undefined;
     const reqCategory = row.reqCategory ?? undefined;
-    let modelEntry = this.#cachedValues.get(row.modelId);
-    if (!modelEntry) {
-      modelEntry = new Map();
-      this.#cachedValues.set(row.modelId, modelEntry);
-    }
-    let parentEntry = modelEntry.get(reqParent);
-    if (!parentEntry) {
-      parentEntry = new Map();
-      modelEntry.set(reqParent, parentEntry);
-    }
-    let categoryEntry = parentEntry.get(reqCategory);
-    if (!categoryEntry) {
-      categoryEntry = new Map();
-      parentEntry.set(reqCategory, categoryEntry);
-    }
-
-    let ids = categoryEntry.get(row.ownCategory);
-    if (!ids) {
-      ids = [];
-      categoryEntry.set(row.ownCategory, ids);
-    }
+    const modelEntry = getOrCreate({ map: this.#cachedValues, key: row.modelId, createFunc: () => new Map() });
+    const parentEntry = getOrCreate({ map: modelEntry, key: reqParent, createFunc: () => new Map() });
+    const categoryEntry = getOrCreate({ map: parentEntry, key: reqCategory, createFunc: () => new Map() });
+    const ids = getOrCreate({ map: categoryEntry, key: row.ownCategory, createFunc: () => new Array<Id64String>() });
     ids.push(row.id);
   }
 
   protected ensureDefaultCacheEntries(batch: ChildElementsRequest[]): void {
     for (const { modelId, categoryId, parentElementId, childCategoryIds } of batch) {
-      let modelEntry = this.#cachedValues.get(modelId);
-      if (!modelEntry) {
-        modelEntry = new Map();
-        this.#cachedValues.set(modelId, modelEntry);
-      }
-      let parentEntry = modelEntry.get(parentElementId);
-      if (!parentEntry) {
-        parentEntry = new Map();
-        modelEntry.set(parentElementId, parentEntry);
-      }
-      let categoryEntry = parentEntry.get(categoryId);
-      if (!categoryEntry) {
-        categoryEntry = new Map();
-        parentEntry.set(categoryId, categoryEntry);
-      }
+      const modelEntry = getOrCreate({ map: this.#cachedValues, key: modelId, createFunc: () => new Map() });
+      const parentEntry = getOrCreate({ map: modelEntry, key: parentElementId, createFunc: () => new Map() });
+      const categoryEntry = getOrCreate({ map: parentEntry, key: categoryId, createFunc: () => new Map() });
       for (const childCategoryId of childCategoryIds) {
         if (!categoryEntry.has(childCategoryId)) {
           categoryEntry.set(childCategoryId, []);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -5,6 +5,7 @@
 
 import { defer, EMPTY, from, map, merge, mergeMap } from "rxjs";
 import { Guid } from "@itwin/core-bentley";
+import { getOrCreate } from "../Utils.js";
 import { BatchingCache } from "./BatchingCache.js";
 
 import type { Observable } from "rxjs";
@@ -82,25 +83,13 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     const groupedElementValues = new Map<ModelId, Set<ElementId>>();
     for (const batchEntry of batch) {
       if (batchEntry.categoryId === undefined) {
-        let groupedElementsModelEntry = groupedElementValues.get(batchEntry.modelId);
-        if (!groupedElementsModelEntry) {
-          groupedElementsModelEntry = new Set();
-          groupedElementValues.set(batchEntry.modelId, groupedElementsModelEntry);
-        }
+        const groupedElementsModelEntry = getOrCreate({ map: groupedElementValues, key: batchEntry.modelId, createFunc: () => new Set<ElementId>() });
         groupedElementsModelEntry.add(batchEntry.parentElementId);
         continue;
       }
       const { modelId, parentElementId, categoryId } = batchEntry;
-      let modelEntry = groupedCategoryValues.get(modelId);
-      if (!modelEntry) {
-        modelEntry = new Map();
-        groupedCategoryValues.set(modelId, modelEntry);
-      }
-      let parentEntry = modelEntry.get(parentElementId);
-      if (!parentEntry) {
-        parentEntry = new Set();
-        modelEntry.set(parentElementId, parentEntry);
-      }
+      const modelEntry = getOrCreate({ map: groupedCategoryValues, key: modelId, createFunc: () => new Map<ElementId | undefined, Set<CategoryId>>() });
+      const parentEntry = getOrCreate({ map: modelEntry, key: parentElementId, createFunc: () => new Set<CategoryId>() });
       parentEntry.add(categoryId);
     }
     return merge(
@@ -196,36 +185,16 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
   protected insertRow(row: Row): void {
     const reqParent = row.reqParent ?? undefined;
     const reqCategory = row.reqCategory ?? undefined;
-    let modelEntry = this.#cachedValues.get(row.modelId);
-    if (!modelEntry) {
-      modelEntry = new Map();
-      this.#cachedValues.set(row.modelId, modelEntry);
-    }
-    let parentEntry = modelEntry.get(reqParent);
-    if (!parentEntry) {
-      parentEntry = new Map();
-      modelEntry.set(reqParent, parentEntry);
-    }
-    let categoryEntry = parentEntry.get(reqCategory);
-    if (!categoryEntry) {
-      categoryEntry = [];
-      parentEntry.set(reqCategory, categoryEntry);
-    }
+    const modelEntry = getOrCreate({ map: this.#cachedValues, key: row.modelId, createFunc: () => new Map() });
+    const parentEntry = getOrCreate({ map: modelEntry, key: reqParent, createFunc: () => new Map() });
+    const categoryEntry = getOrCreate({ map: parentEntry, key: reqCategory, createFunc: () => new Array<{ categoryId: CategoryId; count: number }>() });
     categoryEntry.push({ categoryId: row.ownCategory, count: row.cnt });
   }
 
   protected ensureDefaultCacheEntries(batch: DescendantsCountRequest[]): void {
     for (const { modelId, categoryId, parentElementId } of batch) {
-      let modelEntry = this.#cachedValues.get(modelId);
-      if (!modelEntry) {
-        modelEntry = new Map();
-        this.#cachedValues.set(modelId, modelEntry);
-      }
-      let parentEntry = modelEntry.get(parentElementId);
-      if (!parentEntry) {
-        parentEntry = new Map();
-        modelEntry.set(parentElementId, parentEntry);
-      }
+      const modelEntry = getOrCreate({ map: this.#cachedValues, key: modelId, createFunc: () => new Map() });
+      const parentEntry = getOrCreate({ map: modelEntry, key: parentElementId, createFunc: () => new Map() });
       if (!parentEntry.has(categoryId)) {
         parentEntry.set(categoryId, categoryId === undefined ? [] : [{ categoryId, count: 0 }]);
       }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
@@ -6,7 +6,7 @@
 import { defer, forkJoin, from, map, mergeMap, reduce, shareReplay } from "rxjs";
 import { CLASS_NAME_Model } from "../ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
-import { releaseMainThreadOnItemsCount } from "../Utils.js";
+import { getOrCreate, releaseMainThreadOnItemsCount } from "../Utils.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString, Id64Array, Id64Set, Id64String } from "@itwin/core-bentley";
@@ -83,11 +83,11 @@ export class ElementModelCategoriesCache {
       modelCategories: this.queryElementModelCategories().pipe(
         reduce(
           (acc, queriedCategory) => {
-            let modelEntry = acc.modelsCategoriesInfo.get(queriedCategory.modelId);
-            if (modelEntry === undefined) {
-              modelEntry = { categoriesOfTopMostElements: new Set(), allCategories: new Set() };
-              acc.modelsCategoriesInfo.set(queriedCategory.modelId, modelEntry);
-            }
+            const modelEntry = getOrCreate({
+              map: acc.modelsCategoriesInfo,
+              key: queriedCategory.modelId,
+              createFunc: () => ({ categoriesOfTopMostElements: new Set<string>(), allCategories: new Set<string>() }),
+            });
             modelEntry.allCategories.add(queriedCategory.categoryId);
             if (queriedCategory.isTopMostElementCategory) {
               modelEntry.categoriesOfTopMostElements.add(queriedCategory.categoryId);

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
@@ -6,6 +6,7 @@
 import { defer, map, mergeMap, reduce, shareReplay } from "rxjs";
 import { CLASS_NAME_Model } from "../ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { getOrCreate } from "../Utils.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
@@ -91,25 +92,13 @@ export class ModeledElementsCache {
     this.#modeledElementsInfo ??= this.queryModeledElements().pipe(
       reduce(
         (acc, { modelId, categoryId, modeledElementId, parentElements }) => {
-          let modelEntry = acc.modelWithCategoryModeledElements.get(modelId);
-          if (!modelEntry) {
-            modelEntry = new Map();
-            acc.modelWithCategoryModeledElements.set(modelId, modelEntry);
-          }
-          const categoryEntry = modelEntry.get(categoryId);
-          if (!categoryEntry) {
-            modelEntry.set(categoryId, new Set([modeledElementId]));
-          } else {
-            categoryEntry.add(modeledElementId);
-          }
+          const modelEntry = getOrCreate({ map: acc.modelWithCategoryModeledElements, key: modelId, createFunc: () => new Map<CategoryId, Set<ElementId>>() });
+          const categoryEntry = getOrCreate({ map: modelEntry, key: categoryId, createFunc: () => new Set<ElementId>() });
+          categoryEntry.add(modeledElementId);
           acc.allSubModels.add(modeledElementId);
           parentElements.forEach((parentElementId) => {
-            const entry = acc.childSubModels.get(parentElementId);
-            if (!entry) {
-              acc.childSubModels.set(parentElementId, new Set([modeledElementId]));
-            } else {
-              entry.add(modeledElementId);
-            }
+            const parentEntry = getOrCreate({ map: acc.childSubModels, key: parentElementId, createFunc: () => new Set<ElementId>() });
+            parentEntry.add(modeledElementId);
           });
           return acc;
         },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/SubCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/SubCategoriesCache.ts
@@ -7,6 +7,7 @@ import { defer, EMPTY, expand, map, reduce, shareReplay } from "rxjs";
 import { Guid } from "@itwin/core-bentley";
 import { CLASS_NAME_SubCategory } from "../ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
+import { getOrCreate } from "../Utils.js";
 
 import type { Observable } from "rxjs";
 import type { GuidString, Id64String } from "@itwin/core-bentley";
@@ -79,12 +80,8 @@ export class SubCategoriesCache {
         reduce(
           (acc, queriedSubCategory) => {
             acc.subCategoryCategories.set(queriedSubCategory.id, queriedSubCategory.parentId);
-            const entry = acc.categorySubCategories.get(queriedSubCategory.parentId);
-            if (entry) {
-              entry.push(queriedSubCategory.id);
-            } else {
-              acc.categorySubCategories.set(queriedSubCategory.parentId, [queriedSubCategory.id]);
-            }
+            const entry = getOrCreate({ map: acc.categorySubCategories, key: queriedSubCategory.parentId, createFunc: () => new Array<SubCategoryId>() });
+            entry.push(queriedSubCategory.id);
             return acc;
           },
           { subCategoryCategories: new Map<SubCategoryId, CategoryId>(), categorySubCategories: new Map<CategoryId, Array<SubCategoryId>>() },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -29,7 +29,7 @@ import {
 import { assert, Id64 } from "@itwin/core-bentley";
 import { subscribeAll } from "../Rxjs.js";
 import { createVisibilityStatus } from "../Tooltip.js";
-import { countInSet, fromWithRelease, releaseMainThreadOnItemsCount, setDifference } from "../Utils.js";
+import { countInSet, fromWithRelease, getOrCreate, releaseMainThreadOnItemsCount, setDifference } from "../Utils.js";
 import { changeElementStateNoChildrenOperator, getCategoryVisibilityFromAlwaysAndNeverDrawnElementsImpl, mergeVisibilityStatuses } from "../VisibilityUtils.js";
 
 import type { Observable, Subscription } from "rxjs";
@@ -628,11 +628,7 @@ export class BaseVisibilityHelper implements Disposable {
         mergeMap((categoryId) => forkJoin({ categoryId: of(categoryId), models: this.#props.baseIdsCache.getModels({ categoryId, subModels: "include" }) })),
         reduce((acc, { models, categoryId }) => {
           for (const modelId of Id64.iterable(models)) {
-            let entry = acc.get(modelId);
-            if (!entry) {
-              entry = new Set();
-              acc.set(modelId, entry);
-            }
+            const entry = getOrCreate({ map: acc, key: modelId, createFunc: () => new Set<CategoryId>() });
             entry.add(categoryId);
           }
           return acc;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
@@ -322,7 +322,8 @@ export class ModelsTreeIdsCache extends BaseIdsCacheImpl {
       mergeMap((id) => forkJoin({ id: of(id), subModels: this.getModels({ subModels: "only", categoryId: id, includeOnlyIfCategoryOfTopMostElement: true }) })),
       reduce((acc, { id, subModels }) => {
         for (const subModelId of subModels) {
-          getOrCreate({ map: acc, key: subModelId, createFunc: () => new Set<CategoryId>() }).add(id);
+          const entry = getOrCreate({ map: acc, key: subModelId, createFunc: () => new Set<CategoryId>() });
+          entry.add(id);
         }
         return acc;
       }, new Map<ModelId, Set<CategoryId>>()),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
@@ -14,7 +14,7 @@ import {
   CLASS_NAME_Subject,
 } from "../../common/internal/ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../../common/internal/UseErrorState.js";
-import { fromWithRelease, pushToMap } from "../../common/internal/Utils.js";
+import { fromWithRelease, getOrCreate, pushToMap } from "../../common/internal/Utils.js";
 import { createGeometricElementInstanceKeyPaths } from "../ModelsTreeDefinition.js";
 
 import type { Observable } from "rxjs";
@@ -304,17 +304,17 @@ export class ModelsTreeIdsCache extends BaseIdsCacheImpl {
   }
 
   public createUpToModelInstanceKeyPaths(modelId: Id64String): Observable<HierarchyNodeIdentifiersPath> {
-    let entry = this.#upToModelInstanceKeyPaths.get(modelId);
-    if (!entry) {
-      entry = this.getSubjectInfos().pipe(
-        mergeMap((subjectInfos) => subjectInfos.entries()),
-        filter(([_, subjectInfo]) => subjectInfo.childModelIds.has(modelId)),
-        mergeMap(([modelSubjectId]) => this.createSubjectInstanceKeysPath(modelSubjectId)),
-        shareReplay(),
-      );
-      this.#upToModelInstanceKeyPaths.set(modelId, entry);
-    }
-    return entry;
+    return getOrCreate({
+      map: this.#upToModelInstanceKeyPaths,
+      key: modelId,
+      createFunc: () =>
+        this.getSubjectInfos().pipe(
+          mergeMap((subjectInfos) => subjectInfos.entries()),
+          filter(([_, subjectInfo]) => subjectInfo.childModelIds.has(modelId)),
+          mergeMap(([modelSubjectId]) => this.createSubjectInstanceKeysPath(modelSubjectId)),
+          shareReplay(),
+        ),
+    });
   }
 
   public createCategoryInstanceKeyPaths({ categoryIds }: { categoryIds: Id64Array }): Observable<HierarchyNodeIdentifiersPath> {
@@ -322,12 +322,7 @@ export class ModelsTreeIdsCache extends BaseIdsCacheImpl {
       mergeMap((id) => forkJoin({ id: of(id), subModels: this.getModels({ subModels: "only", categoryId: id, includeOnlyIfCategoryOfTopMostElement: true }) })),
       reduce((acc, { id, subModels }) => {
         for (const subModelId of subModels) {
-          const entry = acc.get(subModelId);
-          if (!entry) {
-            acc.set(subModelId, new Set([id]));
-            continue;
-          }
-          entry.add(id);
+          getOrCreate({ map: acc, key: subModelId, createFunc: () => new Set<CategoryId>() }).add(id);
         }
         return acc;
       }, new Map<ModelId, Set<CategoryId>>()),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/SearchResultsTree.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/SearchResultsTree.ts
@@ -5,6 +5,7 @@
 
 import { assert } from "@itwin/core-bentley";
 import { CLASS_NAME_Category, CLASS_NAME_GeometricElement3d, CLASS_NAME_Model, CLASS_NAME_Subject } from "../../../common/internal/ClassNameDefinitions.js";
+import { getOrCreate } from "../../../common/internal/Utils.js";
 import { createSearchResultsTree, SearchResultsNodesHandler } from "../../../common/internal/visibility/BaseSearchResultsTree.js";
 
 import type { Id64Set, Id64String } from "@itwin/core-bentley";
@@ -173,12 +174,8 @@ class ModelsTreeSearchResultsNodesHandler extends SearchResultsNodesHandler<void
         (searchTargets.modelIds ??= new Set()).add(node.id);
         return;
       case "category":
-        const categories = (searchTargets.categories ??= new Map()).get(node.modelId);
-        if (categories) {
-          categories.add(node.id);
-          return;
-        }
-        searchTargets.categories.set(node.modelId, new Set([node.id]));
+        const categories = getOrCreate({ map: (searchTargets.categories ??= new Map()), key: node.modelId, createFunc: () => new Set<CategoryId>() });
+        categories.add(node.id);
         return;
       case "element":
         // Internal search target elements need to have path saved in some way.
@@ -192,12 +189,7 @@ class ModelsTreeSearchResultsNodesHandler extends SearchResultsNodesHandler<void
             topMostParentElementId = node.pathToNode[i].id;
           }
           const identifierAsString = this.convertSearchResultsNodeIdentifierToString(node.pathToNode[i]);
-          let identifierEntry = entry.get(identifierAsString);
-          // create a new entry for parent node if it does not exist
-          if (!identifierEntry) {
-            identifierEntry = { topMostParentElementId };
-            entry.set(identifierAsString, identifierEntry);
-          }
+          const identifierEntry = getOrCreate({ map: entry, key: identifierAsString, createFunc: () => ({ topMostParentElementId }) });
           // last entry in the path don't need to have children
           if (i < node.pathToNode.length - 1) {
             identifierEntry.children ??= new Map();
@@ -206,12 +198,13 @@ class ModelsTreeSearchResultsNodesHandler extends SearchResultsNodesHandler<void
           }
 
           // Add elements who share the same path to the modelCategoryElements map
-          const elements = (identifierEntry.modelCategoryElements ??= new Map()).get(modelCategoryKey);
-          if (elements) {
-            elements.set(node.id, { isSearchTarget: node.isSearchTarget });
-          } else {
-            identifierEntry.modelCategoryElements.set(modelCategoryKey, new Map([[node.id, { isSearchTarget: node.isSearchTarget }]]));
-          }
+          identifierEntry.modelCategoryElements ??= new Map();
+          const elements = getOrCreate({
+            map: identifierEntry.modelCategoryElements,
+            key: modelCategoryKey,
+            createFunc: () => new Map<ElementId, { isSearchTarget: boolean }>(),
+          });
+          elements.set(node.id, { isSearchTarget: node.isSearchTarget });
         }
     }
   }


### PR DESCRIPTION
Extracted the same pattern:
```ts
let entry = map.get(key);
if (!entry) {
  entry = {...};
  map.set(key, entry);
}
```
Into `getOrCreate` function