### PR TITLE
[Tree widget]: allow searching elements by Id on `next`

### DIFF
--- a/change/@itwin-tree-widget-react-04f2a34d-6620-47c9-b297-378af2a324b9.json
+++ b/change/@itwin-tree-widget-react-04f2a34d-6620-47c9-b297-378af2a324b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Categories & Classifications trees: Allow searching for elements by Id. ",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-04f2a34d-6620-47c9-b297-378af2a324b9.json
+++ b/change/@itwin-tree-widget-react-04f2a34d-6620-47c9-b297-378af2a324b9.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Categories & Classifications trees: Allow searching for elements by Id. ",
+  "comment": "Categories & Classifications trees: allow searching for elements by Id. ",
   "packageName": "@itwin/tree-widget-react",
   "email": "100586436+JonasDov@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/CategoriesTreeFiltering.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/CategoriesTreeFiltering.test.tsx
@@ -19,6 +19,7 @@ import {
 } from "test-utilities";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { withEditTxn } from "@itwin/core-backend";
+import { Id64 } from "@itwin/core-bentley";
 import { IModelReadRpcInterface } from "@itwin/core-common";
 import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
@@ -26,6 +27,10 @@ import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { act, renderHook } from "@testing-library/react";
 import { defaultHierarchyConfiguration } from "../../../tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.js";
 import { useCategoriesTree } from "../../../tree-widget-react/components/trees/categories-tree/UseCategoriesTree.js";
+import {
+  CLASS_NAME_GeometricElement2d,
+  CLASS_NAME_GeometricElement3d,
+} from "../../../tree-widget-react/components/trees/common/internal/ClassNameDefinitions.js";
 import { SharedTreeContextProvider } from "../../../tree-widget-react/components/trees/common/SharedTreeContextProvider.js";
 import { buildIModel } from "../../IModelUtils.js";
 import { createFakeViewport, createIModelAccess } from "../Common.js";
@@ -498,6 +503,93 @@ describe("Categories tree", () => {
           identifier: keys.category,
           options: { autoExpand: true },
           children: [{ identifier: keys.subCategory2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+        },
+      ]);
+    });
+
+    it("finds 3d element by base36 ECInstanceId suffix", async function () {
+      await using buildIModelResult = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
+          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "TestDefinitionContainer" });
+          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
+          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
+          const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
+
+          return { definitionContainer, element, category };
+        }),
+      );
+      const { imodelConnection, ...keys } = buildIModelResult;
+
+      const briefcaseId = Id64.getBriefcaseId(keys.element.id).toString(36).toLocaleUpperCase();
+      const localId = Id64.getLocalId(keys.element.id).toString(36).toLocaleUpperCase();
+      const imodelAccess = createIModelAccess(imodelConnection);
+      using hook = renderUseCategoriesTreeHook({
+        imodelConnection,
+        hierarchyConfig: { ...defaultHierarchyConfiguration, showElements: true },
+        searchText: `[${briefcaseId}-${localId}]`,
+        viewType: "3d",
+      });
+      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+        {
+          identifier: keys.definitionContainer,
+          options: { autoExpand: true },
+          children: [
+            {
+              identifier: keys.category,
+              options: { autoExpand: true },
+              children: [
+                {
+                  identifier: { ...keys.element, className: CLASS_NAME_GeometricElement3d },
+                  options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("finds 2d element by base36 ECInstanceId suffix", async function () {
+      await using buildIModelResult = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "TestDefinitionContainer" });
+          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
+          const drawingModel = insertDrawingModelWithPartition({ txn, codeValue: "TestDrawingModel" });
+
+          const category = insertDrawingCategory({ txn, codeValue: "Test Drawing Category", modelId: definitionModel.id });
+          const element = insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: category.id });
+
+          return { definitionContainer, element, category };
+        }),
+      );
+      const { imodelConnection, ...keys } = buildIModelResult;
+
+      const briefcaseId = Id64.getBriefcaseId(keys.element.id).toString(36).toLocaleUpperCase();
+      const localId = Id64.getLocalId(keys.element.id).toString(36).toLocaleUpperCase();
+      const imodelAccess = createIModelAccess(imodelConnection);
+      using hook = renderUseCategoriesTreeHook({
+        imodelConnection,
+        hierarchyConfig: { ...defaultHierarchyConfiguration, showElements: true },
+        searchText: `[${briefcaseId}-${localId}]`,
+        viewType: "2d",
+      });
+      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+        {
+          identifier: keys.definitionContainer,
+          options: { autoExpand: true },
+          children: [
+            {
+              identifier: keys.category,
+              options: { autoExpand: true },
+              children: [
+                {
+                  identifier: { ...keys.element, className: CLASS_NAME_GeometricElement2d },
+                  options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+                },
+              ],
+            },
+          ],
         },
       ]);
     });

--- a/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeFiltering.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeFiltering.test.tsx
@@ -463,7 +463,7 @@ describe("Classifications tree", () => {
         ]);
       });
 
