### PR TITLE
[geo-tools] GoogleAddressProvider now handles more API variants for location requests

### DIFF
--- a/change/@itwin-geo-tools-react-6582ffe5-6858-4b66-9546-d92b561112ee.json
+++ b/change/@itwin-geo-tools-react-6582ffe5-6858-4b66-9546-d92b561112ee.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "GoogleAddressProvider does not always resolve location requests correctly. Now handling different API variants",
+  "packageName": "@itwin/geo-tools-react",
+  "email": "Johannes.Goltz@bentley.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/geo-tools/src/GoogleAddressProvider.ts
+++ b/packages/itwin/geo-tools/src/GoogleAddressProvider.ts
@@ -73,10 +73,19 @@ export class GoogleAddressProvider implements AddressProvider {
       } });
     const json: any = await response.json();
 
-    // Accept either top-level `location`, nested geometry paths depending on API variant
-    // or original code
-    const lat = json?.location?.latitude ?? json?.result?.geometry?.location?.lat ?? json?.location?.geometry?.latitude;
-    const long = json?.location?.longitude ?? json?.result?.geometry?.location?.lng ?? json?.location?.geometry?.longitude;
+    // Google Address Validation API response shape: { location: { latitude, longitude } }
+    // @see https://developers.google.com/maps/documentation/address-validation/reference/rest/v1/TopLevel/validateAddress#Location
+    const lat = json?.location?.latitude
+      // Google Geocoding API response shape: { result: { geometry: { location: { lat, lng } } } }
+      // @see https://developers.google.com/maps/documentation/geocoding/requests-geocoding#Results
+      ?? json?.result?.geometry?.location?.lat
+      // Legacy/wrapper format: { location: { geometry: { latitude, longitude } } }
+      ?? json?.location?.geometry?.latitude;
+
+    const long = json?.location?.longitude
+      ?? json?.result?.geometry?.location?.lng
+      ?? json?.location?.geometry?.longitude;
+
     if (lat === undefined || long === undefined) {
       throw new Error("Invalid location data");
     }

--- a/packages/itwin/geo-tools/src/GoogleAddressProvider.ts
+++ b/packages/itwin/geo-tools/src/GoogleAddressProvider.ts
@@ -73,8 +73,10 @@ export class GoogleAddressProvider implements AddressProvider {
       } });
     const json: any = await response.json();
 
-    const lat = json?.location?.geometry?.latitude
-    const long = json?.location?.geometry?.longitude
+    // Accept either top-level `location`, nested geometry paths depending on API variant
+    // or original code
+    const lat = json?.location?.latitude ?? json?.result?.geometry?.location?.lat ?? json?.location?.geometry?.latitude;
+    const long = json?.location?.longitude ?? json?.result?.geometry?.location?.lng ?? json?.location?.geometry?.longitude;
     if (lat === undefined || long === undefined) {
       throw new Error("Invalid location data");
     }


### PR DESCRIPTION
**Issue**
The GoogleAddressProvider does not always resolve a given place ID to coordinates correctly. It seems the API
supports different variants of query responses but only one variant (legacy ???) is currently accpted.

see screen shoot from my debug session:
<img width="3566" height="1293" alt="image" src="https://github.com/user-attachments/assets/be26746e-adc1-47ae-b155-f249da014c3f" />

**Solution**
[GoogleAddressProvider.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html): broadened location extraction to accept alternative response shapes (top-level [location](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), nested [result.geometry.location.lat/lng](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/c3a26841a8/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and other geometry variants). Kept existing behavior while adding fallbacks and validation.