-      it.only("finds 3d element by base36 ECInstanceId suffix", async function () {
+      it("finds 3d element by base36 ECInstanceId suffix", async function () {
         await using buildIModelResult = await buildIModel(async (imodel) =>
           withEditTxn(imodel, async (txn) => {
             await importClassificationSchema(imodel);

--- a/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeFiltering.test.tsx
+++ b/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeFiltering.test.tsx
@@ -6,6 +6,7 @@
 import { insertPhysicalElement, insertPhysicalModelWithPartition, insertSpatialCategory } from "test-utilities";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { withEditTxn } from "@itwin/core-backend";
+import { Id64 } from "@itwin/core-bentley";
 import { act, renderHook } from "@testing-library/react";
 import { useClassificationsTreeDefinition } from "../../../tree-widget-react/components/trees/classifications-tree/UseClassificationsTreeDefinition.js";
 import {
@@ -454,6 +455,56 @@ describe("Classifications tree", () => {
                         options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
                       },
                     ],
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
+      });
+
+      it.only("finds 3d element by base36 ECInstanceId suffix", async function () {
+        await using buildIModelResult = await buildIModel(async (imodel) =>
+          withEditTxn(imodel, async (txn) => {
+            await importClassificationSchema(imodel);
+
+            const system = insertClassificationSystem({ txn, codeValue: rootClassificationSystemCode });
+            const table = insertClassificationTable({ txn, parentId: system.id, codeValue: "ClassificationTable" });
+            const classification = insertClassification({ txn, modelId: table.id, codeValue: "Classification" });
+            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "Model" });
+            const spatialCategory = insertSpatialCategory({ txn, codeValue: "Category" });
+            const element = insertPhysicalElement({
+              txn,
+              modelId: physicalModel.id,
+              categoryId: spatialCategory.id,
+              codeValue: "Element",
+            });
+            insertElementHasClassificationsRelationship({ txn, elementId: element.id, classificationId: classification.id });
+
+            return { table, classification, element };
+          }),
+        );
+        const { imodelConnection, ...keys } = buildIModelResult;
+
+        const briefcaseId = Id64.getBriefcaseId(keys.element.id).toString(36).toLocaleUpperCase();
+        const localId = Id64.getLocalId(keys.element.id).toString(36).toLocaleUpperCase();
+        using hook = renderUseClassificationsTreeDefinitionHook({
+          imodels: [imodelConnection],
+          hierarchyConfig: defaultHierarchyConfiguration,
+          search: { searchText: `[${briefcaseId}-${localId}]` },
+        });
+        expect(await act(async () => hook.result.current.getSearchPaths?.({ abortSignal: new AbortController().signal }))).toEqual([
+          {
+            identifier: keys.table,
+            options: { autoExpand: true },
+            children: [
+              {
+                identifier: keys.classification,
+                options: { autoExpand: true },
+                children: [
+                  {
+                    identifier: { ...keys.element, className: CLASS_NAME_GeometricElement3d },
+                    options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
                   },
                 ],
               },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -263,8 +263,12 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
 
   private async createISubModeledElementChildrenQuery({
     parentNodeInstanceIds: elementIds,
+    parentNode,
     nodeSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
+    if (CategoriesTreeNode.isDefinitionContainerNode(parentNode)) {
+      return [];
+    }
     // note: we do not apply hierarchy level filtering on this hierarchy level, because it's always
     // hidden - the filter will get applied on the child hierarchy levels
     return [
@@ -786,7 +790,8 @@ function createInstanceKeyPathsFromInstanceLabel(
         }
         const [categoryLabelSelectClause, subCategoryLabelSelectClause, elementLabelSelectClause, definitionContainerLabelSelectClause] = await Promise.all(
           [categoryClass, CLASS_NAME_SubCategory, elementClass, ...(definitionContainers.length > 0 ? [CLASS_NAME_DefinitionContainer] : [])].map(
-            async (className) => labelsFactory.createSelectClause({ classAlias: "this", className }),
+            async (className) =>
+              labelsFactory.createSelectClause({ classAlias: "this", className, selectorsConcatenator: ECSql.createConcatenatedValueStringSelector }),
           ),
         );
         const ctes = [

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -428,7 +428,7 @@ function createInstanceKeyPathsFromInstanceLabelObs({
   return defer(async () => {
     const [classificationTableLabelSelectClause, classificationLabelSelectClause, elementLabelSelectClause] = await Promise.all(
       [CLASS_NAME_ClassificationTable, CLASS_NAME_Classification, CLASS_NAME_GeometricElement3d].map(async (className) =>
-        props.labelsFactory.createSelectClause({ classAlias: "this", className }),
+        props.labelsFactory.createSelectClause({ classAlias: "this", className, selectorsConcatenator: ECSql.createConcatenatedValueStringSelector }),
       ),
     );
     const classificationIds = await firstValueFrom(props.idsCache.getAllClassifications());


### PR DESCRIPTION
Found out, that searching for elements by their id in categories and classifications trees was not possible