### PR TITLE
[Tree widget]: cleanup on `next`

### DIFF
--- a/change/@itwin-tree-widget-react-7b3e9c1a-2f4d-4a8e-9c6b-1e5a8d3f6b2c.json
+++ b/change/@itwin-tree-widget-react-7b3e9c1a-2f4d-4a8e-9c6b-1e5a8d3f6b2c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@itwin-tree-widget-react-7b3e9c1a-2f4d-4a8e-9c6b-1e5a8d3f6b2c.json
+++ b/change/@itwin-tree-widget-react-7b3e9c1a-2f4d-4a8e-9c6b-1e5a8d3f6b2c.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "",
+  "comment": "Categories tree: refactor category/sub-model visibility handling.",
   "packageName": "@itwin/tree-widget-react",
   "email": "100586436+JonasDov@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/itwin/tree-widget/src/test/IModelUtils.ts
+++ b/packages/itwin/tree-widget/src/test/IModelUtils.ts
@@ -14,6 +14,13 @@ function getTestName(): string {
   return expect.getState().currentTestName?.replace(/[^\w]/gi, "-").replace(/-+/g, "-").toLowerCase() ?? "unknown";
 }
 
+export namespace TestSchema {
+  export const Name = "TestSchema";
+  export const ModeledElement2dClassName = "SubModelableDrawingGraphic";
+  export const SubModel2dClassName = "DrawingGraphicModel";
+  export const ModeledElement3dClassName = "SubModelablePhysicalObject";
+}
+
 export async function buildIModel(
   setup?: (imodel: IModelDb, testSchema: TestSchemaDefinition) => Promise<void>,
 ): Promise<{ imodelConnection: IModelConnection } & AsyncDisposable>;
@@ -27,12 +34,28 @@ export async function buildIModel<TResult extends object | undefined>(setup?: (i
       imodel,
       schemaContentXml: `
         <ECSchemaReference name="BisCore" version="01.00.16" alias="bis" />
-        <ECEntityClass typeName="SubModelablePhysicalObject" displayLabel="Test Physical Object" modifier="Sealed" description="Similar to generic:PhysicalObject but also sub-modelable.">
+        <ECEntityClass typeName="${TestSchema.ModeledElement3dClassName}" displayLabel="Test Physical Object" modifier="Sealed" description="Similar to generic:PhysicalObject but also sub-modelable.">
           <BaseClass>bis:PhysicalElement</BaseClass>
           <BaseClass>bis:ISubModeledElement</BaseClass>
         </ECEntityClass>
+        <ECEntityClass typeName="${TestSchema.ModeledElement2dClassName}" displayLabel="Test Drawing Graphic" modifier="Sealed" description="Similar to generic:DrawingGraphic but also sub-modelable.">
+          <BaseClass>bis:DrawingGraphic</BaseClass>
+          <BaseClass>bis:ISubModeledElement</BaseClass>
+        </ECEntityClass>
+        <ECEntityClass typeName="${TestSchema.SubModel2dClassName}" displayLabel="Drawing Graphic Model" modifier="Sealed" description="A 2d geometric model that can sub-model a DrawingGraphic element.">
+          <BaseClass>bis:GraphicalModel2d</BaseClass>
+        </ECEntityClass>
+        <ECRelationshipClass typeName="DrawingGraphicModelBreaksDownSubModelableDrawingGraphic" strength="embedding" strengthDirection="backward" modifier="None">
+          <BaseClass>bis:ModelModelsElement</BaseClass>
+          <Source multiplicity="(0..1)" roleLabel="models" polymorphic="true">
+              <Class class="DrawingGraphicModel"/>
+          </Source>
+          <Target multiplicity="(0..1)" roleLabel="is modeled by" polymorphic="true">
+              <Class class="SubModelableDrawingGraphic"/>
+          </Target>
+        </ECRelationshipClass>
       `,
-      schemaName: "TestSchema",
+      schemaName: TestSchema.Name,
       schemaAlias: "test",
     })) as TestSchemaDefinition;
     const setupResult = setup ? await setup(imodel, testSchema) : undefined;
@@ -47,5 +70,9 @@ export async function buildIModel<TResult extends object | undefined>(setup?: (i
 }
 
 interface TestSchemaDefinition extends ImportSchemaResult {
-  items: { SubModelablePhysicalObject: { name: string; fullName: string; label: string } };
+  items: {
+    [TestSchema.ModeledElement3dClassName]: { name: string; fullName: string; label: string };
+    [TestSchema.ModeledElement2dClassName]: { name: string; fullName: string; label: string };
+    [TestSchema.SubModel2dClassName]: { name: string; fullName: string; label: string };
+  };
 }

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { firstValueFrom, toArray } from "rxjs";
+import { firstValueFrom } from "rxjs";
 import {
   HierarchyCacheMode,
   initializeCore,
@@ -24,6 +24,7 @@ import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { CategoriesTreeIdsCache } from "../../../../tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 import { BaseIdsCache } from "../../../../tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.js";
+import { collect } from "../../../../tree-widget-react/components/trees/common/internal/Rxjs.js";
 import { getClassesByView } from "../../../../tree-widget-react/components/trees/common/internal/Utils.js";
 import { buildIModel } from "../../../IModelUtils.js";
 import { createIModelAccess } from "../../Common.js";
@@ -193,7 +194,7 @@ describe("CategoriesTreeIdsCache", () => {
       expect(
         await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
       ).toEqual({
-        categories: [{ id: keys.category.id, subCategoryChildCount: 1, hasElements: true }],
+        categories: [{ id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true }],
         definitionContainers: [],
       });
     });
@@ -216,7 +217,7 @@ describe("CategoriesTreeIdsCache", () => {
           idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id], includeEmpty: true }),
         ),
       ).toEqual({
-        categories: [{ id: keys.category.id, subCategoryChildCount: 1, hasElements: false }],
+        categories: [{ id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: false, hasElements: false }],
         definitionContainers: [],
       });
     });
@@ -262,7 +263,7 @@ describe("CategoriesTreeIdsCache", () => {
       expect(
         await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
       ).toEqual({
-        categories: [{ id: keys.category.id, subCategoryChildCount: 1, hasElements: true }],
+        categories: [{ id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true }],
         definitionContainers: [],
       });
     });
@@ -291,7 +292,7 @@ describe("CategoriesTreeIdsCache", () => {
       expect(
         await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
       ).toEqual({
-        categories: [{ id: keys.directCategory.id, subCategoryChildCount: 1, hasElements: true }],
+        categories: [{ id: keys.directCategory.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true }],
         definitionContainers: [keys.definitionModelChild.id],
       });
     });
@@ -317,7 +318,7 @@ describe("CategoriesTreeIdsCache", () => {
       expect(
         await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionModelChild.id] })),
       ).toEqual({
-        categories: [{ id: keys.indirectCategory.id, subCategoryChildCount: 1, hasElements: true }],
+        categories: [{ id: keys.indirectCategory.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true }],
         definitionContainers: [],
       });
     });
@@ -337,29 +338,13 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual(new Set());
+      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual([]);
     });
 
-    it("returns empty list when definition container contains empty categories", async () => {
+    it("returns empty categories when definition container contains them", async () => {
       await using buildIModelResult = await buildIModel(async (imodel) =>
         withEditTxn(imodel, (txn) => {
           insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          return { definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual(new Set());
-    });
-
-    it("returns contained categories when definition container contains empty categories and includeEmptyCategories is true", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
           const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
           const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
           const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
@@ -370,9 +355,14 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id], includeEmptyCategories: true })),
-      ).toEqual(new Set([keys.category.id]));
+      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual([
+        {
+          hasElements: false,
+          id: keys.category.id,
+          isTopMostElementCategory: false,
+          subCategoryChildCount: 1,
+        },
+      ]);
     });
 
     it("returns indirectly contained categories when definition container contains definition container that has categories", async () => {
@@ -392,9 +382,14 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainerRoot.id] }))).toEqual(
-        new Set([keys.category.id]),
-      );
+      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainerRoot.id] }))).toEqual([
+        {
+          hasElements: true,
+          id: keys.category.id,
+          isTopMostElementCategory: true,
+          subCategoryChildCount: 1,
+        },
+      ]);
     });
 
     it("returns child categories when definition container contains categories", async () => {
@@ -412,9 +407,14 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual(
-        new Set([keys.category.id]),
-      );
+      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual([
+        {
+          hasElements: true,
+          id: keys.category.id,
+          isTopMostElementCategory: true,
+          subCategoryChildCount: 1,
+        },
+      ]);
     });
 
     it("returns direct and indirect categories when definition container contains categories and definition containers that contain categories", async () => {
@@ -438,9 +438,9 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const result = await firstValueFrom(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainerRoot.id] }));
+      const result = await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainerRoot.id] }));
       const expectedResult = [keys.indirectCategory.id, keys.directCategory.id];
-      expect(expectedResult.every((id) => result.has(id))).toBe(true);
+      expect(expectedResult.every((id) => result.some(({ id: categoryId }) => categoryId === id))).toBe(true);
     });
   });
 
@@ -533,8 +533,8 @@ describe("CategoriesTreeIdsCache", () => {
     });
   });
 
-  describe("getCategoriesSearchPaths", () => {
-    it("returns empty list when category doesn't exist", async () => {
+  describe("getSearchPathsUpToRootCategory", () => {
+    it("returns no paths when category doesn't exist", async () => {
       await using buildIModelResult = await buildIModel(async (imodel) =>
         withEditTxn(imodel, (txn) => {
           const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
@@ -546,10 +546,10 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getCategoriesSearchPaths({ categoryIds: "0x123", includePathsWithSubModels: false }))).toEqual([]);
+      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: "0x123" }))).toEqual([]);
     });
 
-    it("returns only category when only category exists", async () => {
+    it("returns empty list when category does not have definition container", async () => {
       await using buildIModelResult = await buildIModel(async (imodel) =>
         withEditTxn(imodel, (txn) => {
           const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
@@ -562,12 +562,10 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getCategoriesSearchPaths({ categoryIds: keys.category.id, includePathsWithSubModels: false }))).toEqual([
-        keys.category,
-      ]);
+      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[]]);
     });
 
-    it("returns category path when it exist under sub-model", async () => {
+    it("returns up to category path when it exist under sub-model", async () => {
       await using buildIModelResult = await buildIModel(async (imodel, testSchema) =>
         withEditTxn(imodel, (txn) => {
           const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
@@ -596,26 +594,10 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getCategoriesSearchPaths({ categoryIds: keys.category.id, includePathsWithSubModels: false }).pipe(toArray())),
-      ).toEqual([[keys.definitionContainer, keys.category]]);
-      expect(
-        (await firstValueFrom(idsCache.getCategoriesSearchPaths({ categoryIds: keys.category.id, includePathsWithSubModels: true }).pipe(toArray()))).sort(
-          (path1, path2) => path1.length - path2.length,
-        ),
-      ).toEqual([
-        [keys.definitionContainer, keys.category],
-        [
-          keys.definitionContainer,
-          keys.category,
-          { className: getClassesByView("3d").elementClass, id: keys.modeledElement.id },
-          { className: getClassesByView("3d").modelClass, id: keys.subModel.id },
-          keys.category,
-        ],
-      ]);
+      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[keys.definitionContainer]]);
     });
 
-    it("returns path to category when definition container contains category", async () => {
+    it("returns path up to category when definition container contains category", async () => {
       await using buildIModelResult = await buildIModel(async (imodel) =>
         withEditTxn(imodel, (txn) => {
           const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
@@ -630,13 +612,10 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getCategoriesSearchPaths({ categoryIds: keys.category.id, includePathsWithSubModels: false }))).toEqual([
-        keys.definitionContainer,
-        keys.category,
-      ]);
+      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[keys.definitionContainer]]);
     });
 
-    it("returns path to category when definition container contains definition container that contains category", async () => {
+    it("returns path up to category when definition container contains definition container that contains category", async () => {
       await using buildIModelResult = await buildIModel(async (imodel) =>
         withEditTxn(imodel, (txn) => {
           const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
@@ -653,10 +632,8 @@ describe("CategoriesTreeIdsCache", () => {
       const imodelAccess = createIModelAccess(imodelConnection);
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getCategoriesSearchPaths({ categoryIds: keys.category.id, includePathsWithSubModels: false }))).toEqual([
-        keys.definitionContainerRoot,
-        keys.definitionContainerChild,
-        keys.category,
+      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([
+        [keys.definitionContainerRoot, keys.definitionContainerChild],
       ]);
     });
   });
@@ -962,7 +939,7 @@ describe("CategoriesTreeIdsCache", () => {
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
       expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories({ includeEmpty: true }))).toEqual({
-        categories: [{ id: keys.rootCategory.id, subCategoryChildCount: 1, hasElements: false }],
+        categories: [{ id: keys.rootCategory.id, subCategoryChildCount: 1, isTopMostElementCategory: false, hasElements: false }],
         definitionContainers: [keys.definitionContainer.id],
       });
     });
@@ -983,7 +960,7 @@ describe("CategoriesTreeIdsCache", () => {
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
       expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-        categories: [{ id: keys.category.id, subCategoryChildCount: 1, hasElements: true }],
+        categories: [{ id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true }],
         definitionContainers: [],
       });
     });
@@ -1006,7 +983,7 @@ describe("CategoriesTreeIdsCache", () => {
       const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
       const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
       expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-        categories: [{ id: keys.category.id, subCategoryChildCount: 1, hasElements: true }],
+        categories: [{ id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true }],
         definitionContainers: [],
       });
     });
@@ -1088,8 +1065,8 @@ describe("CategoriesTreeIdsCache", () => {
       const result = await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories());
       const expectedResult = {
         categories: [
-          { id: keys.rootCategory1.id, subCategoryChildCount: 1, hasElements: true },
-          { id: keys.rootCategory2.id, subCategoryChildCount: 1, hasElements: true },
+          { id: keys.rootCategory1.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true },
+          { id: keys.rootCategory2.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true },
         ],
         definitionContainers: [keys.definitionContainerRoot.id, keys.definitionContainerRoot2.id],
       };

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -48,7 +48,6 @@ import {
   createElementHierarchyNode,
   createModelHierarchyNode,
   createSubCategoryHierarchyNode,
-  createSubModelCategoryHierarchyNode,
 } from "./Utils.js";
 import { validateNodeVisibility } from "./VisibilityValidation.js";
 
@@ -1992,10 +1991,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
               expectations: (ids) => ({
                 [ids.category.id]: "visible",
                   [ids.modeledElement.id]: "visible",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                      [ids.subModelElement?.id ?? ""]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                      [ids.subModelElement!.id]: "visible",
 
-                [ids.subModelCategory?.id ?? ""]: "partial",
+                [ids.subModelCategory!.id]: "hidden",
               }),
             },
             {
@@ -2009,12 +2008,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 }),
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "partial",
+                [ids.subModelCategory!.id]: "hidden",
 
                 [ids.category.id]: "partial",
                   [ids.modeledElement.id]: "visible",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                      [ids.subModelElement?.id ?? ""]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                      [ids.subModelElement!.id]: "visible",
               }),
             },
             {
@@ -2028,12 +2027,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 }),
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "partial",
+                [ids.subModelCategory!.id]: "hidden",
 
                 [ids.category.id]: "partial",
                   [ids.modeledElement.id]: "visible",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                      [ids.subModelElement?.id ?? ""]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                      [ids.subModelElement!.id]: "visible",
               }),
             },
             {
@@ -2041,25 +2040,26 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) => createModelHierarchyNode({ id: ids.modeledElement.id, hasChildren: true }),
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "partial",
+                [ids.subModelCategory!.id]: "hidden",
 
                 [ids.category.id]: "partial",
                   [ids.modeledElement.id]: "partial",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                      [ids.subModelElement?.id ?? ""]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                      [ids.subModelElement!.id]: "visible",
               }),
             },
             {
               name: "modeled element, its model and category have partial visibility when its sub-model element's category display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) => createSubModelCategoryHierarchyNode(ids.modeledElement.id, ids.subModelCategory?.id, true),
+              getTargetNode: (ids: IModelWithSubModelIds) =>
+                createCategoryHierarchyNode({ id: ids.subModelCategory!.id, isCategoryOfSubModel: true, modelIds: [ids.modeledElement.id] }),
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "visible",
+                [ids.subModelCategory!.id]: "hidden",
 
                 [ids.category.id]: "partial",
                   [ids.modeledElement.id]: "partial",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                      [ids.subModelElement?.id ?? ""]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                      [ids.subModelElement!.id]: "visible",
               }),
             },
             {
@@ -2067,17 +2067,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) =>
                 createElementHierarchyNode({
                   modelId: ids.modeledElement.id,
-                  categoryId: ids.subModelCategory?.id,
+                  categoryId: ids.subModelCategory!.id,
                   elementId: ids.subModelElement!.id,
                 }),
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "partial",
+                [ids.subModelCategory!.id]: "hidden",
 
                 [ids.category.id]: "partial",
                   [ids.modeledElement.id]: "partial",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory?.id ?? ""}`]: "visible",
-                      [ids.subModelElement?.id ?? ""]: "visible",
+                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                      [ids.subModelElement!.id]: "visible",
               }),
             },
           ],

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
@@ -39,34 +39,10 @@ export function createCategoryHierarchyNode(
       : [],
     extendedData: {
       isCategory: true,
-      modelIds: props.isCategoryOfSubModel ? props.modelIds : undefined,
+      modelIds: props.isCategoryOfSubModel ? props.modelIds : [],
       categoryId: props.id,
       isCategoryOfSubModel: !!props.isCategoryOfSubModel,
       hasSubCategories: !props.isCategoryOfSubModel ? !!props.hasSubCategories : undefined,
-    },
-  };
-}
-
-/** @internal */
-export function createSubModelCategoryHierarchyNode(
-  modelId?: Id64String,
-  categoryId?: Id64String,
-  hasChildren?: boolean,
-  viewType: "2d" | "3d" = "3d",
-): NonGroupingHierarchyNode {
-  const { categoryClass } = getClassesByView(viewType);
-  return {
-    key: {
-      type: "instances",
-      instanceKeys: [{ className: categoryClass, id: categoryId ?? "" }],
-    },
-    children: !!hasChildren,
-    label: "",
-    parentKeys: [],
-    extendedData: {
-      isCategory: true,
-      modelId: modelId ?? "0x1",
-      categoryId: categoryId ?? "0x2",
     },
   };
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -5,26 +5,23 @@
 
 import {
   bufferCount,
-  defer,
   distinct,
   EMPTY,
+  filter,
   firstValueFrom,
-  forkJoin,
   from,
   fromEvent,
   identity,
   map,
   merge,
-  mergeAll,
   mergeMap,
-  of,
   reduce,
   switchMap,
   takeUntil,
   toArray,
 } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
-import { createPredicateBasedHierarchyDefinition, HierarchyNode, ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
+import { createPredicateBasedHierarchyDefinition, ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
 import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
 import { eachValueFrom } from "../../utils/EachValueFrom.js";
 import {
@@ -45,7 +42,7 @@ import {
   releaseMainThreadOnItemsCount,
 } from "../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../common/TreeErrors.js";
-import { CategoriesTreeNode } from "./CategoriesTreeNode.js";
+import { CategoriesTreeNodeInternal } from "./internal/CategoriesTreeNodeInternal.js";
 
 import type { Observable, ObservedValueOf, OperatorFunction } from "rxjs";
 import type { GuidString, Id64Array, Id64String, MarkRequired } from "@itwin/core-bentley";
@@ -67,9 +64,11 @@ import type {
   EC,
   ECClassHierarchyInspector,
   ECSchemaProvider,
+  ECSqlBinding,
   ECSqlQueryRow,
   IInstanceLabelSelectClauseFactory,
   InstanceKey,
+  Props,
 } from "@itwin/presentation-shared";
 import type { CategoryId, DefinitionContainerId, ElementId, ModelId, SubCategoryId } from "../common/internal/Types.js";
 import type { CategoriesTreeIdsCache, CategoryInfo } from "./internal/CategoriesTreeIdsCache.js";
@@ -140,7 +139,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
   }
 
   public preProcessNode: NodePreProcessor = async ({ node }) => {
-    if (node.extendedData?.isCategory) {
+    if (CategoriesTreeNodeInternal.isRawCategoryNode(node)) {
       return {
         ...node,
         extendedData: {
@@ -153,60 +152,59 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
   };
 
   public postProcessNode: NodePostProcessor = async ({ node }) => {
-    if (ProcessedHierarchyNode.isGroupingNode(node)) {
-      const modelElementsMap = new Map<
-        ModelId,
-        {
-          elementIds: Set<ElementId>;
-          categoryOfTopMostParentElement: CategoryId;
-          childrenWhichAreParents: Set<ElementId>;
-        }
-      >();
-      for (const child of node.children) {
-        const modelEntry = getOrCreate({
-          map: modelElementsMap,
-          key: child.extendedData?.modelId,
-          createFunc: () => ({
-            elementIds: new Set(),
-            categoryOfTopMostParentElement: child.extendedData?.categoryOfTopMostParentElement,
-            childrenWhichAreParents: new Set<ElementId>(),
-          }),
-        });
-        assert(CategoriesTreeNode.isElementNode(child));
-        const addId = child.children
-          ? (id: Id64String) => {
-              modelEntry.elementIds.add(id);
-              modelEntry.childrenWhichAreParents.add(id);
-            }
-          : (id: Id64String) => modelEntry.elementIds.add(id);
-        for (const { id } of child.key.instanceKeys) {
-          addId(id);
-        }
-      }
-
-      const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
-      const firstChild = node.children[0];
-      assert(HierarchyNode.isInstancesNode(firstChild));
-      return {
-        ...node,
-        label: node.label,
-        extendedData: {
-          ...node.extendedData,
-          topMostParentElementId: firstChild.key.instanceKeys.every((instanceKey) => instanceKey.id !== firstChild.extendedData?.topMostParentElementId)
-            ? firstChild.extendedData?.topMostParentElementId
-            : undefined,
-          // add `categoryId` from the first grouped element
-          categoryId: firstChild.extendedData?.categoryId,
-          modelElementsMap,
-          ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
-          ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
-          // `imageId` is assigned to instance nodes at query time, but grouping ones need to
-          // be handled during post-processing
-          imageId: "icon-ec-class",
-        },
-      };
+    if (!ProcessedHierarchyNode.isGroupingNode(node)) {
+      return node;
     }
-    return node;
+    const modelElementsMap = new Map<
+      ModelId,
+      {
+        elementIds: Set<ElementId>;
+        childrenWhichAreParents: Set<ElementId>;
+      }
+    >();
+    for (const child of node.children) {
+      assert(CategoriesTreeNodeInternal.isRawElementNode(child));
+      const modelEntry = getOrCreate({
+        map: modelElementsMap,
+        key: child.extendedData.modelId,
+        createFunc: () => ({
+          elementIds: new Set<ElementId>(),
+          childrenWhichAreParents: new Set<ElementId>(),
+          categoryOfTopMostParentElement: child.extendedData.categoryOfTopMostParentElement,
+        }),
+      });
+      const addId = child.children
+        ? (id: Id64String) => {
+            modelEntry.elementIds.add(id);
+            modelEntry.childrenWhichAreParents.add(id);
+          }
+        : (id: Id64String) => modelEntry.elementIds.add(id);
+      for (const { id } of child.key.instanceKeys) {
+        addId(id);
+      }
+    }
+
+    const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
+    const firstChild = node.children[0];
+    assert(CategoriesTreeNodeInternal.isRawElementNode(firstChild));
+    return {
+      ...node,
+      label: node.label,
+      extendedData: {
+        ...node.extendedData,
+        topMostParentElementId: firstChild.key.instanceKeys.every((instanceKey) => instanceKey.id !== firstChild.extendedData.topMostParentElementId)
+          ? firstChild.extendedData.topMostParentElementId
+          : undefined,
+        // add `categoryId` from the first grouped element
+        categoryId: firstChild.extendedData.categoryId,
+        modelElementsMap,
+        ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
+        ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
+        // `imageId` is assigned to instance nodes at query time, but grouping ones need to
+        // be handled during post-processing
+        imageId: "icon-ec-class",
+      },
+    };
   };
 
   private async getHierarchyDefinition(): Promise<HierarchyDefinition> {
@@ -266,9 +264,10 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     parentNode,
     nodeSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    if (CategoriesTreeNode.isDefinitionContainerNode(parentNode)) {
+    if (CategoriesTreeNodeInternal.isDefinitionContainerNode(parentNode)) {
       return [];
     }
+    assert(CategoriesTreeNodeInternal.isElementNode(parentNode), "Expected parent node to be element node");
     // note: we do not apply hierarchy level filtering on this hierarchy level, because it's always
     // hidden - the filter will get applied on the child hierarchy levels
     return [
@@ -306,7 +305,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory,
     instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const [instanceFilterClauses, categoryIds] = await Promise.all([
+    const [categoryInstanceFilterClauses, categoryIds] = await Promise.all([
       nodeSelectClauseFactory.createFilterClauses({
         filter: instanceFilter,
         contentClass: { fullName: this.#categoryClass, alias: "this" },
@@ -316,36 +315,25 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     if (categoryIds.length === 0) {
       return [];
     }
-
     return [
       {
         fullClassName: this.#categoryClass,
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
-                ecClassId: { selector: "this.ECClassId" },
-                ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: this.#categoryClass,
-                  }),
-                },
-                grouping: { byLabel: { action: "merge", groupId: "category" } },
+              ${await this.createCategoryNodeSelectClause({
+                nodeSelectClauseFactory,
+                instanceLabelSelectClauseFactory,
                 hasChildren: true,
                 extendedData: {
-                  imageId: "icon-layers",
-                  isCategory: true,
-                  modelIds: { selector: createIdsSelector(modelIds) },
                   isCategoryOfSubModel: true,
+                  modelIds: { selector: createIdsSelector(modelIds) },
                 },
-                supportsFiltering: true,
               })}
-            FROM ${instanceFilterClauses.from} this
+            FROM ${categoryInstanceFilterClauses.from} this
             JOIN IdSet(?) categoryIdSet ON categoryIdSet.id = this.ECInstanceId
-            ${instanceFilterClauses.joins}
-            ${instanceFilterClauses.where ? `WHERE ${instanceFilterClauses.where}` : ""}
+            ${categoryInstanceFilterClauses.joins}
+            ${categoryInstanceFilterClauses.where ? `WHERE ${categoryInstanceFilterClauses.where}` : ""}
             ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: categoryIds }],
@@ -369,7 +357,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     );
     const hierarchyDefinition = new Array<HierarchyNodesDefinition>();
     if (categories.length > 0) {
-      (await this.createCategoriesQuery({ categories, instanceFilter, instanceLabelSelectClauseFactory, nodeSelectClauseFactory })).forEach((def) =>
+      (await this.createTopMostCategoriesQuery({ categories, instanceFilter, instanceLabelSelectClauseFactory, nodeSelectClauseFactory })).forEach((def) =>
         hierarchyDefinition.push(def),
       );
     }
@@ -436,7 +424,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     ];
   }
 
-  private async createCategoriesQuery({
+  private async createTopMostCategoriesQuery({
     categories,
     instanceFilter,
     instanceLabelSelectClauseFactory,
@@ -447,35 +435,38 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
     nodeSelectClauseFactory: NodesQueryClauseFactory;
   }): Promise<HierarchyLevelDefinition> {
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
-      filter: instanceFilter,
-      contentClass: { fullName: this.#categoryClass, alias: "this" },
-    });
+    const [instanceFilterClauses, subModels] = await Promise.all([
+      nodeSelectClauseFactory.createFilterClauses({
+        filter: instanceFilter,
+        contentClass: { fullName: this.#categoryClass, alias: "this" },
+      }),
+      this.#hierarchyConfig.showElements ? firstValueFrom(this.#idsCache.getAllSubModels()) : new Set<ModelId>(),
+    ]);
     const categoriesWithMultipleSubCategories = categories
       .filter((categoryInfo) => categoryInfo.subCategoryChildCount > 1)
       .map((categoryInfo) => categoryInfo.id);
 
-    const hasChildrenSelector = () => {
-      const conditions = new Array<string>();
-      if (!this.#hierarchyConfig.hideSubCategories && categoriesWithMultipleSubCategories.length > 0) {
-        conditions.push(`InVirtualSet(?, this.ECInstanceId)`);
-      }
-      if (this.#hierarchyConfig.showElements) {
-        conditions.push(`
+    const conditions = new Array<string>();
+    if (!this.#hierarchyConfig.hideSubCategories && categoriesWithMultipleSubCategories.length > 0) {
+      conditions.push(`InVirtualSet(?, this.ECInstanceId)`);
+    }
+    if (this.#hierarchyConfig.showElements) {
+      conditions.push(`
           this.ECInstanceId IN (
             SELECT e.Category.Id
             FROM ${this.#categoryElementClass} e
             WHERE
               e.Parent.Id IS NULL
-              AND e.ECInstanceId NOT IN (SELECT m.ECInstanceId FROM ${this.#categoryModelClass} m)
+              ${subModels.size > 0 ? `AND NOT InVirtualSet(?, e.Model.Id)` : ""}
           )`);
-      }
-      return conditions.length > 0
+    }
+
+    const hasChildren =
+      conditions.length > 0
         ? {
             selector: `IIF(${conditions.join(" OR ")}, 1, 0)`,
           }
         : false;
-    };
 
     return [
       {
@@ -483,24 +474,16 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
-                ecClassId: { selector: ECSql.createRawPropertyValueSelector("this", "ECClassId") },
-                ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: this.#categoryClass,
-                  }),
-                },
-                hasChildren: hasChildrenSelector(),
+              ${await this.createCategoryNodeSelectClause({
+                nodeSelectClauseFactory,
+                instanceLabelSelectClauseFactory,
+                hasChildren,
                 extendedData: {
                   description: { selector: "this.Description" },
-                  isCategory: true,
-                  imageId: "icon-layers",
+                  modelIds: { selector: createIdsSelector(new Array<ModelId>()) },
                   hasSubCategories:
                     categoriesWithMultipleSubCategories.length > 0 ? { selector: "IIF(InVirtualSet(?, this.ECInstanceId), true, false)" } : false,
                 },
-                supportsFiltering: true,
               })}
             FROM ${instanceFilterClauses.from} this
             JOIN IdSet(?) categoryIdSet ON this.ECInstanceId = categoryIdSet.id
@@ -512,6 +495,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
             ...(!this.#hierarchyConfig.hideSubCategories && categoriesWithMultipleSubCategories.length > 0
               ? [{ type: "idset" as const, value: categoriesWithMultipleSubCategories }]
               : []),
+            ...(subModels.size > 0 ? [{ type: "idset" as const, value: [...subModels] }] : []),
             ...(categoriesWithMultipleSubCategories.length > 0 ? [{ type: "idset" as const, value: categoriesWithMultipleSubCategories }] : []),
             { type: "idset", value: categories.map((category) => category.id) },
           ],
@@ -576,6 +560,86 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     ];
   }
 
+  private async createElementNodeSelectClause({
+    nodeSelectClauseFactory,
+    instanceLabelSelectClauseFactory,
+    allSubModels,
+    extendedData,
+  }: {
+    nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
+    instanceLabelSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["instanceLabelSelectClauseFactory"];
+    allSubModels: Id64String[];
+    extendedData: Props<typeof nodeSelectClauseFactory.createSelectClause>["extendedData"];
+  }): Promise<{ selectClause: string; bindings: ECSqlBinding[] }> {
+    const selectClause = await nodeSelectClauseFactory.createSelectClause({
+      ecClassId: { selector: "this.ECClassId" },
+      ecInstanceId: { selector: "this.ECInstanceId" },
+      nodeLabel: {
+        selector: await instanceLabelSelectClauseFactory.createSelectClause({
+          classAlias: "this",
+          className: this.#categoryElementClass,
+        }),
+      },
+      hasChildren: {
+        selector: `
+          IFNULL(
+            (
+              SELECT 1
+              FROM ${this.#categoryElementClass} ce
+              WHERE ce.Parent.Id = this.ECInstanceId
+              LIMIT 1
+            ),
+            ${allSubModels.length ? "InVirtualSet(?, this.ECInstanceId)" : `0`}
+            )
+        `,
+      },
+      grouping: { byClass: true },
+      extendedData: {
+        modelId: { selector: "IdToHex(this.Model.Id)" },
+        categoryId: { selector: "IdToHex(this.Category.Id)" },
+        imageId: "icon-item",
+        isElement: true,
+        ...extendedData,
+      },
+      supportsFiltering: true,
+    });
+    return {
+      selectClause,
+      bindings: allSubModels.length > 0 ? [{ type: "idset", value: allSubModels }] : [],
+    };
+  }
+
+  private async createCategoryNodeSelectClause({
+    nodeSelectClauseFactory,
+    instanceLabelSelectClauseFactory,
+    extendedData,
+    hasChildren,
+  }: {
+    nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
+    instanceLabelSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["instanceLabelSelectClauseFactory"];
+    extendedData: Props<typeof nodeSelectClauseFactory.createSelectClause>["extendedData"];
+    hasChildren: boolean | { selector: string };
+  }): Promise<string> {
+    return nodeSelectClauseFactory.createSelectClause({
+      ecClassId: { selector: "this.ECClassId" },
+      ecInstanceId: { selector: "this.ECInstanceId" },
+      nodeLabel: {
+        selector: await instanceLabelSelectClauseFactory.createSelectClause({
+          classAlias: "this",
+          className: this.#categoryClass,
+        }),
+      },
+      grouping: { byLabel: { action: "merge", groupId: "category" } },
+      hasChildren,
+      extendedData: {
+        imageId: "icon-layers",
+        isCategory: true,
+        ...extendedData,
+      },
+      supportsFiltering: true,
+    });
+  }
+
   private async createCategoryElementsQuery({
     parentNodeInstanceIds: categoryIds,
     instanceFilter,
@@ -583,92 +647,57 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory,
     instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
-      filter: instanceFilter,
-      contentClass: { fullName: this.#categoryElementClass, alias: "this" },
-    });
-    const modelIds: Id64Array = parentNode.extendedData?.isCategoryOfSubModel
-      ? parseIdsSelectorResult(parentNode.extendedData?.modelIds)
-      : await firstValueFrom(
-          from(categoryIds).pipe(
-            mergeMap((categoryId) => this.#idsCache.getModels({ categoryId, subModels: "exclude" })),
-            mergeAll(),
-            distinct(),
-            toArray(),
-          ),
-        );
+    assert(CategoriesTreeNodeInternal.isCategoryNode(parentNode), "Expected category node as parent");
+    const [instanceFilterClauses, allSubModels] = await Promise.all([
+      nodeSelectClauseFactory.createFilterClauses({
+        filter: instanceFilter,
+        contentClass: { fullName: this.#categoryElementClass, alias: "this" },
+      }),
+      firstValueFrom(this.#idsCache.getAllSubModels()),
+    ]);
+    const modelIds: Id64Array =
+      parentNode.extendedData.modelIds.length > 0
+        ? parseIdsSelectorResult(parentNode.extendedData.modelIds)
+        : await firstValueFrom(
+            from(categoryIds).pipe(
+              mergeMap((categoryId) => this.#idsCache.getModels({ categoryId })),
+              filter(({ isSubModel }) => !isSubModel), // sub-models are handled as separate nodes, so we need to filter them out here
+              map(({ id }) => id),
+              distinct(),
+              toArray(),
+            ),
+          );
 
     if (modelIds.length === 0) {
       return [];
     }
-    const modeledElements = await firstValueFrom(
-      from(modelIds).pipe(
-        mergeMap((modelId) =>
-          from(categoryIds).pipe(
-            mergeMap((categoryId) => this.#idsCache.getSubModels({ modelId, categoryId })),
-            mergeAll(),
-          ),
-        ),
-        toArray(),
-      ),
-    );
+    const { selectClause, bindings } = await this.createElementNodeSelectClause({
+      nodeSelectClauseFactory,
+      instanceLabelSelectClauseFactory,
+      allSubModels: [...allSubModels],
+      extendedData: {
+        categoryOfTopMostParentElement: { selector: "IdToHex(this.Category.Id)" },
+        topMostParentElementId: { selector: "IdToHex(this.ECInstanceId)" },
+      },
+    });
     return [
       {
         fullClassName: this.#categoryElementClass,
         query: {
           ecsql: `
             SELECT
-            ${await nodeSelectClauseFactory.createSelectClause({
-              ecClassId: { selector: "this.ECClassId" },
-              ecInstanceId: { selector: "this.ECInstanceId" },
-              nodeLabel: {
-                selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                  classAlias: "this",
-                  className: this.#categoryElementClass,
-                }),
-              },
-              hasChildren: {
-                selector: `
-                  IIF(
-                    ${modeledElements.length ? "InVirtualSet(?, this.ECInstanceId)" : "FALSE"},
-                    1,
-                    IFNULL((
-                      SELECT 1
-                      FROM ${this.#categoryElementClass} ce
-                      WHERE ce.Parent.Id = this.ECInstanceId
-                      LIMIT 1
-                    ), 0)
-                  )
-                `,
-              },
-              grouping: {
-                byClass: true,
-              },
-              extendedData: {
-                modelId: { selector: "IdToHex(this.Model.Id)" },
-                categoryId: { selector: "IdToHex(this.Category.Id)" },
-                imageId: "icon-item",
-                isElement: true,
-                categoryOfTopMostParentElement: { selector: "IdToHex(this.Category.Id)" },
-                topMostParentElementId: { selector: "IdToHex(this.ECInstanceId)" },
-              },
-              supportsFiltering: true,
-            })}
-          FROM ${instanceFilterClauses.from} this
-          JOIN IdSet(?) categoryIdSet ON this.Category.Id = categoryIdSet.id
-          JOIN IdSet(?) modelIdSet ON this.Model.Id = modelIdSet.id
-          ${parentNode.extendedData?.isCategoryOfSubModel ? "" : `JOIN ${CLASS_NAME_InformationPartitionElement} ipe ON ipe.ECInstanceId = this.Model.Id`}
-          ${instanceFilterClauses.joins}
-          WHERE
-            this.Parent.Id IS NULL
-            ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
-          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
-          `,
-          bindings: [
-            ...(modeledElements.length > 0 ? [{ type: "idset" as const, value: modeledElements }] : []),
-            { type: "idset", value: categoryIds },
-            { type: "idset", value: modelIds },
-          ],
+              ${selectClause}
+            FROM ${instanceFilterClauses.from} this
+            JOIN IdSet(?) categoryIdSet ON this.Category.Id = categoryIdSet.id
+            JOIN IdSet(?) modelIdSet ON this.Model.Id = modelIdSet.id
+            ${parentNode.extendedData?.isCategoryOfSubModel ? "" : `JOIN ${CLASS_NAME_InformationPartitionElement} ipe ON ipe.ECInstanceId = this.Model.Id`}
+            ${instanceFilterClauses.joins}
+            WHERE
+              this.Parent.Id IS NULL
+              ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
+            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
+            `,
+          bindings: [...bindings, { type: "idset", value: categoryIds }, { type: "idset", value: modelIds }],
         },
       },
     ];
@@ -681,9 +710,26 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory,
     instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
-      filter: instanceFilter,
-      contentClass: { fullName: this.#categoryElementClass, alias: "this" },
+    assert(CategoriesTreeNodeInternal.isElementNode(parentNode), "Expected parent node to be element node");
+
+    const [elementInstanceFilterClauses, allSubModels] = await Promise.all([
+      nodeSelectClauseFactory.createFilterClauses({
+        filter: instanceFilter,
+        contentClass: { fullName: this.#categoryElementClass, alias: "this" },
+      }),
+      firstValueFrom(this.#idsCache.getAllSubModels()),
+    ]);
+
+    const { selectClause, bindings } = await this.createElementNodeSelectClause({
+      nodeSelectClauseFactory,
+      instanceLabelSelectClauseFactory,
+      allSubModels: [...allSubModels],
+      extendedData: {
+        categoryOfTopMostParentElement: {
+          selector: `IdToHex(${parentNode.extendedData?.categoryOfTopMostParentElement})`,
+        },
+        topMostParentElementId: { selector: `IdToHex(${parentNode.extendedData?.topMostParentElementId})` },
+      },
     });
     return [
       {
@@ -691,48 +737,14 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
-                ecClassId: { selector: "this.ECClassId" },
-                ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: this.#categoryElementClass,
-                  }),
-                },
-                hasChildren: {
-                  selector: `
-                    IFNULL((
-                      SELECT 1
-                      FROM ${this.#categoryElementClass} ce
-                      JOIN ${CLASS_NAME_Model} m ON ce.Model.Id = m.ECInstanceId
-                      WHERE ce.Parent.Id = this.ECInstanceId OR (ce.Model.Id = this.ECInstanceId AND m.IsPrivate = false)
-                      LIMIT 1
-                    ), 0)
-                  `,
-                },
-                grouping: {
-                  byClass: true,
-                },
-                extendedData: {
-                  modelId: { selector: "IdToHex(this.Model.Id)" },
-                  categoryId: { selector: "IdToHex(this.Category.Id)" },
-                  imageId: "icon-item",
-                  isElement: true,
-                  categoryOfTopMostParentElement: {
-                    selector: `IdToHex(${parentNode.extendedData?.categoryOfTopMostParentElement})`,
-                  },
-                  topMostParentElementId: { selector: `IdToHex(${parentNode.extendedData?.topMostParentElementId})` },
-                },
-                supportsFiltering: true,
-              })}
-            FROM ${instanceFilterClauses.from} this
+              ${selectClause}
+            FROM ${elementInstanceFilterClauses.from} this
             JOIN IdSet(?) elementIdSet ON this.Parent.Id = elementIdSet.id
-            ${instanceFilterClauses.joins}
-            ${instanceFilterClauses.where ? `WHERE ${instanceFilterClauses.where}` : ""}
+            ${elementInstanceFilterClauses.joins}
+            ${elementInstanceFilterClauses.where ? `WHERE ${elementInstanceFilterClauses.where}` : ""}
             ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
-          bindings: [{ type: "idset", value: elementIds }],
+          bindings: [...bindings, { type: "idset", value: elementIds }],
         },
       },
     ];
@@ -1049,64 +1061,70 @@ export function createGeometricElementInstanceKeyPaths(props: {
     return EMPTY;
   }
 
-  return defer(() => {
-    const ctes = [
-      `CategoriesElementsHierarchy(ECInstanceId, ParentId, ModelId, Path) AS (
-        SELECT
-          e.ECInstanceId,
-          e.Parent.Id,
-          e.Model.Id,
-          IIF(e.Parent.Id IS NULL,
-            '${MODEL_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([m].[ECInstanceId]) AS TEXT) || '${separator}${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([c].[ECInstanceId]) AS TEXT) || '${separator}${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([e].[ECInstanceId]) AS TEXT),
+  return props.idsCache.getAllSubModels().pipe(
+    mergeMap((subModelIds) => {
+      const ctes = [
+        `CategoriesElementsHierarchy(ECInstanceId, ParentId, ModelId, CategoryId, Path) AS (
+          SELECT
+            e.ECInstanceId,
+            e.Parent.Id,
+            e.Model.Id,
+            e.Category.Id,
             '${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([e].[ECInstanceId]) AS TEXT)
-          )
-        FROM ${elementClass} e
-        JOIN IdSet(?) targetItemIdSet ON e.ECInstanceId = targetItemIdSet.id
-        LEFT JOIN ${modelClass} m ON (e.Parent.Id IS NULL AND m.ECInstanceId = e.Model.Id)
-        LEFT JOIN ${categoryClass} c ON (e.Parent.Id IS NULL AND c.ECInstanceId = e.Category.Id)
-        ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
+          FROM ${elementClass} e
+          JOIN IdSet(?) targetItemIdSet ON e.ECInstanceId = targetItemIdSet.id
+          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
-        UNION ALL
+          UNION ALL
 
-        SELECT
-          pe.ECInstanceId,
-          pe.Parent.Id,
-          pe.Model.Id,
-          IIF(pe.Parent.Id IS NULL,
-            '${MODEL_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([m].[ECInstanceId]) AS TEXT) || '${separator}${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([c].[ECInstanceId]) AS TEXT) || '${separator}${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([pe].[ECInstanceId]) AS TEXT) || '${separator}' || ce.Path,
-            '${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([pe].[ECInstanceId]) AS TEXT) || '${separator}' || ce.Path
-          )
-        FROM CategoriesElementsHierarchy ce
-        JOIN ${elementClass} pe ON (pe.ECInstanceId = ce.ParentId OR pe.ECInstanceId = ce.ModelId AND ce.ParentId IS NULL)
-        LEFT JOIN ${modelClass} m ON (pe.Parent.Id IS NULL AND m.ECInstanceId = pe.Model.Id)
-        LEFT JOIN ${categoryClass} c ON (pe.Parent.Id IS NULL AND c.ECInstanceId = pe.Category.Id)
-      )`,
-    ];
-    const ecsql = `
-      SELECT mce.Path
-      FROM CategoriesElementsHierarchy mce
-      WHERE mce.ParentId IS NULL
-    `;
+          SELECT
+            pe.ECInstanceId,
+            pe.Parent.Id,
+            pe.Model.Id,
+            pe.Category.Id,
+            (
+              '${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}'
+              || CAST(IdToHex([pe].[ECInstanceId]) AS TEXT)
+              || IIF(ce.ParentId IS NULL,
+                  '${separator}${MODEL_CLASS_NAME_QUERY_ALIAS}${separator}'
+                  || CAST(IdToHex([ce].[ModelId]) AS TEXT)
+                  || '${separator}${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}'
+                  || CAST(IdToHex(ce.CategoryId) AS TEXT),
+                  ''
+                )
+              || '${separator}'
+              || ce.Path
+            )
+          FROM CategoriesElementsHierarchy ce
+          JOIN ${elementClass} pe ON (pe.ECInstanceId = ce.ParentId OR pe.ECInstanceId = ce.ModelId AND ce.ParentId IS NULL)
+        )`,
+      ];
+      const ecsql = `
+        SELECT '${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([mce].[CategoryId]) AS TEXT) || '${separator}' || mce.Path
+        FROM CategoriesElementsHierarchy mce
+        WHERE mce.ParentId IS NULL ${subModelIds.size > 0 ? `AND NOT InVirtualSet(?, mce.ModelId)` : ""}
+      `;
 
-    return queryExecutor.createQueryReader(
-      { ctes, ecsql, bindings: [{ type: "idset", value: targetItems }] },
-      { rowFormat: "Indexes", limit: "unbounded", restartToken: `${componentName}/${componentId}/element-paths/${chunkIndex}` },
-    );
-  }).pipe(
+      return queryExecutor.createQueryReader(
+        {
+          ctes,
+          ecsql,
+          bindings: [{ type: "idset", value: targetItems }, ...(subModelIds.size > 0 ? [{ type: "idset" as const, value: [...subModelIds] }] : [])],
+        },
+        { rowFormat: "Indexes", limit: "unbounded", restartToken: `${componentName}/${componentId}/element-paths/${chunkIndex}` },
+      );
+    }),
     catchBeSQLiteInterrupts,
     targetItems.length > 300 ? releaseMainThreadOnItemsCount(300) : identity,
     map((row) => parseQueryRow(row, separator, elementClass, categoryClass, modelClass)),
     mergeMap((elementHierarchyPath) =>
-      forkJoin({
-        elementHierarchyPath: of(elementHierarchyPath),
-        pathToCategory: idsCache.getCategoriesSearchPaths({ categoryIds: elementHierarchyPath[0].id, includePathsWithSubModels: false }),
-      }),
+      idsCache.getSearchPathsUpToRootCategory({ categoryId: elementHierarchyPath[0].id }).pipe(
+        map((pathUpToCategory) => {
+          const path = [...pathUpToCategory, ...elementHierarchyPath];
+          return { path, target: elementHierarchyPath[elementHierarchyPath.length - 1].id };
+        }),
+      ),
     ),
-    map(({ elementHierarchyPath, pathToCategory }) => {
-      pathToCategory.pop(); // category is already included in the element hierarchy path
-      const path = [...pathToCategory, ...elementHierarchyPath];
-      return { path, target: elementHierarchyPath[elementHierarchyPath.length - 1].id };
-    }),
   );
 }
 
@@ -1117,22 +1135,18 @@ function parseQueryRow(
   categoryClassName: EC.FullClassName,
   modelClassName: EC.FullClassName,
 ) {
-  const rowElements: string[] = row[0].split(separator);
+  const queriedPath: string[] = row[0].split(separator);
   const path = new Array<InstanceKey>();
-  for (let i = 0; i < rowElements.length; i += 2) {
-    switch (rowElements[i]) {
+  for (let i = 0; i < queriedPath.length; i += 2) {
+    switch (queriedPath[i]) {
       case ELEMENT_CLASS_NAME_QUERY_ALIAS:
-        path.push({ className: elementClassName, id: rowElements[i + 1] });
+        path.push({ className: elementClassName, id: queriedPath[i + 1] });
         break;
       case CATEGORY_CLASS_NAME_QUERY_ALIAS:
-        path.push({ className: categoryClassName, id: rowElements[i + 1] });
+        path.push({ className: categoryClassName, id: queriedPath[i + 1] });
         break;
       case MODEL_CLASS_NAME_QUERY_ALIAS:
-        // Ignore first model since it isn't in hierarchy
-        if (i === 0) {
-          break;
-        }
-        path.push({ className: modelClassName, id: rowElements[i + 1] });
+        path.push({ className: modelClassName, id: queriedPath[i + 1] });
         break;
     }
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -160,6 +160,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
       {
         elementIds: Set<ElementId>;
         childrenWhichAreParents: Set<ElementId>;
+        categoryOfTopMostParentElement: CategoryId;
       }
     >();
     for (const child of node.children) {
@@ -569,7 +570,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
     instanceLabelSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["instanceLabelSelectClauseFactory"];
     allSubModels: Id64String[];
-    extendedData: Props<typeof nodeSelectClauseFactory.createSelectClause>["extendedData"];
+    extendedData: Props<DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["extendedData"];
   }): Promise<{ selectClause: string; bindings: ECSqlBinding[] }> {
     const selectClause = await nodeSelectClauseFactory.createSelectClause({
       ecClassId: { selector: "this.ECClassId" },
@@ -617,7 +618,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
   }: {
     nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
     instanceLabelSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["instanceLabelSelectClauseFactory"];
-    extendedData: Props<typeof nodeSelectClauseFactory.createSelectClause>["extendedData"];
+    extendedData: Props<DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["extendedData"];
     hasChildren: boolean | { selector: string };
   }): Promise<string> {
     return nodeSelectClauseFactory.createSelectClause({
@@ -634,6 +635,8 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
       extendedData: {
         imageId: "icon-layers",
         isCategory: true,
+        isCategoryOfSubModel: false,
+        modelIds: { selector: createIdsSelector(new Array<ModelId>()) },
         ...extendedData,
       },
       supportsFiltering: true,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeIdsCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defer, EMPTY, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, shareReplay, toArray } from "rxjs";
+import { defer, EMPTY, filter, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, shareReplay, toArray } from "rxjs";
 import { Guid, Id64 } from "@itwin/core-bentley";
 import { BaseIdsCacheImpl } from "../../common/internal/caches/BaseIdsCache.js";
 import { CLASS_NAME_DefinitionContainer, CLASS_NAME_Model, CLASS_NAME_SubCategory } from "../../common/internal/ClassNameDefinitions.js";
@@ -12,7 +12,7 @@ import { fromWithRelease, getClassesByView, getOrCreate } from "../../common/int
 import { createGeometricElementInstanceKeyPaths } from "../CategoriesTreeDefinition.js";
 
 import type { Observable } from "rxjs";
-import type { GuidString, Id64Arg, Id64Array, Id64Set, Id64String } from "@itwin/core-bentley";
+import type { GuidString, Id64Arg, Id64Array, Id64String } from "@itwin/core-bentley";
 import type { HierarchyNodeIdentifiersPath, LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 import type { EC } from "@itwin/presentation-shared";
 import type { BaseIdsCacheImplProps } from "../../common/internal/caches/BaseIdsCache.js";
@@ -36,6 +36,7 @@ export interface CategoryInfo {
   id: CategoryId;
   subCategoryChildCount: number;
   hasElements: boolean;
+  isTopMostElementCategory: boolean;
 }
 
 interface CategoriesTreeIdsCacheProps extends BaseIdsCacheImplProps {
@@ -46,7 +47,12 @@ interface CategoriesTreeIdsCacheProps extends BaseIdsCacheImplProps {
 /** @internal */
 export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
   #definitionContainersInfo: Observable<Map<DefinitionContainerId, DefinitionContainerInfo>> | undefined;
-  #modelsCategoriesInfo: Observable<Map<ModelId, CategoriesInfo>> | undefined;
+  #cachedCategoryData:
+    | Observable<{
+        categoriesGroupedByModel: Map<ModelId, CategoriesInfo>;
+        categoriesWithModel: Map<CategoryId, { modelId: ModelId; isDefinitionContainer: boolean }>;
+      }>
+    | undefined;
   #definitionContainerInstanceKeyPaths: Map<DefinitionContainerId, Observable<HierarchyNodeIdentifiersPath>> = new Map();
   #categoryClass: EC.FullClassName;
   #categoryElementClass: EC.FullClassName;
@@ -122,6 +128,7 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     parentDefinitionContainerExists: boolean;
     subCategoryChildCount: number;
     hasElements: boolean;
+    isTopMostElementCategory: boolean;
   }> {
     return this.getIsDefinitionContainerSupported().pipe(
       mergeMap((isDefinitionContainerSupported) =>
@@ -143,7 +150,11 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
               IFNULL(
                 (SELECT 1 FROM ${this.#categoryElementClass} e WHERE e.Category.Id = this.ECInstanceId LIMIT 1),
                 0
-              ) hasElements
+              ) hasElements,
+              IFNULL(
+                (SELECT 1 FROM ${this.#categoryElementClass} e WHERE e.Category.Id = this.ECInstanceId AND e.Parent.Id IS NULL LIMIT 1),
+                0
+              ) isTopMostElementCategory
             FROM
               ${this.#categoryClass} this
               JOIN ${CLASS_NAME_SubCategory} sc ON sc.Parent.Id = this.ECInstanceId
@@ -166,6 +177,7 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
               parentDefinitionContainerExists: row.parentDefinitionContainerExists,
               subCategoryChildCount: row.subCategoryChildCount,
               hasElements: !!row.hasElements,
+              isTopMostElementCategory: !!row.isTopMostElementCategory,
             };
           }),
         ),
@@ -258,44 +270,56 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     );
   }
 
-  private getModelsCategoriesInfo() {
-    this.#modelsCategoriesInfo ??= this.queryCategories()
+  private getCachedCategoryData() {
+    this.#cachedCategoryData ??= this.queryCategories()
       .pipe(
-        reduce((acc, queriedCategory) => {
-          const modelCategories = getOrCreate({
-            map: acc,
-            key: queriedCategory.modelId,
-            createFunc: () => ({
-              parentDefinitionContainerExists: queriedCategory.parentDefinitionContainerExists,
-              childCategories: [] as { id: string; subCategoryChildCount: number; hasElements: boolean }[],
-            }),
-          });
-          modelCategories.childCategories.push({
-            id: queriedCategory.id,
-            subCategoryChildCount: queriedCategory.subCategoryChildCount,
-            hasElements: queriedCategory.hasElements,
-          });
-          return acc;
-        }, new Map<ModelId, CategoriesInfo>()),
+        reduce(
+          (acc, queriedCategory) => {
+            const modelCategories = getOrCreate({
+              map: acc.categoriesGroupedByModel,
+              key: queriedCategory.modelId,
+              createFunc: () => ({
+                parentDefinitionContainerExists: queriedCategory.parentDefinitionContainerExists,
+                childCategories: new Array<CategoryInfo>(),
+              }),
+            });
+            modelCategories.childCategories.push({
+              id: queriedCategory.id,
+              subCategoryChildCount: queriedCategory.subCategoryChildCount,
+              hasElements: queriedCategory.hasElements,
+              isTopMostElementCategory: queriedCategory.isTopMostElementCategory,
+            });
+            acc.categoriesWithModel.set(queriedCategory.id, {
+              modelId: queriedCategory.modelId,
+              isDefinitionContainer: queriedCategory.parentDefinitionContainerExists,
+            });
+            return acc;
+          },
+          {
+            categoriesGroupedByModel: new Map<ModelId, CategoriesInfo>(),
+            categoriesWithModel: new Map<CategoryId, { modelId: ModelId; isDefinitionContainer: boolean }>(),
+          },
+        ),
       )
       .pipe(shareReplay());
-    return this.#modelsCategoriesInfo;
+    return this.#cachedCategoryData;
   }
 
   private getDefinitionContainersInfo() {
     this.#definitionContainersInfo ??= forkJoin({
       isDefinitionContainerSupported: this.getIsDefinitionContainerSupported(),
-      modelsCategoriesInfo: this.getModelsCategoriesInfo(),
+      cachedCategoryData: this.getCachedCategoryData(),
     })
       .pipe(
-        mergeMap(({ isDefinitionContainerSupported, modelsCategoriesInfo }) => {
+        mergeMap(({ isDefinitionContainerSupported, cachedCategoryData }) => {
           const definitionContainersInfo = new Map<DefinitionContainerId, DefinitionContainerInfo>();
-          if (!isDefinitionContainerSupported || modelsCategoriesInfo.size === 0) {
+          const categoriesGroupedByModel = cachedCategoryData.categoriesGroupedByModel;
+          if (!isDefinitionContainerSupported || categoriesGroupedByModel.size === 0) {
             return of(definitionContainersInfo);
           }
           return this.queryDefinitionContainers().pipe(
             reduce((acc, queriedDefinitionContainer) => {
-              const modelCategoriesInfo = modelsCategoriesInfo.get(queriedDefinitionContainer.id);
+              const modelCategoriesInfo = categoriesGroupedByModel.get(queriedDefinitionContainer.id);
               acc.set(queriedDefinitionContainer.id, {
                 childCategories: modelCategoriesInfo?.childCategories ?? [],
                 modelId: queriedDefinitionContainer.modelId,
@@ -354,45 +378,27 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
 
   public getAllContainedCategories({
     definitionContainerIds,
-    includeEmptyCategories,
   }: {
     definitionContainerIds: Id64Arg;
-    includeEmptyCategories?: boolean;
-  }): Observable<Id64Set> {
+  }): Observable<{ id: CategoryId; hasElements: boolean; isTopMostElementCategory: boolean }> {
     return this.getDefinitionContainersInfo().pipe(
       mergeMap((definitionContainersInfo) =>
         from(Id64.iterable(definitionContainerIds)).pipe(
-          mergeMap((definitionContainerId) => {
+          mergeMap((definitionContainerId): Observable<{ id: CategoryId; hasElements: boolean; isTopMostElementCategory: boolean }> => {
             const definitionContainerInfo = definitionContainersInfo.get(definitionContainerId);
             if (definitionContainerInfo === undefined) {
-              return of({ directCategories: undefined, indirectCategories: undefined });
+              return EMPTY;
             }
             const childDefinitionContainerIds = definitionContainerInfo.childDefinitionContainers.map(({ id }) => id);
-            return (
+            return merge(
               childDefinitionContainerIds.length > 0
                 ? this.getAllContainedCategories({
                     definitionContainerIds: childDefinitionContainerIds,
-                    includeEmptyCategories,
                   })
-                : of(new Set<CategoryId>())
-            ).pipe(
-              map((indirectCategories) => {
-                return {
-                  directCategories: applyElementsFilter(definitionContainerInfo.childCategories, includeEmptyCategories).map((category) => category.id),
-                  indirectCategories,
-                };
-              }),
+                : EMPTY,
+              from(definitionContainerInfo.childCategories),
             );
           }),
-          reduce((acc, { directCategories, indirectCategories }) => {
-            for (const categoryId of directCategories ?? []) {
-              acc.add(categoryId);
-            }
-            for (const categoryId of indirectCategories ?? []) {
-              acc.add(categoryId);
-            }
-            return acc;
-          }, new Set<CategoryId>()),
         ),
       ),
     );
@@ -411,8 +417,12 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
             if (!subCategories || subCategories.length <= 1) {
               return of([]);
             }
-            return this.getCategoriesSearchPaths({ categoryIds: categoryOfSubCategory, includePathsWithSubModels: false }).pipe(
-              map((pathToCategory) => [...pathToCategory, { id: subCategoryId, className: CLASS_NAME_SubCategory }]),
+            return this.getSearchPathsUpToRootCategory({ categoryId: categoryOfSubCategory }).pipe(
+              map((pathsUpToCategory) => [
+                ...pathsUpToCategory,
+                { id: categoryOfSubCategory, className: this.#categoryClass },
+                { id: subCategoryId, className: CLASS_NAME_SubCategory },
+              ]),
             );
           }),
         ),
@@ -452,6 +462,27 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     );
   }
 
+  public getSearchPathsUpToRootCategory({ categoryId }: { categoryId: Id64String }): Observable<HierarchyNodeIdentifiersPath> {
+    return this.getCachedCategoryData().pipe(
+      mergeMap(({ categoriesWithModel, categoriesGroupedByModel }) => {
+        if (categoriesGroupedByModel.size === 0) {
+          return EMPTY;
+        }
+        if (categoriesWithModel.size === 0) {
+          return EMPTY;
+        }
+        const entry = categoriesWithModel.get(categoryId);
+        if (!entry) {
+          return EMPTY;
+        }
+        if (!entry.isDefinitionContainer) {
+          return of([]);
+        }
+        return this.getDefinitionContainersSearchPaths({ definitionContainerIds: entry.modelId });
+      }),
+    );
+  }
+
   public getCategoriesSearchPaths({
     categoryIds,
     includePathsWithSubModels,
@@ -462,7 +493,14 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     const pathsWithSubModels = includePathsWithSubModels
       ? fromWithRelease({ source: categoryIds, releaseOnCount: 200 }).pipe(
           mergeMap((id) =>
-            forkJoin({ id: of(id), subModels: this.getModels({ subModels: "only", categoryId: id, includeOnlyIfCategoryOfTopMostElement: true }) }),
+            forkJoin({
+              id: of(id),
+              subModels: this.getModels({ categoryId: id }).pipe(
+                filter(({ categoryIsOfTopMostElement, isSubModel }) => isSubModel && categoryIsOfTopMostElement),
+                map(({ id: modelId }) => modelId),
+                toArray(),
+              ),
+            }),
           ),
           reduce((acc, { id, subModels }) => {
             for (const subModelId of subModels) {
@@ -500,11 +538,11 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
         )
       : EMPTY;
 
-    const pathsWithoutSubModels = this.getModelsCategoriesInfo().pipe(
-      mergeMap((modelsCategoriesInfo) =>
+    const pathsWithoutSubModels = this.getCachedCategoryData().pipe(
+      mergeMap(({ categoriesGroupedByModel }) =>
         fromWithRelease({ source: categoryIds, releaseOnCount: 200 }).pipe(
           mergeMap((categoryId) => {
-            for (const [modelId, modelCategoriesInfo] of modelsCategoriesInfo) {
+            for (const [modelId, modelCategoriesInfo] of categoriesGroupedByModel) {
               if (modelCategoriesInfo.childCategories.find((childCategory) => childCategory.id === categoryId)) {
                 const instanceKey = { id: categoryId, className: this.#categoryClass };
                 if (!modelCategoriesInfo.parentDefinitionContainerExists) {
@@ -528,8 +566,8 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     includeEmpty?: boolean;
   }): Observable<{ categories: Array<CategoryId>; definitionContainers: Array<DefinitionContainerId> }> {
     return forkJoin({
-      categories: this.getModelsCategoriesInfo().pipe(
-        mergeMap((modelsCategoriesInfo) => modelsCategoriesInfo.values()),
+      categories: this.getCachedCategoryData().pipe(
+        mergeMap(({ categoriesGroupedByModel }) => categoriesGroupedByModel.values()),
         reduce((acc, modelCategoriesInfo) => {
           applyElementsFilter(modelCategoriesInfo.childCategories, props?.includeEmpty).forEach((categoryInfo) => acc.push(categoryInfo.id));
           return acc;
@@ -551,8 +589,8 @@ export class CategoriesTreeIdsCache extends BaseIdsCacheImpl {
     includeEmpty?: boolean;
   }): Observable<{ categories: CategoryInfo[]; definitionContainers: Array<DefinitionContainerId> }> {
     return forkJoin({
-      categories: this.getModelsCategoriesInfo().pipe(
-        mergeMap((modelsCategoriesInfo) => modelsCategoriesInfo.values()),
+      categories: this.getCachedCategoryData().pipe(
+        mergeMap(({ categoriesGroupedByModel }) => categoriesGroupedByModel.values()),
         reduce((acc, modelCategoriesInfo) => {
           if (!modelCategoriesInfo.parentDefinitionContainerExists) {
             applyElementsFilter(modelCategoriesInfo.childCategories, props?.includeEmpty).forEach((categoryInfo) => acc.push(categoryInfo));

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeNodeInternal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/CategoriesTreeNodeInternal.ts
@@ -22,18 +22,13 @@ export namespace CategoriesTreeNodeInternal {
   export const isCategoryNode = (
     node: Pick<HierarchyNode, "extendedData">,
   ): node is Omit<NonGroupingHierarchyNode, "extendedData"> & { key: InstancesNodeKey } & {
-    extendedData: {
-      description?: string;
-      hasSubCategories?: boolean;
-    } & (
-      | {
-          isCategoryOfSubModel?: false;
-        }
-      | {
-          modelIds: Id64Array;
-          isCategoryOfSubModel: true;
-        }
-    );
+    extendedData: CategoryNodeProps;
+  } => CategoriesTreeNode.isCategoryNode(node);
+
+  export const isRawCategoryNode = (
+    node: Pick<HierarchyNode, "extendedData">,
+  ): node is Omit<NonGroupingHierarchyNode, "extendedData"> & { key: InstancesNodeKey } & {
+    extendedData: Pick<CategoryNodeProps, "description" | "hasSubCategories"> & { [key: string]: any };
   } => CategoriesTreeNode.isCategoryNode(node);
 
   export const isModelNode = (node: Pick<HierarchyNode, "extendedData">): node is NonGroupingHierarchyNode & { key: InstancesNodeKey } =>
@@ -42,23 +37,49 @@ export namespace CategoriesTreeNodeInternal {
   export const isElementNode = (
     node: Pick<HierarchyNode, "extendedData">,
   ): node is Omit<NonGroupingHierarchyNode, "extendedData"> & { key: InstancesNodeKey } & {
-    extendedData: {
-      modelId: Id64String;
-      categoryId: Id64String;
-      categoryOfTopMostParentElement: Id64String;
-      topMostParentElementId: Id64String;
-    };
+    extendedData: ElementNodeProps;
+  } => CategoriesTreeNode.isElementNode(node);
+
+  export const isRawElementNode = (
+    node: Pick<HierarchyNode, "extendedData">,
+  ): node is Omit<NonGroupingHierarchyNode, "extendedData"> & { key: InstancesNodeKey } & {
+    extendedData: ElementNodeProps & { [key: string]: any };
   } => CategoriesTreeNode.isElementNode(node);
 
   export const isElementClassGroupingNode = (
     node: Pick<HierarchyNode, "key">,
   ): node is Omit<GroupingHierarchyNode, "extendedData"> & { key: ClassGroupingNodeKey } & {
-    extendedData: {
-      categoryId: Id64String;
-      topMostParentElementId?: Id64String;
-      modelElementsMap: Map<Id64String, { elementIds: Set<Id64String>; categoryOfTopMostParentElement: Id64String; childrenWhichAreParents: Set<ElementId> }>;
-    };
+    extendedData: ElementClassGroupingNodeProps;
   } => CategoriesTreeNode.isElementClassGroupingNode(node);
 
   export const isSubCategoryNode = CategoriesTreeNode.isSubCategoryNode;
+}
+
+/** @internal */
+export interface CategoryNodeProps {
+  description?: string;
+  hasSubCategories?: boolean;
+  modelIds: Id64Array;
+  isCategoryOfSubModel: boolean;
+}
+
+/**
+ * @internal
+ */
+export interface ElementNodeProps {
+  modelId: Id64String;
+  categoryId: Id64String;
+  categoryOfTopMostParentElement: Id64String;
+  topMostParentElementId: Id64String;
+}
+
+/**
+ * @internal
+ */
+export interface ElementClassGroupingNodeProps {
+  categoryId: Id64String;
+  topMostParentElementId?: Id64String;
+  modelElementsMap: Map<Id64String, { elementIds: Set<Id64String>; categoryOfTopMostParentElement: Id64String; childrenWhichAreParents: Set<ElementId> }>;
+  hasDirectNonSearchTargets?: boolean;
+  hasSearchTargetAncestor?: boolean;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/UseSearchPaths.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/UseSearchPaths.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { useEffect, useMemo, useState } from "react";
-import { firstValueFrom } from "rxjs";
+import { filter, firstValueFrom, identity, tap } from "rxjs";
 import { assert } from "@itwin/core-bentley";
 import { HierarchyNodeIdentifier, HierarchySearchTree } from "@itwin/presentation-hierarchies";
 import { CLASS_NAME_DefinitionContainer, CLASS_NAME_SubCategory } from "../../common/internal/ClassNameDefinitions.js";
+import { toVoidPromise } from "../../common/internal/Rxjs.js";
 import { getClassesByView, getOrCreate } from "../../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../../common/TreeErrors.js";
 import { useTelemetryContext } from "../../common/UseTelemetryContext.js";
@@ -143,14 +144,16 @@ async function getCategoriesFromPaths(
     }
 
     if (identifier.className === CLASS_NAME_DefinitionContainer) {
-      const definitionContainerCategories = await firstValueFrom(
-        idsCache.getAllContainedCategories({ definitionContainerIds: identifier.id, includeEmptyCategories: hierarchyConfig.showEmptyCategories }),
+      await toVoidPromise(
+        idsCache.getAllContainedCategories({ definitionContainerIds: identifier.id }).pipe(
+          hierarchyConfig.showEmptyCategories ? identity : filter(({ hasElements }) => hasElements),
+          tap(({ id }) => {
+            if (!categories.has(id)) {
+              categories.set(id, []);
+            }
+          }),
+        ),
       );
-      for (const categoryId of definitionContainerCategories) {
-        if (!categories.has(categoryId)) {
-          categories.set(categoryId, []);
-        }
-      }
       return;
     }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.ts
@@ -153,10 +153,17 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
     }
 
     if (CategoriesTreeNodeInternal.isCategoryNode(node)) {
-      return this.#visibilityHelper.getCategoriesVisibilityStatus({
-        categoryIds: node.key.instanceKeys.map((instanceKey) => instanceKey.id),
-        modelId: node.extendedData.isCategoryOfSubModel ? node.extendedData.modelIds[0] : undefined,
-      });
+      const modelIds = node.extendedData.modelIds.length > 0 ? node.extendedData.modelIds : [undefined];
+      const categoryIds = node.key.instanceKeys.map((instanceKey) => instanceKey.id);
+      return from(modelIds).pipe(
+        mergeMap((modelId) =>
+          this.#visibilityHelper.getCategoriesVisibilityStatus({
+            categoryIds,
+            modelId,
+          }),
+        ),
+        mergeVisibilityStatuses(),
+      );
     }
 
     if (CategoriesTreeNodeInternal.isSubCategoryNode(node)) {
@@ -212,11 +219,17 @@ export class CategoriesTreeVisibilityHandler implements Disposable, TreeSpecific
       }
 
       if (CategoriesTreeNodeInternal.isCategoryNode(node)) {
-        return this.#visibilityHelper.changeCategoriesVisibilityStatus({
-          categoryIds: node.key.instanceKeys.map((instanceKey) => instanceKey.id),
-          modelId: node.extendedData.isCategoryOfSubModel ? node.extendedData.modelIds[0] : undefined,
-          on,
-        });
+        const categoryIds = node.key.instanceKeys.map((instanceKey) => instanceKey.id);
+        const modelIds = node.extendedData.modelIds.length > 0 ? node.extendedData.modelIds : [undefined];
+        return from(modelIds).pipe(
+          mergeMap((modelId) =>
+            this.#visibilityHelper.changeCategoriesVisibilityStatus({
+              categoryIds,
+              modelId,
+              on,
+            }),
+          ),
+        );
       }
 
       if (CategoriesTreeNodeInternal.isSubCategoryNode(node)) {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -43,39 +43,22 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
    * Determines visibility status by checking visibility status of related categories.
    */
   public getDefinitionContainersVisibilityStatus(props: { definitionContainerIds: Id64Arg }): Observable<VisibilityStatus> {
-    return this.#props.idsCache
-      .getAllContainedCategories({
-        definitionContainerIds: props.definitionContainerIds,
-      })
-      .pipe(
-        reduce(
-          (acc, { id, hasElements, isTopMostElementCategory }) => {
-            if (isTopMostElementCategory) {
-              acc.topMostElementCategories.push(id);
-              return acc;
-            }
-            if (this.#props.hierarchyConfig.showEmptyCategories && !hasElements) {
-              acc.emptyCategories.push(id);
-            }
-            return acc;
-          },
-          { emptyCategories: new Array<Id64String>(), topMostElementCategories: new Array<Id64String>() },
-        ),
-        mergeMap(({ emptyCategories, topMostElementCategories }) => {
-          return merge(
-            from(emptyCategories).pipe(
-              map((id) => (this.#props.viewport.viewsCategory(id) ? createVisibilityStatus("visible") : createVisibilityStatus("hidden"))),
-            ),
-            topMostElementCategories.length < 1001
-              ? this.getCategoriesVisibilityStatus({ categoryIds: topMostElementCategories, modelId: undefined })
-              : from(topMostElementCategories).pipe(
-                  bufferCount(getOptimalBatchSize({ totalSize: topMostElementCategories.length, maximumBatchSize: 1001 })),
-                  concatMap((categoryIdsBatch) => this.getCategoriesVisibilityStatus({ categoryIds: categoryIdsBatch, modelId: undefined }).pipe(delay(0))),
-                ),
-          );
-        }),
-        mergeVisibilityStatuses(),
-      );
+    return this.getCategorizedContainedCategories(props.definitionContainerIds).pipe(
+      mergeMap(({ emptyCategories, topMostElementCategories }) => {
+        return merge(
+          from(emptyCategories).pipe(
+            map((id) => (this.#props.viewport.viewsCategory(id) ? createVisibilityStatus("visible") : createVisibilityStatus("hidden"))),
+          ),
+          topMostElementCategories.length < 1001
+            ? this.getCategoriesVisibilityStatus({ categoryIds: topMostElementCategories, modelId: undefined })
+            : from(topMostElementCategories).pipe(
+                bufferCount(getOptimalBatchSize({ totalSize: topMostElementCategories.length, maximumBatchSize: 1001 })),
+                concatMap((categoryIdsBatch) => this.getCategoriesVisibilityStatus({ categoryIds: categoryIdsBatch, modelId: undefined }).pipe(delay(0))),
+              ),
+        );
+      }),
+      mergeVisibilityStatuses(),
+    );
   }
 
   /** Gets grouped elements visibility status. */
@@ -112,31 +95,14 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
    * Does this by changing visibility status of related categories.
    */
   public changeDefinitionContainersVisibilityStatus(props: { definitionContainerIds: Id64Arg; on: boolean }): Observable<void> {
-    return this.#props.idsCache
-      .getAllContainedCategories({
-        definitionContainerIds: props.definitionContainerIds,
-      })
-      .pipe(
-        reduce(
-          (acc, { id, hasElements, isTopMostElementCategory }) => {
-            if (isTopMostElementCategory) {
-              acc.topMostElementCategories.push(id);
-              return acc;
-            }
-            if (this.#props.hierarchyConfig.showEmptyCategories && !hasElements) {
-              acc.emptyCategories.push(id);
-            }
-            return acc;
-          },
-          { emptyCategories: new Array<Id64String>(), topMostElementCategories: new Array<Id64String>() },
-        ),
-        mergeMap(({ emptyCategories, topMostElementCategories }) => {
-          if (emptyCategories.length > 0) {
-            this.#props.viewport.changeCategoryDisplay({ categoryIds: emptyCategories, display: props.on });
-          }
-          return this.changeCategoriesVisibilityStatus({ categoryIds: topMostElementCategories, modelId: undefined, on: props.on });
-        }),
-      );
+    return this.getCategorizedContainedCategories(props.definitionContainerIds).pipe(
+      mergeMap(({ emptyCategories, topMostElementCategories }) => {
+        if (emptyCategories.length > 0) {
+          this.#props.viewport.changeCategoryDisplay({ categoryIds: emptyCategories, display: props.on });
+        }
+        return this.changeCategoriesVisibilityStatus({ categoryIds: topMostElementCategories, modelId: undefined, on: props.on });
+      }),
+    );
   }
 
   /**
@@ -178,6 +144,27 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
           parentElementsIdsPath,
         });
       }),
+    );
+  }
+
+  /** Gets categories contained in the given definition containers, split into empty and top most element categories. */
+  private getCategorizedContainedCategories(
+    definitionContainerIds: Id64Arg,
+  ): Observable<{ emptyCategories: Id64String[]; topMostElementCategories: Id64String[] }> {
+    return this.#props.idsCache.getAllContainedCategories({ definitionContainerIds }).pipe(
+      reduce(
+        (acc, { id, hasElements, isTopMostElementCategory }) => {
+          if (isTopMostElementCategory) {
+            acc.topMostElementCategories.push(id);
+            return acc;
+          }
+          if (this.#props.hierarchyConfig.showEmptyCategories && !hasElements) {
+            acc.emptyCategories.push(id);
+          }
+          return acc;
+        },
+        { emptyCategories: new Array<Id64String>(), topMostElementCategories: new Array<Id64String>() },
+      ),
     );
   }
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -43,7 +43,7 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
    * Determines visibility status by checking visibility status of related categories.
    */
   public getDefinitionContainersVisibilityStatus(props: { definitionContainerIds: Id64Arg }): Observable<VisibilityStatus> {
-    return this.getCategorizedContainedCategories(props.definitionContainerIds).pipe(
+    return this.getGroupedContainedCategories(props.definitionContainerIds).pipe(
       mergeMap(({ emptyCategories, topMostElementCategories }) => {
         return merge(
           from(emptyCategories).pipe(
@@ -95,7 +95,7 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
    * Does this by changing visibility status of related categories.
    */
   public changeDefinitionContainersVisibilityStatus(props: { definitionContainerIds: Id64Arg; on: boolean }): Observable<void> {
-    return this.getCategorizedContainedCategories(props.definitionContainerIds).pipe(
+    return this.getGroupedContainedCategories(props.definitionContainerIds).pipe(
       mergeMap(({ emptyCategories, topMostElementCategories }) => {
         if (emptyCategories.length > 0) {
           this.#props.viewport.changeCategoryDisplay({ categoryIds: emptyCategories, display: props.on });
@@ -148,7 +148,7 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
   }
 
   /** Gets categories contained in the given definition containers, split into empty and top most element categories. */
-  private getCategorizedContainedCategories(
+  private getGroupedContainedCategories(
     definitionContainerIds: Id64Arg,
   ): Observable<{ emptyCategories: Id64String[]; topMostElementCategories: Id64String[] }> {
     return this.#props.idsCache.getAllContainedCategories({ definitionContainerIds }).pipe(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHelper.ts
@@ -3,8 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { bufferCount, concat, concatMap, delay, EMPTY, from, map, mergeAll, mergeMap, toArray } from "rxjs";
+import { bufferCount, concat, concatMap, delay, EMPTY, from, map, merge, mergeMap, reduce, toArray } from "rxjs";
 import { HierarchyNodeKey } from "@itwin/presentation-hierarchies";
+import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
 import { getOptimalBatchSize, getParentElementsIdsPath } from "../../../common/internal/Utils.js";
 import { BaseVisibilityHelper } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import { mergeVisibilityStatuses } from "../../../common/internal/VisibilityUtils.js";
@@ -45,20 +46,35 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
     return this.#props.idsCache
       .getAllContainedCategories({
         definitionContainerIds: props.definitionContainerIds,
-        includeEmptyCategories: this.#props.hierarchyConfig.showEmptyCategories,
       })
       .pipe(
-        mergeMap((categoryIds) => {
-          if (categoryIds.size < 1001) {
-            return this.getCategoriesVisibilityStatus({ categoryIds, modelId: undefined });
-          }
-          const optimalBatchSize = getOptimalBatchSize({ totalSize: categoryIds.size, maximumBatchSize: 1001 });
-          return from(categoryIds).pipe(
-            bufferCount(optimalBatchSize),
-            concatMap((categoryIdsBatch) => this.getCategoriesVisibilityStatus({ categoryIds: categoryIdsBatch, modelId: undefined }).pipe(delay(0))),
-            mergeVisibilityStatuses(),
+        reduce(
+          (acc, { id, hasElements, isTopMostElementCategory }) => {
+            if (isTopMostElementCategory) {
+              acc.topMostElementCategories.push(id);
+              return acc;
+            }
+            if (this.#props.hierarchyConfig.showEmptyCategories && !hasElements) {
+              acc.emptyCategories.push(id);
+            }
+            return acc;
+          },
+          { emptyCategories: new Array<Id64String>(), topMostElementCategories: new Array<Id64String>() },
+        ),
+        mergeMap(({ emptyCategories, topMostElementCategories }) => {
+          return merge(
+            from(emptyCategories).pipe(
+              map((id) => (this.#props.viewport.viewsCategory(id) ? createVisibilityStatus("visible") : createVisibilityStatus("hidden"))),
+            ),
+            topMostElementCategories.length < 1001
+              ? this.getCategoriesVisibilityStatus({ categoryIds: topMostElementCategories, modelId: undefined })
+              : from(topMostElementCategories).pipe(
+                  bufferCount(getOptimalBatchSize({ totalSize: topMostElementCategories.length, maximumBatchSize: 1001 })),
+                  concatMap((categoryIdsBatch) => this.getCategoriesVisibilityStatus({ categoryIds: categoryIdsBatch, modelId: undefined }).pipe(delay(0))),
+                ),
           );
         }),
+        mergeVisibilityStatuses(),
       );
   }
 
@@ -99,9 +115,28 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
     return this.#props.idsCache
       .getAllContainedCategories({
         definitionContainerIds: props.definitionContainerIds,
-        includeEmptyCategories: this.#props.hierarchyConfig.showEmptyCategories,
       })
-      .pipe(mergeMap((categoryIds) => this.changeCategoriesVisibilityStatus({ categoryIds, modelId: undefined, on: props.on })));
+      .pipe(
+        reduce(
+          (acc, { id, hasElements, isTopMostElementCategory }) => {
+            if (isTopMostElementCategory) {
+              acc.topMostElementCategories.push(id);
+              return acc;
+            }
+            if (this.#props.hierarchyConfig.showEmptyCategories && !hasElements) {
+              acc.emptyCategories.push(id);
+            }
+            return acc;
+          },
+          { emptyCategories: new Array<Id64String>(), topMostElementCategories: new Array<Id64String>() },
+        ),
+        mergeMap(({ emptyCategories, topMostElementCategories }) => {
+          if (emptyCategories.length > 0) {
+            this.#props.viewport.changeCategoryDisplay({ categoryIds: emptyCategories, display: props.on });
+          }
+          return this.changeCategoriesVisibilityStatus({ categoryIds: topMostElementCategories, modelId: undefined, on: props.on });
+        }),
+      );
   }
 
   /**
@@ -149,9 +184,8 @@ export class CategoriesTreeVisibilityHelper extends BaseVisibilityHelper {
   /** Turns on category and its' related models. Does not turn on other categories contained in those models.*/
   private enableCategoryWithoutEnablingOtherCategories({ categoryId }: { categoryId: Id64String }): Observable<void> {
     this.#props.viewport.changeCategoryDisplay({ categoryIds: categoryId, display: true });
-    return this.#props.idsCache.getModels({ categoryId, subModels: "include" }).pipe(
-      mergeAll(),
-      mergeMap((modelId) => {
+    return this.#props.idsCache.getModels({ categoryId }).pipe(
+      mergeMap(({ id: modelId }) => {
         this.#props.viewport.setPerModelCategoryOverride({ modelIds: modelId, categoryIds: categoryId, override: "none" });
         return this.#props.viewport.viewsModel(modelId)
           ? EMPTY

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defer, EMPTY, expand, from, map, mergeMap, of, reduce, shareReplay } from "rxjs";
+import { defer, EMPTY, expand, from, map, merge, mergeMap, of, reduce, shareReplay } from "rxjs";
 import { Guid, Id64 } from "@itwin/core-bentley";
 import { normalizeFullClassName } from "@itwin/presentation-shared";
 import { BaseIdsCacheImpl } from "../../common/internal/caches/BaseIdsCache.js";
@@ -195,36 +195,19 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
     return this.#classificationInfos;
   }
 
-  public getAllContainedCategories(classificationOrTableIds: Id64Arg): Observable<Id64Array> {
-    const result = new Array<CategoryId>();
+  public getAllContainedCategories(classificationOrTableIds: Id64Arg): Observable<CategoryId> {
     if (Id64.sizeOf(classificationOrTableIds) === 0) {
-      return of(result);
+      return EMPTY;
     }
     return this.getClassificationsInfo().pipe(
       mergeMap((classificationsInfo) =>
         from(Id64.iterable(classificationOrTableIds)).pipe(
-          reduce(
-            (acc, classificationOrTableId) => {
-              const classificationInfo = classificationsInfo.get(classificationOrTableId);
-              if (classificationInfo === undefined) {
-                return acc;
-              }
-              classificationInfo.relatedCategories.forEach((id) => acc.categories.push(id));
-              classificationInfo.childClassificationIds.forEach((id) => acc.childClassifications.push(id));
-              return acc;
-            },
-            { categories: new Array<CategoryId>(), childClassifications: new Array<Id64String>() },
-          ),
-          mergeMap(({ categories, childClassifications }) => {
-            if (childClassifications.length === 0) {
-              return of(categories);
+          mergeMap((classificationOrTableId) => {
+            const classificationInfo = classificationsInfo.get(classificationOrTableId);
+            if (classificationInfo === undefined) {
+              return EMPTY;
             }
-            return this.getAllContainedCategories(childClassifications).pipe(
-              map((childCategories) => {
-                childCategories.forEach((id) => categories.push(id));
-                return categories;
-              }),
-            );
+            return merge(from(classificationInfo.relatedCategories), this.getAllContainedCategories(classificationInfo.childClassificationIds));
           }),
         ),
       ),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHelper.ts
@@ -9,6 +9,7 @@ import { BaseVisibilityHelper } from "../../../common/internal/visibility/BaseVi
 
 import type { Observable } from "rxjs";
 import type { Id64Arg } from "@itwin/core-bentley";
+import type { CategoryId } from "../../../common/internal/Types.js";
 import type { BaseVisibilityHelperProps } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 import type { VisibilityStatus } from "../../../common/UseHierarchyVisibility.js";
 import type { ClassificationsTreeIdsCache } from "../ClassificationsTreeIdsCache.js";
@@ -37,11 +38,7 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Determines visibility status by checking visibility status of related categories.
    */
   public getClassificationTablesVisibilityStatus(props: { classificationTableIds: Id64Arg }): Observable<VisibilityStatus> {
-    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
-      mergeMap((topMostCategories) => {
-        return this.#props.idsCache.getAllContainedCategories(props.classificationTableIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
-      }),
-      toArray(),
+    return this.getTopMostContainedCategories(props.classificationTableIds).pipe(
       mergeMap((categories) => {
         return this.getCategoriesVisibilityStatus({
           modelId: undefined,
@@ -59,11 +56,7 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Determines visibility status by checking visibility status of related categories.
    */
   public getClassificationsVisibilityStatus(props: { classificationIds: Id64Arg }): Observable<VisibilityStatus> {
-    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
-      mergeMap((topMostCategories) => {
-        return this.#props.idsCache.getAllContainedCategories(props.classificationIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
-      }),
-      toArray(),
+    return this.getTopMostContainedCategories(props.classificationIds).pipe(
       mergeMap((categories) =>
         this.getCategoriesVisibilityStatus({
           modelId: undefined,
@@ -81,11 +74,7 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Does this by changing visibility status of related categories.
    */
   public changeClassificationTablesVisibilityStatus(props: { classificationTableIds: Id64Arg; on: boolean }): Observable<void> {
-    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
-      mergeMap((topMostCategories) => {
-        return this.#props.idsCache.getAllContainedCategories(props.classificationTableIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
-      }),
-      toArray(),
+    return this.getTopMostContainedCategories(props.classificationTableIds).pipe(
       mergeMap((categories) =>
         this.changeCategoriesVisibilityStatus({
           modelId: undefined,
@@ -102,11 +91,7 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Does this by changing visibility status of related categories.
    */
   public changeClassificationsVisibilityStatus(props: { classificationIds: Id64Arg; on: boolean }): Observable<void> {
-    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
-      mergeMap((topMostCategories) => {
-        return this.#props.idsCache.getAllContainedCategories(props.classificationIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
-      }),
-      toArray(),
+    return this.getTopMostContainedCategories(props.classificationIds).pipe(
       mergeMap((categories) =>
         this.changeCategoriesVisibilityStatus({
           modelId: undefined,
@@ -114,6 +99,16 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
           on: props.on,
         }),
       ),
+    );
+  }
+
+  /** Gets top most element categories contained in the given classification tables or classifications. */
+  private getTopMostContainedCategories(classificationOrTableIds: Id64Arg): Observable<CategoryId[]> {
+    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
+      mergeMap((topMostCategories) => {
+        return this.#props.idsCache.getAllContainedCategories(classificationOrTableIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
+      }),
+      toArray(),
     );
   }
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/visibility/ClassificationsTreeVisibilityHelper.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defaultIfEmpty, mergeMap } from "rxjs";
+import { defaultIfEmpty, filter, mergeMap, toArray } from "rxjs";
 import { createVisibilityStatus } from "../../../common/internal/Tooltip.js";
 import { BaseVisibilityHelper } from "../../../common/internal/visibility/BaseVisibilityHelper.js";
 
@@ -37,13 +37,18 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Determines visibility status by checking visibility status of related categories.
    */
   public getClassificationTablesVisibilityStatus(props: { classificationTableIds: Id64Arg }): Observable<VisibilityStatus> {
-    return this.#props.idsCache.getAllContainedCategories(props.classificationTableIds).pipe(
-      mergeMap((categories) =>
-        this.getCategoriesVisibilityStatus({
+    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
+      mergeMap((topMostCategories) => {
+        return this.#props.idsCache.getAllContainedCategories(props.classificationTableIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
+      }),
+      toArray(),
+      mergeMap((categories) => {
+        return this.getCategoriesVisibilityStatus({
           modelId: undefined,
           categoryIds: categories,
-        }),
-      ),
+          ignoreSubCategories: true,
+        });
+      }),
       defaultIfEmpty(createVisibilityStatus("disabled")),
     );
   }
@@ -54,11 +59,16 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Determines visibility status by checking visibility status of related categories.
    */
   public getClassificationsVisibilityStatus(props: { classificationIds: Id64Arg }): Observable<VisibilityStatus> {
-    return this.#props.idsCache.getAllContainedCategories(props.classificationIds).pipe(
+    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
+      mergeMap((topMostCategories) => {
+        return this.#props.idsCache.getAllContainedCategories(props.classificationIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
+      }),
+      toArray(),
       mergeMap((categories) =>
         this.getCategoriesVisibilityStatus({
           modelId: undefined,
           categoryIds: categories,
+          ignoreSubCategories: true,
         }),
       ),
       defaultIfEmpty(createVisibilityStatus("disabled")),
@@ -71,7 +81,11 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Does this by changing visibility status of related categories.
    */
   public changeClassificationTablesVisibilityStatus(props: { classificationTableIds: Id64Arg; on: boolean }): Observable<void> {
-    return this.#props.idsCache.getAllContainedCategories(props.classificationTableIds).pipe(
+    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
+      mergeMap((topMostCategories) => {
+        return this.#props.idsCache.getAllContainedCategories(props.classificationTableIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
+      }),
+      toArray(),
       mergeMap((categories) =>
         this.changeCategoriesVisibilityStatus({
           modelId: undefined,
@@ -88,7 +102,11 @@ export class ClassificationsTreeVisibilityHelper extends BaseVisibilityHelper {
    * Does this by changing visibility status of related categories.
    */
   public changeClassificationsVisibilityStatus(props: { classificationIds: Id64Arg; on: boolean }): Observable<void> {
-    return this.#props.idsCache.getAllContainedCategories(props.classificationIds).pipe(
+    return this.#props.idsCache.getAllTopMostElementCategories().pipe(
+      mergeMap((topMostCategories) => {
+        return this.#props.idsCache.getAllContainedCategories(props.classificationIds).pipe(filter((categoryId) => topMostCategories.has(categoryId)));
+      }),
+      toArray(),
       mergeMap((categories) =>
         this.changeCategoriesVisibilityStatus({
           modelId: undefined,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { map, mergeAll, mergeMap, of, toArray } from "rxjs";
-import { Guid } from "@itwin/core-bentley";
+import { EMPTY, filter, forkJoin, map, mergeAll, mergeMap, of } from "rxjs";
+import { assert, Guid } from "@itwin/core-bentley";
 import { ChildElementsCache } from "./ChildElementsCache.js";
 import { DescendantsCountCache } from "./DescendantsCountCache.js";
 import { ElementModelCategoriesCache } from "./ElementModelCategoriesCache.js";
@@ -12,7 +12,7 @@ import { ModeledElementsCache } from "./ModeledElementsCache.js";
 import { SubCategoriesCache } from "./SubCategoriesCache.js";
 
 import type { Observable } from "rxjs";
-import type { GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
+import type { GuidString, Id64Set, Id64String } from "@itwin/core-bentley";
 import type { LimitingECSqlQueryExecutor } from "@itwin/presentation-hierarchies";
 import type { Props } from "@itwin/presentation-shared";
 
@@ -64,35 +64,44 @@ export class BaseIdsCache {
   }
 
   // Implement get sub-models method
-
   public getSubModels(
-    props: { modelId: Id64String; categoryId?: Id64String } | { categoryId: Id64String; modelId: Id64String | undefined },
-  ): Observable<Id64Array> {
-    if (props.modelId) {
-      const { modelId, categoryId } = props;
+    props: { modelId: Id64String; categoryId?: undefined } | { categoryId: Id64String; modelId?: undefined } | { categoryId: Id64String; modelId: Id64String },
+  ): Observable<Id64String> {
+    const { modelId, categoryId } = props;
+    if (modelId) {
       if (categoryId) {
-        return this.#modeledElementsCache.getCategoryModeledElements({ modelId, categoryId }).pipe(toArray());
+        return this.#modeledElementsCache.getCategoryModeledElements({
+          modelId,
+          categoryId,
+        });
       }
-
       return this.#modeledElementsCache.hasModeledElements({ modelId }).pipe(
         mergeMap((hasModeledElements) => {
           if (!hasModeledElements) {
             return of([]);
           }
-          return this.#elementModelCategoriesCache.getModelCategoryIds({ modelId }).pipe(
-            mergeAll(),
-            mergeMap((modelCategoryId) => this.#modeledElementsCache.getCategoryModeledElements({ modelId, categoryId: modelCategoryId })),
-            toArray(),
-          );
+          return this.#elementModelCategoriesCache.getModelCategoryIds({ modelId, includeOnlyIfCategoryOfTopMostElement: true });
         }),
+        mergeAll(),
+        mergeMap((modelCategoryId) => this.#modeledElementsCache.getCategoryModeledElements({ modelId, categoryId: modelCategoryId })),
       );
     }
+    assert(categoryId !== undefined, "Either modelId or categoryId must be provided");
 
-    return this.#elementModelCategoriesCache.getCategoryElementModels({ categoryId: props.categoryId!, subModels: "exclude" }).pipe(
-      mergeAll(),
-      mergeMap((categoryModelId) => this.#modeledElementsCache.getCategoryModeledElements({ modelId: categoryModelId, categoryId: props.categoryId! })),
-      toArray(),
+    return this.#elementModelCategoriesCache.getCategoryElementModels({ categoryId }).pipe(
+      filter(({ isSubModel, categoryIsOfTopMostElement }) => !isSubModel && categoryIsOfTopMostElement),
+      mergeMap(({ id }) => forkJoin({ hasModeledElements: this.#modeledElementsCache.hasModeledElements({ modelId: id }), categoryModelId: of(id) })),
+      mergeMap(({ categoryModelId, hasModeledElements }) => {
+        if (!hasModeledElements) {
+          return EMPTY;
+        }
+        return this.#modeledElementsCache.getCategoryModeledElements({ modelId: categoryModelId, categoryId });
+      }),
     );
+  }
+
+  public getAllSubModels(): Observable<Id64Set> {
+    return this.#modeledElementsCache.getModeledElementsInfo().pipe(map(({ allSubModels }) => allSubModels));
   }
 
   public hasSubModels({ modelId }: { modelId: Id64String }): Observable<boolean> {
@@ -113,6 +122,10 @@ export class BaseIdsCache {
 
   public getAllCategoriesOfElements(): ReturnType<ElementModelCategoriesCache["getAllCategoriesOfElements"]> {
     return this.#elementModelCategoriesCache.getAllCategoriesOfElements();
+  }
+
+  public getAllTopMostElementCategories(): ReturnType<ElementModelCategoriesCache["getAllTopMostElementCategories"]> {
+    return this.#elementModelCategoriesCache.getAllTopMostElementCategories();
   }
 
   public getModels(props: Props<ElementModelCategoriesCache["getCategoryElementModels"]>): ReturnType<ElementModelCategoriesCache["getCategoryElementModels"]> {
@@ -193,9 +206,13 @@ export class BaseIdsCacheImpl {
   }
 
   public getSubModels(
-    props: { modelId: Id64String; categoryId?: Id64String } | { categoryId: Id64String; modelId: Id64String | undefined },
-  ): Observable<Id64Array> {
+    props: { modelId: Id64String; categoryId: Id64String } | { modelId: Id64String; categoryId?: undefined } | { categoryId: Id64String; modelId?: undefined },
+  ): Observable<Id64String> {
     return this.#baseIdsCache.getSubModels(props);
+  }
+
+  public getAllSubModels(): Observable<Id64Set> {
+    return this.#baseIdsCache.getAllSubModels();
   }
 
   public hasSubModels({ modelId }: { modelId: Id64String }): Observable<boolean> {
@@ -232,6 +249,10 @@ export class BaseIdsCacheImpl {
 
   public getAllCategoriesOfElements(): ReturnType<ElementModelCategoriesCache["getAllCategoriesOfElements"]> {
     return this.#baseIdsCache.getAllCategoriesOfElements();
+  }
+
+  public getAllTopMostElementCategories(): ReturnType<ElementModelCategoriesCache["getAllTopMostElementCategories"]> {
+    return this.#baseIdsCache.getAllTopMostElementCategories();
   }
 
   public getCategoriesOfModelsTopMostElements(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ElementModelCategoriesCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defer, forkJoin, from, map, mergeMap, reduce, shareReplay } from "rxjs";
+import { defer, delay, forkJoin, from, map, mergeMap, reduce, shareReplay, tap } from "rxjs";
 import { CLASS_NAME_Model } from "../ClassNameDefinitions.js";
 import { catchBeSQLiteInterrupts } from "../UseErrorState.js";
 import { getOrCreate, releaseMainThreadOnItemsCount } from "../Utils.js";
@@ -21,6 +21,14 @@ interface ElementModelCategoriesCacheProps {
   modeledElementsCache: ModeledElementsCache;
 }
 
+interface CachedData {
+  modelsCategoriesInfo: Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>;
+  categoryModelsInfo: Map<CategoryId, Array<{ id: ModelId; isSubModel: boolean; categoryIsOfTopMostElement: boolean }>>;
+  categoriesWithParentElements: Set<CategoryId>;
+  allCategories: Set<CategoryId>;
+  allTopMostElementCategories: Set<CategoryId>;
+}
+
 /** @internal */
 export class ElementModelCategoriesCache {
   #queryExecutor: LimitingECSqlQueryExecutor;
@@ -28,12 +36,9 @@ export class ElementModelCategoriesCache {
   #componentName: string;
   #elementClassName: string;
   #modeledElementsCache: ModeledElementsCache;
-  #cachedData:
-    | Observable<{
-        modelsCategoriesInfo: Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId>; isSubModel: boolean }>;
-        categoriesWithParentElements: Set<CategoryId>;
-      }>
-    | undefined;
+  #cachedData: Observable<CachedData> | undefined;
+  #dataResolved = false;
+  #subscriberBatches: Array<{ obs: Observable<CachedData>; subscriberCount: number }> = [];
 
   constructor(props: ElementModelCategoriesCacheProps) {
     this.#queryExecutor = props.queryExecutor;
@@ -83,6 +88,17 @@ export class ElementModelCategoriesCache {
       modelCategories: this.queryElementModelCategories().pipe(
         reduce(
           (acc, queriedCategory) => {
+            acc.allCategories.add(queriedCategory.categoryId);
+            const categoryModelsEntry = getOrCreate({
+              map: acc.categoryModelsInfo,
+              key: queriedCategory.categoryId,
+              createFunc: () => new Array<{ id: ModelId; isSubModel: boolean; categoryIsOfTopMostElement: boolean }>(),
+            });
+            categoryModelsEntry.push({
+              id: queriedCategory.modelId,
+              isSubModel: false,
+              categoryIsOfTopMostElement: queriedCategory.isTopMostElementCategory,
+            });
             const modelEntry = getOrCreate({
               map: acc.modelsCategoriesInfo,
               key: queriedCategory.modelId,
@@ -91,6 +107,7 @@ export class ElementModelCategoriesCache {
             modelEntry.allCategories.add(queriedCategory.categoryId);
             if (queriedCategory.isTopMostElementCategory) {
               modelEntry.categoriesOfTopMostElements.add(queriedCategory.categoryId);
+              acc.allTopMostElementCategories.add(queriedCategory.categoryId);
             }
             if (queriedCategory.hasParentElements) {
               acc.categoriesWithParentElements.add(queriedCategory.categoryId);
@@ -100,6 +117,9 @@ export class ElementModelCategoriesCache {
           {
             modelsCategoriesInfo: new Map<ModelId, { categoriesOfTopMostElements: Set<CategoryId>; allCategories: Set<CategoryId> }>(),
             categoriesWithParentElements: new Set<CategoryId>(),
+            allTopMostElementCategories: new Set<CategoryId>(),
+            allCategories: new Set<CategoryId>(),
+            categoryModelsInfo: new Map<CategoryId, Array<{ id: ModelId; categoryIsOfTopMostElement: boolean; isSubModel: boolean }>>(),
           },
         ),
       ),
@@ -116,33 +136,59 @@ export class ElementModelCategoriesCache {
             isSubModel,
           });
         }
-        return { modelsCategoriesInfo, categoriesWithParentElements: modelCategories.categoriesWithParentElements };
+        if (allSubModels.size > 0) {
+          for (const categoryModels of modelCategories.categoryModelsInfo.values()) {
+            for (const categoryModelEntry of categoryModels) {
+              if (allSubModels.has(categoryModelEntry.id)) {
+                categoryModelEntry.isSubModel = true;
+              }
+            }
+          }
+        }
+
+        return {
+          modelsCategoriesInfo,
+          categoriesWithParentElements: modelCategories.categoriesWithParentElements,
+          allTopMostElementCategories: modelCategories.allTopMostElementCategories,
+          allCategories: modelCategories.allCategories,
+          categoryModelsInfo: modelCategories.categoryModelsInfo,
+        };
+      }),
+      tap(() => {
+        this.#dataResolved = true;
+        this.#subscriberBatches = [];
       }),
       shareReplay(),
     );
-    return this.#cachedData;
+
+    // Once the data is resolved, every subscriber gets a synchronous replay, so batching is no longer needed.
+    if (this.#dataResolved) {
+      return this.#cachedData;
+    }
+
+    // While the data is still loading, group subscribers into batches. The first batch subscribes directly to the
+    // shared source; each subsequent batch chains off the previous one through a `delay(0)`, so
+    // when the source resolves the batches are notified with a slight delay between each batch.
+    // This prevents main thread blocking.
+    if (this.#subscriberBatches.length === 0) {
+      this.#subscriberBatches.push({ obs: this.#cachedData, subscriberCount: 1 });
+      return this.#cachedData;
+    }
+
+    let lastBatch = this.#subscriberBatches[this.#subscriberBatches.length - 1];
+
+    const maxSubscribersPerBatch = 400;
+    if (lastBatch.subscriberCount >= maxSubscribersPerBatch) {
+      lastBatch = { obs: lastBatch.obs.pipe(delay(0), shareReplay({ refCount: true })), subscriberCount: 1 };
+      this.#subscriberBatches.push(lastBatch);
+    } else {
+      ++lastBatch.subscriberCount;
+    }
+    return lastBatch.obs;
   }
 
-  public getCategoryElementModels(props: {
-    categoryId: Id64String;
-    subModels: "include" | "exclude" | "only";
-    includeOnlyIfCategoryOfTopMostElement?: boolean;
-  }): Observable<Array<ModelId>> {
-    const { categoryId, subModels } = props;
-    return this.getCachedData().pipe(
-      map(({ modelsCategoriesInfo }) => {
-        const categoryModels = new Array<ModelId>();
-        for (const [modelId, { allCategories, categoriesOfTopMostElements, isSubModel }] of modelsCategoriesInfo) {
-          if (
-            (subModels === "include" || (subModels === "only" && isSubModel) || (subModels === "exclude" && !isSubModel)) &&
-            (props.includeOnlyIfCategoryOfTopMostElement ? categoriesOfTopMostElements.has(categoryId) : allCategories.has(categoryId))
-          ) {
-            categoryModels.push(modelId);
-          }
-        }
-        return categoryModels;
-      }),
-    );
+  public getCategoryElementModels(props: { categoryId: Id64String }): Observable<{ id: ModelId; isSubModel: boolean; categoryIsOfTopMostElement: boolean }> {
+    return this.getCachedData().pipe(mergeMap(({ categoryModelsInfo }) => categoryModelsInfo.get(props.categoryId) ?? []));
   }
 
   public getModelCategoryIds({
@@ -173,15 +219,11 @@ export class ElementModelCategoriesCache {
   }
 
   public getAllCategoriesOfElements(): Observable<Id64Set> {
-    return this.getCachedData().pipe(
-      mergeMap(({ modelsCategoriesInfo }) => from(modelsCategoriesInfo.values())),
-      reduce((acc, { allCategories }) => {
-        for (const categoryId of allCategories) {
-          acc.add(categoryId);
-        }
-        return acc;
-      }, new Set<CategoryId>()),
-    );
+    return this.getCachedData().pipe(map(({ allCategories }) => allCategories));
+  }
+
+  public getAllTopMostElementCategories(): Observable<Id64Set> {
+    return this.getCachedData().pipe(map(({ allTopMostElementCategories }) => allTopMostElementCategories));
   }
 
   public getAllModels(): Observable<Array<ModelId>> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/ModeledElementsCache.ts
@@ -116,15 +116,13 @@ export class ModeledElementsCache {
   public getSubModelsUnderElement(elementId: Id64String): Observable<Id64Array> {
     return this.getModeledElementsInfo().pipe(
       map(({ allSubModels, childSubModels }) => {
-        const subModels = new Array<ElementId>();
         if (allSubModels.has(elementId)) {
-          subModels.push(elementId);
+          // If element is a sub-model, it can not be a parent.
+          return [elementId];
         }
-        const elementEntry = childSubModels.get(elementId);
-        for (const childSubModelId of elementEntry ?? []) {
-          subModels.push(childSubModelId);
-        }
-        return subModels;
+        // Convert sub-models set into array.
+        // When element does not contain sub-model, return empty array.
+        return [...(childSubModels.get(elementId) ?? [])];
       }),
     );
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -691,9 +691,7 @@ export class BaseVisibilityHelper implements Disposable {
         mergeMap((categoryId) =>
           this.#props.baseIdsCache.getModels({ categoryId }).pipe(
             filter(({ categoryIsOfTopMostElement, isSubModel }) => categoryIsOfTopMostElement && !isSubModel),
-            map(({ id }) => {
-              return { modelId: id, categoryId };
-            }),
+            map(({ id }) => ({ modelId: id, categoryId })),
           ),
         ),
         reduce((acc, { modelId, categoryId }) => {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -138,29 +138,42 @@ export class BaseVisibilityHelper implements Disposable {
    */
   public getModelsVisibilityStatus(props: { modelIds: Id64Arg }): Observable<VisibilityStatus> {
     const result = defer(() => {
+      if (Id64.sizeOf(props.modelIds) === 0) {
+        return EMPTY;
+      }
       const { modelIds } = props;
-      return from(Id64.iterable(modelIds)).pipe(
-        mergeMap((modelId) => {
-          // For hidden models we only need to check subModels
-          if (!this.#props.viewport.viewsModel(modelId)) {
-            return this.#props.baseIdsCache.getSubModels({ modelId }).pipe(
-              mergeMap((subModels) => this.getModelsVisibilityStatus({ modelIds: subModels })),
-              map((subModelsVisibilityStatus) =>
-                subModelsVisibilityStatus.state !== "hidden" ? createVisibilityStatus("partial") : subModelsVisibilityStatus,
+      return merge(
+        from(Id64.iterable(modelIds)).pipe(
+          mergeMap((modelId) => this.#props.baseIdsCache.getSubModels({ modelId })),
+          toArray(),
+          mergeMap((subModels) => this.getModelsVisibilityStatus({ modelIds: subModels })),
+        ),
+        from(Id64.iterable(modelIds)).pipe(
+          mergeMap((modelId) => {
+            // For hidden models we only need to check subModels
+            if (!this.#props.viewport.viewsModel(modelId)) {
+              return of(createVisibilityStatus("hidden"));
+            }
+            // For visible models we need to check all categories.
+            // Only need to take top-most categories, they take into account all descendants.
+            return this.#props.baseIdsCache.getCategories({ modelId, includeOnlyIfCategoryOfTopMostElement: true }).pipe(
+              mergeMap((categories) => {
+                if (categories.size === 0) {
+                  return EMPTY;
+                }
+                return fromWithRelease({ source: categories, releaseOnCount: 100 });
+              }),
+              mergeMap((categoryId) =>
+                this.getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
+                  modelId,
+                  categoryId,
+                }),
               ),
-              defaultIfEmpty(createVisibilityStatus("hidden")),
+              defaultIfEmpty(createVisibilityStatus("visible")),
             );
-          }
-          // For visible models we need to check all categories.
-          // getCategoriesVisibilityStatus already checks subModels, no need to do that
-          // Only need to take top-most categories, they take into account all descendants.
-          return this.#props.baseIdsCache.getCategories({ modelId, includeOnlyIfCategoryOfTopMostElement: true }).pipe(
-            mergeMap((categories) => this.getCategoriesVisibilityStatus({ modelId, categoryIds: categories })),
-            defaultIfEmpty(createVisibilityStatus("visible")),
-          );
-        }),
-        mergeVisibilityStatuses(),
-      );
+          }),
+        ),
+      ).pipe(mergeVisibilityStatuses());
     });
     return this.#props.overrideHandler
       ? this.#props.overrideHandler.createVisibilityHandlerResult({
@@ -209,40 +222,88 @@ export class BaseVisibilityHelper implements Disposable {
    * - Visibility of models that are related to the categories;
    * - sub-categories visibility.
    */
-  public getCategoriesVisibilityStatus(props: { categoryIds: Id64Arg; modelId: Id64String | undefined }): Observable<VisibilityStatus> {
+  public getCategoriesVisibilityStatus(props: {
+    categoryIds: Id64Arg;
+    modelId: Id64String | undefined;
+    ignoreSubCategories?: boolean;
+  }): Observable<VisibilityStatus> {
     const result = defer(() => {
       const { categoryIds, modelId: modelIdFromProps } = props;
       if (modelIdFromProps) {
-        return fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
-          mergeMap((categoryId) => this.getModelWithCategoryVisibilityStatus({ modelId: modelIdFromProps, categoryId })),
-          mergeVisibilityStatuses(),
-        );
+        return this.getModelWithCategoriesVisibilityStatus({
+          modelId: modelIdFromProps,
+          categoryIds: Id64.toIdSet(categoryIds),
+        });
       }
 
-      return fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
-        mergeMap((categoryId) =>
-          merge(
-            // When always drawn exclusive mode is enabled need to get only models for which category has top most element.
-            // This is because always/never drawn elements can be retrieved using top most category.
-            // TODO fix with: https://github.com/iTwin/viewer-components-react/issues/1100
-            this.#props.baseIdsCache
-              .getModels({ categoryId, includeOnlyIfCategoryOfTopMostElement: this.#props.viewport.isAlwaysDrawnExclusive, subModels: "include" })
-              .pipe(
-                mergeAll(),
-                mergeMap((modelId) => this.getModelWithCategoryVisibilityStatus({ modelId, categoryId })),
-              ),
-            // For category not under specific model, need to check subCategories as well
-            this.#props.baseIdsCache
-              .getSubCategories({ categoryId })
-              .pipe(mergeMap((subCategoryIds) => this.getSubCategoriesVisibilityStatus({ categoryId, subCategoryIds }))),
-          ).pipe(
-            // This can happen when category does not have any geometric elements or sub-categories
-            defaultIfEmpty(
-              createVisibilityStatus(!this.#props.viewport.isAlwaysDrawnExclusive && this.#props.viewport.viewsCategory(categoryId) ? "visible" : "hidden"),
+      const subCategoriesVisibilityStatus = props.ignoreSubCategories
+        ? EMPTY
+        : fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
+            mergeMap((categoryId) =>
+              this.#props.baseIdsCache
+                .getSubCategories({ categoryId })
+                .pipe(mergeMap((subCategoryIds) => this.getSubCategoriesVisibilityStatus({ categoryId, subCategoryIds }))),
             ),
+          );
+
+      const categoryModelsObservable = fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
+        mergeMap((categoryId) =>
+          this.#props.baseIdsCache.getModels({ categoryId }).pipe(
+            filter(({ categoryIsOfTopMostElement, isSubModel }) => categoryIsOfTopMostElement && !isSubModel),
+            map(({ id: modelId }) => {
+              return {
+                modelId,
+                categoryId,
+              };
+            }),
           ),
         ),
+        shareReplay({ refCount: true }),
+      );
+
+      const categorySubModelsVisibilityStatus = categoryModelsObservable.pipe(
+        mergeMap(({ modelId, categoryId }) =>
+          this.#props.baseIdsCache.hasSubModels({ modelId }).pipe(
+            mergeMap((hasSubModels) => {
+              if (!hasSubModels) {
+                return EMPTY;
+              }
+              return this.#props.baseIdsCache.getSubModels({
+                modelId,
+                categoryId,
+              });
+            }),
+          ),
+        ),
+        toArray(),
+        mergeMap((subModels) => (subModels.length > 0 ? this.getModelsVisibilityStatus({ modelIds: subModels }) : EMPTY)),
+      );
+      const categoryAlwaysAndNeverDrawnVisibilityStatus = categoryModelsObservable.pipe(
+        mergeMap(({ modelId, categoryId }) =>
+          this.#props.viewport.viewsModel(modelId)
+            ? this.getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
+                modelId,
+                categoryId,
+              })
+            : of(createVisibilityStatus("hidden")),
+        ),
+      );
+      const getEmptyCategoryVisibilityStatus = () => {
+        let isVisible = true;
+        for (const categoryId of Id64.iterable(categoryIds)) {
+          if (this.#props.viewport.viewsCategory(categoryId)) {
+            if (!isVisible) {
+              return "partial";
+            }
+            continue;
+          }
+          isVisible = false;
+        }
+        return isVisible ? "visible" : "hidden";
+      };
+      return merge(subCategoriesVisibilityStatus, categorySubModelsVisibilityStatus, categoryAlwaysAndNeverDrawnVisibilityStatus).pipe(
         mergeVisibilityStatuses(),
+        defaultIfEmpty(createVisibilityStatus(!this.#props.viewport.isAlwaysDrawnExclusive ? getEmptyCategoryVisibilityStatus() : "hidden")),
       );
     });
 
@@ -263,18 +324,24 @@ export class BaseVisibilityHelper implements Disposable {
    * - Default categories visibility status in the viewport;
    * - SubModels that are related to the modelId and categoryId.
    */
-  private getModelWithCategoryVisibilityStatus({ modelId, categoryId }: { modelId: Id64String; categoryId: Id64String }): Observable<VisibilityStatus> {
+  private getModelWithCategoriesVisibilityStatus({ modelId, categoryIds }: { modelId: Id64String; categoryIds: Id64Set }): Observable<VisibilityStatus> {
     const modelVisibilityStatus = this.#props.viewport.viewsModel(modelId)
       ? // For visible model need to check category and always/never drawn elements
-        this.getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
-          modelId,
-          categoryId,
-        })
+        fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
+          mergeMap((categoryId) =>
+            this.getCategoryVisibilityFromAlwaysAndNeverDrawnElements({
+              modelId,
+              categoryId,
+            }),
+          ),
+        )
       : of(createVisibilityStatus("hidden"));
 
-    const subModelsVisibilityStatus = this.#props.baseIdsCache
-      .getSubModels({ modelId, categoryId })
-      .pipe(mergeMap((subModels) => this.getModelsVisibilityStatus({ modelIds: subModels })));
+    const subModelsVisibilityStatus = fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
+      mergeMap((categoryId) => this.#props.baseIdsCache.getSubModels({ modelId, categoryId })),
+      toArray(),
+      mergeMap((subModels) => this.getModelsVisibilityStatus({ modelIds: subModels })),
+    );
 
     return merge(modelVisibilityStatus, subModelsVisibilityStatus).pipe(mergeVisibilityStatuses());
   }
@@ -538,6 +605,7 @@ export class BaseVisibilityHelper implements Disposable {
         this.#props.viewport.changeModelDisplay({ modelIds, display: false });
         return from(Id64.iterable(modelIds)).pipe(
           mergeMap((modelId) => this.#props.baseIdsCache.getSubModels({ modelId })),
+          toArray(),
           mergeMap((subModels) => this.changeModelsVisibilityStatus({ modelIds: subModels, on })),
         );
       }
@@ -625,12 +693,17 @@ export class BaseVisibilityHelper implements Disposable {
       this.#props.viewport.changeCategoryDisplay({ categoryIds, display: on, enableAllSubCategories: false });
 
       const categoryModelsObs = fromWithRelease({ source: categoryIds, releaseOnCount: 500 }).pipe(
-        mergeMap((categoryId) => forkJoin({ categoryId: of(categoryId), models: this.#props.baseIdsCache.getModels({ categoryId, subModels: "include" }) })),
-        reduce((acc, { models, categoryId }) => {
-          for (const modelId of Id64.iterable(models)) {
-            const entry = getOrCreate({ map: acc, key: modelId, createFunc: () => new Set<CategoryId>() });
-            entry.add(categoryId);
-          }
+        mergeMap((categoryId) =>
+          this.#props.baseIdsCache.getModels({ categoryId }).pipe(
+            filter(({ categoryIsOfTopMostElement, isSubModel }) => categoryIsOfTopMostElement && !isSubModel),
+            map(({ id }) => {
+              return { modelId: id, categoryId };
+            }),
+          ),
+        ),
+        reduce((acc, { modelId, categoryId }) => {
+          const entry = getOrCreate({ map: acc, key: modelId, createFunc: () => new Set<CategoryId>() });
+          entry.add(categoryId);
           return acc;
         }, new Map<ModelId, Set<CategoryId>>()),
         mergeMap((modelCategoriesMap) => modelCategoriesMap.entries()),
@@ -645,10 +718,11 @@ export class BaseVisibilityHelper implements Disposable {
           if (!hasSubModels) {
             return EMPTY;
           }
-          return fromWithRelease({ source: modelCategories, releaseOnCount: 500 }).pipe(
-            mergeMap((modelCategoryId) => this.#props.baseIdsCache.getSubModels({ categoryId: modelCategoryId, modelId })),
+          return fromWithRelease({ source: modelCategories, releaseOnCount: 100 }).pipe(
+            mergeMap((categoryId) => this.#props.baseIdsCache.getSubModels({ modelId, categoryId })),
           );
         }),
+        toArray(),
         mergeMap((subModels) => this.changeModelsVisibilityStatus({ modelIds: subModels, on })),
       );
       const changeModelsObs = on
@@ -673,31 +747,32 @@ export class BaseVisibilityHelper implements Disposable {
         mergeMap(([modelId, modelCategories]) => this.clearAlwaysAndNeverDrawnElements({ categoryIds: modelCategories, modelId })),
       );
 
-      const changeChildElementsInDifferentCategoriesObs = categoryModelsObs.pipe(
-        mergeMap(([modelId, modelCategories]) =>
-          // Descendants need to be changed only when model is visible, if it's hidden, any changes to A/N drawn won't have any effect.
-          this.#props.viewport.viewsModel(modelId)
-            ? this.getDescendantsToChange({ modelId, categoryIds: modelCategories, on, parentElementIdsPath: [] })
-            : EMPTY,
-        ),
-        reduce(
-          (acc, { matchingDesiredState, notMatchingDesiredState }) => {
-            acc.matchingDesiredState.push(...matchingDesiredState);
-            acc.notMatchingDesiredState.push(...notMatchingDesiredState);
-            return acc;
-          },
-          { matchingDesiredState: Array<ElementId>(), notMatchingDesiredState: Array<ElementId>() },
-        ),
-        mergeMap(({ matchingDesiredState, notMatchingDesiredState }) =>
-          matchingDesiredState.length > 0 || notMatchingDesiredState.length > 0
-            ? this.queueElementsVisibilityChange({
-                elementsMatchingDesiredState: matchingDesiredState.length > 0 ? matchingDesiredState : undefined,
-                elementsNotMatchingDesiredState: notMatchingDesiredState.length > 0 ? notMatchingDesiredState : undefined,
-                on,
-              })
-            : EMPTY,
-        ),
-      );
+      const getChangeChildElementsInDifferentCategoriesObs = () =>
+        categoryModelsObs.pipe(
+          mergeMap(([modelId, modelCategories]) =>
+            // Descendants need to be changed only when model is visible, if it's hidden, any changes to A/N drawn won't have any effect.
+            this.#props.viewport.viewsModel(modelId)
+              ? this.getDescendantsToChange({ modelId, categoryIds: modelCategories, on, parentElementIdsPath: [] })
+              : EMPTY,
+          ),
+          reduce(
+            (acc, { matchingDesiredState, notMatchingDesiredState }) => {
+              acc.matchingDesiredState.push(...matchingDesiredState);
+              acc.notMatchingDesiredState.push(...notMatchingDesiredState);
+              return acc;
+            },
+            { matchingDesiredState: Array<ElementId>(), notMatchingDesiredState: Array<ElementId>() },
+          ),
+          mergeMap(({ matchingDesiredState, notMatchingDesiredState }) =>
+            matchingDesiredState.length > 0 || notMatchingDesiredState.length > 0
+              ? this.queueElementsVisibilityChange({
+                  elementsMatchingDesiredState: matchingDesiredState.length > 0 ? matchingDesiredState : undefined,
+                  elementsNotMatchingDesiredState: notMatchingDesiredState.length > 0 ? notMatchingDesiredState : undefined,
+                  on,
+                })
+              : EMPTY,
+          ),
+        );
 
       const changeSubCategoriesObs = on
         ? fromWithRelease({ source: categoryIds, releaseOnCount: 200 }).pipe(
@@ -717,7 +792,7 @@ export class BaseVisibilityHelper implements Disposable {
         changeModelsObs.pipe(
           defaultIfEmpty(undefined),
           takeLast(1),
-          mergeMap(() => changeChildElementsInDifferentCategoriesObs),
+          mergeMap(() => getChangeChildElementsInDifferentCategoriesObs()),
         ),
         removeCategoriesOverridesObs,
         changeAlwaysAndNeverDrawnElementsObs,
@@ -786,26 +861,29 @@ export class BaseVisibilityHelper implements Disposable {
       modelId,
     });
 
-    const changeChildElementsInDifferentCategoriesObs = this.getDescendantsToChange({ modelId, categoryIds, on, parentElementIdsPath: [] }).pipe(
-      mergeMap(({ matchingDesiredState, notMatchingDesiredState }) => {
-        return matchingDesiredState.size > 0 || notMatchingDesiredState.length > 0
-          ? this.queueElementsVisibilityChange({
-              elementsMatchingDesiredState: matchingDesiredState.size > 0 ? matchingDesiredState : undefined,
-              elementsNotMatchingDesiredState: notMatchingDesiredState.length > 0 ? notMatchingDesiredState : undefined,
-              on,
-            })
-          : EMPTY;
-      }),
-    );
+    const getChangeChildElementsInDifferentCategoriesObs = () =>
+      this.getDescendantsToChange({ modelId, categoryIds, on, parentElementIdsPath: [] }).pipe(
+        mergeMap(({ matchingDesiredState, notMatchingDesiredState }) => {
+          return matchingDesiredState.size > 0 || notMatchingDesiredState.length > 0
+            ? this.queueElementsVisibilityChange({
+                elementsMatchingDesiredState: matchingDesiredState.size > 0 ? matchingDesiredState : undefined,
+                elementsNotMatchingDesiredState: notMatchingDesiredState.length > 0 ? notMatchingDesiredState : undefined,
+                on,
+              })
+            : EMPTY;
+        }),
+      );
 
     const changeSubModelsObs = this.#props.baseIdsCache.hasSubModels({ modelId }).pipe(
       mergeMap((hasSubModels) => {
         if (!hasSubModels) {
           return EMPTY;
         }
-        return fromWithRelease({ source: categoryIds, releaseOnCount: 200 });
+        return fromWithRelease({ source: categoryIds, releaseOnCount: 100 }).pipe(
+          mergeMap((categoryId) => this.#props.baseIdsCache.getSubModels({ modelId, categoryId })),
+        );
       }),
-      mergeMap((categoryId) => this.#props.baseIdsCache.getSubModels({ categoryId, modelId })),
+      toArray(),
       mergeMap((subModels) => this.changeModelsVisibilityStatus({ modelIds: subModels, on })),
     );
     return merge(
@@ -813,7 +891,7 @@ export class BaseVisibilityHelper implements Disposable {
         defaultIfEmpty(undefined),
         takeLast(1),
         // Descendants need to be changed only when model is visible, if it's hidden, any changes to A/N drawn won't have any effect.
-        mergeMap(() => (this.#props.viewport.viewsModel(modelId) ? changeChildElementsInDifferentCategoriesObs : EMPTY)),
+        mergeMap(() => (this.#props.viewport.viewsModel(modelId) ? getChangeChildElementsInDifferentCategoriesObs() : EMPTY)),
       ),
       changeAlwaysAndNeverDrawnElementsObs,
       changeSubModelsObs,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/visibility/BaseVisibilityHelper.ts
@@ -250,12 +250,7 @@ export class BaseVisibilityHelper implements Disposable {
         mergeMap((categoryId) =>
           this.#props.baseIdsCache.getModels({ categoryId }).pipe(
             filter(({ categoryIsOfTopMostElement, isSubModel }) => categoryIsOfTopMostElement && !isSubModel),
-            map(({ id: modelId }) => {
-              return {
-                modelId,
-                categoryId,
-              };
-            }),
+            map(({ id: modelId }) => ({ modelId, categoryId })),
           ),
         ),
         shareReplay({ refCount: true }),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -3,23 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  bufferCount,
-  defer,
-  firstValueFrom,
-  forkJoin,
-  from,
-  fromEvent,
-  identity,
-  map,
-  merge,
-  mergeAll,
-  mergeMap,
-  reduce,
-  switchMap,
-  takeUntil,
-  toArray,
-} from "rxjs";
+import { bufferCount, defer, firstValueFrom, forkJoin, from, fromEvent, identity, map, merge, mergeMap, reduce, switchMap, takeUntil } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
 import { IModel } from "@itwin/core-common";
 import { createPredicateBasedHierarchyDefinition, NodeSelectClauseColumnNames, ProcessedHierarchyNode } from "@itwin/presentation-hierarchies";
@@ -45,6 +29,7 @@ import {
   releaseMainThreadOnItemsCount,
 } from "../common/internal/Utils.js";
 import { SearchLimitExceededError } from "../common/TreeErrors.js";
+import { ModelsTreeNodeInternal } from "./internal/ModelsTreeNodeInternal.js";
 
 import type { Observable, ObservedValueOf, OperatorFunction } from "rxjs";
 import type { GuidString, Id64String } from "@itwin/core-bentley";
@@ -70,6 +55,7 @@ import type {
   ECSqlQueryRow,
   IInstanceLabelSelectClauseFactory,
   InstanceKey,
+  Props,
 } from "@itwin/presentation-shared";
 import type { ModelsTreeIdsCache } from "./internal/ModelsTreeIdsCache.js";
 
@@ -200,7 +186,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   }
 
   public preProcessNode: NodePreProcessor = async ({ node }) => {
-    if (node.extendedData?.isCategory) {
+    if (ModelsTreeNodeInternal.isRawCategoryNode(node)) {
       return {
         ...node,
         extendedData: {
@@ -213,38 +199,40 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
   };
 
   public postProcessNode: NodePostProcessor = async ({ node }) => {
-    if (ProcessedHierarchyNode.isGroupingNode(node)) {
-      const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
-      const childrenWhichAreParents = new Set(
-        node.children
-          .filter((child) => !!child.children)
-          .map((child) => {
-            assert(!ProcessedHierarchyNode.isGroupingNode(child), "Expected only non-grouping nodes as children");
-            return child.key.instanceKeys.map(({ id }) => id);
-          })
-          .flat(),
-      );
-
-      return {
-        ...node,
-        label: this.#hierarchyConfig.elementClassGrouping === "enableWithCounts" ? `${node.label} (${node.children.length})` : node.label,
-        extendedData: {
-          ...node.extendedData,
-          // `modelId`, `categoryId`, `categoryOfTopMostParentElement`, `topMostParentElementId` are shared by all grouped elements.
-          categoryId: node.children[0].extendedData?.categoryId,
-          modelId: node.children[0].extendedData?.modelId,
-          categoryOfTopMostParentElement: node.children[0].extendedData?.categoryOfTopMostParentElement,
-          topMostParentElementId: node.children[0].extendedData?.topMostParentElementId,
-          childrenWhichAreParents,
-          ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
-          ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
-          // `imageId` is assigned to instance nodes at query time, but grouping ones need to
-          // be handled during post-processing
-          imageId: "icon-ec-class",
-        },
-      };
+    if (!ProcessedHierarchyNode.isGroupingNode(node)) {
+      return node;
     }
-    return node;
+    const { hasSearchTargetAncestor, hasDirectNonSearchTargets } = groupingNodeDataFromChildren(node.children);
+    const childrenWhichAreParents = new Set(
+      node.children
+        .filter((child) => !!child.children)
+        .map((child) => {
+          assert(ModelsTreeNodeInternal.isRawElementNode(child), "Expect all children of grouping nodes to be element nodes");
+          return child.key.instanceKeys.map(({ id }) => id);
+        })
+        .flat(),
+    );
+    const firstChild = node.children[0];
+    assert(ModelsTreeNodeInternal.isRawElementNode(firstChild), "Expect first child of grouping node to be an element node");
+
+    return {
+      ...node,
+      label: this.#hierarchyConfig.elementClassGrouping === "enableWithCounts" ? `${node.label} (${node.children.length})` : node.label,
+      extendedData: {
+        ...node.extendedData,
+        // `modelId`, `categoryId`, `categoryOfTopMostParentElement`, `topMostParentElementId` are shared by all grouped elements.
+        categoryId: firstChild.extendedData.categoryId,
+        modelId: firstChild.extendedData.modelId,
+        categoryOfTopMostParentElement: firstChild.extendedData.categoryOfTopMostParentElement,
+        topMostParentElementId: firstChild.extendedData.topMostParentElementId,
+        childrenWhichAreParents,
+        ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
+        ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
+        // `imageId` is assigned to instance nodes at query time, but grouping ones need to
+        // be handled during post-processing
+        imageId: "icon-ec-class",
+      },
+    };
   };
 
   public async defineHierarchyLevel(props: DefineHierarchyLevelProps) {
@@ -422,7 +410,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory,
     instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const [instanceFilterClauses, categoryIds] = await Promise.all([
+    const [categoryInstanceFilterClauses, categoryIds] = await Promise.all([
       nodeSelectClauseFactory.createFilterClauses({
         filter: instanceFilter,
         contentClass: { fullName: CLASS_NAME_SpatialCategory, alias: "this" },
@@ -438,34 +426,101 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
-                ecClassId: { selector: "this.ECClassId" },
-                ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: CLASS_NAME_SpatialCategory,
-                  }),
-                },
-                grouping: { byLabel: { action: "merge", groupId: "category" } },
-                hasChildren: true,
-                extendedData: {
-                  imageId: "icon-layers",
-                  isCategory: true,
-                  modelIds: { selector: createIdsSelector(modelIds) },
-                },
-                supportsFiltering: this.supportsFiltering(),
+              ${await this.createCategoryNodeSelectClause({
+                nodeSelectClauseFactory,
+                instanceLabelSelectClauseFactory,
+                extendedData: { modelIds: { selector: createIdsSelector(modelIds) } },
               })}
-            FROM ${instanceFilterClauses.from} this
+            FROM ${categoryInstanceFilterClauses.from} this
             JOIN IdSet(?) categoryIdSet ON categoryIdSet.id = this.ECInstanceId
-            ${instanceFilterClauses.joins}
-            ${instanceFilterClauses.where ? `WHERE ${instanceFilterClauses.where}` : ""}
+            ${categoryInstanceFilterClauses.joins}
+            ${categoryInstanceFilterClauses.where ? `WHERE ${categoryInstanceFilterClauses.where}` : ""}
             ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
           bindings: [{ type: "idset", value: categoryIds }],
         },
       },
     ];
+  }
+
+  private async createElementNodeSelectClause({
+    nodeSelectClauseFactory,
+    instanceLabelSelectClauseFactory,
+    allSubModels,
+    extendedData,
+  }: {
+    nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
+    instanceLabelSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["instanceLabelSelectClauseFactory"];
+    allSubModels: Id64String[];
+    extendedData: Props<DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["extendedData"];
+  }): Promise<{ selectClause: string; bindings: ECSqlBinding[] }> {
+    const selectClause = await nodeSelectClauseFactory.createSelectClause({
+      ecClassId: { selector: "this.ECClassId" },
+      ecInstanceId: { selector: "this.ECInstanceId" },
+      nodeLabel: {
+        selector: await instanceLabelSelectClauseFactory.createSelectClause({
+          classAlias: "this",
+          className: this.#hierarchyConfig.elementClassSpecification,
+        }),
+      },
+      grouping: {
+        byClass: this.#hierarchyConfig.elementClassGrouping !== "disable",
+      },
+      hasChildren: {
+        selector: `
+          IFNULL(
+            (
+              SELECT 1
+              FROM ${this.#hierarchyConfig.elementClassSpecification} ce
+              WHERE ce.Parent.Id = this.ECInstanceId
+              LIMIT 1
+            ),
+            ${allSubModels.length ? "InVirtualSet(?, this.ECInstanceId)" : `0`}
+            )
+        `,
+      },
+      extendedData: {
+        isElement: true,
+        modelId: { selector: "IdToHex(this.Model.Id)" },
+        categoryId: { selector: "IdToHex(this.Category.Id)" },
+        imageId: "icon-item",
+        ...extendedData,
+      },
+      supportsFiltering: this.supportsFiltering(),
+    });
+    return {
+      selectClause,
+      bindings: allSubModels.length > 0 ? [{ type: "idset", value: allSubModels }] : [],
+    };
+  }
+
+  private async createCategoryNodeSelectClause({
+    nodeSelectClauseFactory,
+    instanceLabelSelectClauseFactory,
+    extendedData,
+  }: {
+    nodeSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"];
+    instanceLabelSelectClauseFactory: DefineInstanceNodeChildHierarchyLevelProps["instanceLabelSelectClauseFactory"];
+    extendedData: Props<DefineInstanceNodeChildHierarchyLevelProps["nodeSelectClauseFactory"]["createSelectClause"]>["extendedData"];
+  }): Promise<string> {
+    return nodeSelectClauseFactory.createSelectClause({
+      ecClassId: { selector: "this.ECClassId" },
+      ecInstanceId: { selector: "this.ECInstanceId" },
+      nodeLabel: {
+        selector: await instanceLabelSelectClauseFactory.createSelectClause({
+          classAlias: "this",
+          className: CLASS_NAME_SpatialCategory,
+        }),
+      },
+      grouping: { byLabel: { action: "merge", groupId: "category" } },
+      hasChildren: true,
+      extendedData: {
+        imageId: "icon-layers",
+        isCategory: true,
+        ...extendedData,
+      },
+      supportsFiltering: this.supportsFiltering(),
+    });
   }
 
   private async createSpatialCategoryChildrenQuery({
@@ -475,67 +530,31 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory,
     instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const modelIds = parseIdsSelectorResult(parentNode.extendedData?.modelIds);
-    if (modelIds.length === 0) {
-      throw new Error(`Invalid category node "${parentNode.label}" - missing model information.`);
-    }
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
-      filter: instanceFilter,
-      contentClass: { fullName: this.#hierarchyConfig.elementClassSpecification, alias: "this" },
+    assert(ModelsTreeNodeInternal.isCategoryNode(parentNode), "Expected category node as parent");
+    const modelIds = parseIdsSelectorResult(parentNode.extendedData.modelIds);
+    const [instanceFilterClauses, allSubModels] = await Promise.all([
+      nodeSelectClauseFactory.createFilterClauses({
+        filter: instanceFilter,
+        contentClass: { fullName: this.#hierarchyConfig.elementClassSpecification, alias: "this" },
+      }),
+      firstValueFrom(this.#idsCache.getAllSubModels()),
+    ]);
+    const { selectClause, bindings } = await this.createElementNodeSelectClause({
+      nodeSelectClauseFactory,
+      instanceLabelSelectClauseFactory,
+      allSubModels: [...allSubModels],
+      extendedData: {
+        categoryOfTopMostParentElement: { selector: "IdToHex(this.Category.Id)" },
+        topMostParentElementId: { selector: "IdToHex(this.ECInstanceId)" },
+      },
     });
-    const modeledElements = await firstValueFrom(
-      from(modelIds).pipe(
-        mergeMap((modelId) =>
-          from(categoryIds).pipe(
-            mergeMap((categoryId) => this.#idsCache.getSubModels({ modelId, categoryId })),
-            mergeAll(),
-          ),
-        ),
-        toArray(),
-      ),
-    );
     return [
       {
         fullClassName: this.#hierarchyConfig.elementClassSpecification,
         query: {
           ecsql: `
             SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
-                ecClassId: { selector: "this.ECClassId" },
-                ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: this.#hierarchyConfig.elementClassSpecification,
-                  }),
-                },
-                grouping: {
-                  byClass: this.#hierarchyConfig.elementClassGrouping !== "disable",
-                },
-                hasChildren: {
-                  selector: `
-                    IIF(
-                      ${modeledElements.length ? "InVirtualSet(?, this.ECInstanceId)" : `FALSE`},
-                      1,
-                      IFNULL((
-                        SELECT 1
-                        FROM ${this.#hierarchyConfig.elementClassSpecification} ce
-                        WHERE ce.Parent.Id = this.ECInstanceId
-                        LIMIT 1
-                      ), 0)
-                    )
-                  `,
-                },
-                extendedData: {
-                  isElement: true,
-                  modelId: { selector: "IdToHex(this.Model.Id)" },
-                  categoryId: { selector: "IdToHex(this.Category.Id)" },
-                  imageId: "icon-item",
-                  categoryOfTopMostParentElement: { selector: "IdToHex(this.Category.Id)" },
-                  topMostParentElementId: { selector: "IdToHex(this.ECInstanceId)" },
-                },
-                supportsFiltering: this.supportsFiltering(),
-              })}
+              ${selectClause}
             FROM ${instanceFilterClauses.from} this
             JOIN IdSet(?) categoryIdSet ON this.Category.Id = categoryIdSet.id
             JOIN IdSet(?) modelIdSet ON this.Model.Id = modelIdSet.id
@@ -545,11 +564,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
               ${instanceFilterClauses.where ? `AND ${instanceFilterClauses.where}` : ""}
             ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `,
-          bindings: [
-            ...(modeledElements.length > 0 ? [{ type: "idset" as const, value: modeledElements }] : []),
-            { type: "idset", value: categoryIds },
-            { type: "idset", value: modelIds },
-          ],
+          bindings: [...bindings, { type: "idset", value: categoryIds }, { type: "idset", value: modelIds }],
         },
       },
     ];
@@ -562,58 +577,40 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory,
     instanceLabelSelectClauseFactory,
   }: DefineInstanceNodeChildHierarchyLevelProps): Promise<HierarchyLevelDefinition> {
-    const instanceFilterClauses = await nodeSelectClauseFactory.createFilterClauses({
-      filter: instanceFilter,
-      contentClass: { fullName: this.#hierarchyConfig.elementClassSpecification, alias: "this" },
+    assert(ModelsTreeNodeInternal.isElementNode(parentNode), "Expected parent node to be element node");
+    const [elementInstanceFilterClauses, allSubModels] = await Promise.all([
+      nodeSelectClauseFactory.createFilterClauses({
+        filter: instanceFilter,
+        contentClass: { fullName: this.#hierarchyConfig.elementClassSpecification, alias: "this" },
+      }),
+      firstValueFrom(this.#idsCache.getAllSubModels()),
+    ]);
+
+    const { selectClause, bindings } = await this.createElementNodeSelectClause({
+      nodeSelectClauseFactory,
+      instanceLabelSelectClauseFactory,
+      allSubModels: [...allSubModels],
+      extendedData: {
+        categoryOfTopMostParentElement: {
+          selector: `IdToHex(${parentNode.extendedData.categoryOfTopMostParentElement})`,
+        },
+        topMostParentElementId: { selector: `IdToHex(${parentNode.extendedData.topMostParentElementId})` },
+      },
     });
     return [
       {
         fullClassName: this.#hierarchyConfig.elementClassSpecification,
         query: {
           ecsql: `
-            SELECT
-              ${await nodeSelectClauseFactory.createSelectClause({
-                ecClassId: { selector: "this.ECClassId" },
-                ecInstanceId: { selector: "this.ECInstanceId" },
-                nodeLabel: {
-                  selector: await instanceLabelSelectClauseFactory.createSelectClause({
-                    classAlias: "this",
-                    className: this.#hierarchyConfig.elementClassSpecification,
-                  }),
-                },
-                grouping: {
-                  byClass: this.#hierarchyConfig.elementClassGrouping !== "disable",
-                },
-                hasChildren: {
-                  selector: `
-                    IFNULL((
-                      SELECT 1
-                      FROM ${this.#hierarchyConfig.elementClassSpecification} ce
-                      JOIN ${CLASS_NAME_Model} m ON ce.Model.Id = m.ECInstanceId
-                      WHERE ce.Parent.Id = this.ECInstanceId OR (ce.Model.Id = this.ECInstanceId AND m.IsPrivate = false)
-                      LIMIT 1
-                    ), 0)
-                  `,
-                },
-                extendedData: {
-                  isElement: true,
-                  modelId: { selector: "IdToHex(this.Model.Id)" },
-                  categoryId: { selector: "IdToHex(this.Category.Id)" },
-                  imageId: "icon-item",
-                  categoryOfTopMostParentElement: {
-                    selector: `IdToHex(${parentNode.extendedData?.categoryOfTopMostParentElement})`,
-                  },
-                  topMostParentElementId: { selector: `IdToHex(${parentNode.extendedData?.topMostParentElementId})` },
-                },
-                supportsFiltering: this.supportsFiltering(),
-              })}
-            FROM ${instanceFilterClauses.from} this
-            JOIN IdSet(?) elementIdSet ON this.Parent.Id = elementIdSet.id
-            ${instanceFilterClauses.joins}
-            ${instanceFilterClauses.where ? `WHERE ${instanceFilterClauses.where}` : ""}
-            ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
-          `,
-          bindings: [{ type: "idset", value: elementIds }],
+          SELECT
+            ${selectClause}
+          FROM ${elementInstanceFilterClauses.from} this
+          JOIN IdSet(?) elementIdSet ON this.Parent.Id = elementIdSet.id
+          ${elementInstanceFilterClauses.joins}
+          ${elementInstanceFilterClauses.where ? `WHERE ${elementInstanceFilterClauses.where}` : ""}
+          ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
+        `,
+          bindings: [...bindings, { type: "idset", value: elementIds }],
         },
       },
     ];
@@ -699,19 +696,20 @@ export function createGeometricElementInstanceKeyPaths(props: {
       bindings.push({ type: "idset", value: parent.modelIds });
     }
   });
-  return defer(() => {
-    const targetElementsInfoQuery =
-      elementIds.length > 0
-        ? `
+  return props.idsCache.getAllSubModels().pipe(
+    mergeMap(() => {
+      const targetElementsInfoQuery =
+        elementIds.length > 0
+          ? `
             SELECT e.ECInstanceId, e.ECClassId, e.Parent.Id, e.Model.Id, e.Category.Id, -1
             FROM ${elementClassName} e
             JOIN IdSet(?) elementIdSet ON e.ECInstanceId = elementIdSet.id
             ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
           `
-        : undefined;
+          : undefined;
 
-    const targetGroupingNodesElementInfoQueries = groupInfos.map(
-      ({ parent, groupingNode }, index) => `
+      const targetGroupingNodesElementInfoQueries = groupInfos.map(
+        ({ parent, groupingNode }, index) => `
           SELECT e.ECInstanceId, e.ECClassId, e.Parent.Id, e.Model.Id, e.Category.Id, ${index}
           FROM ${elementClassName} e
           JOIN IdSet(?) parentIdSet${index} ON ${parent.type === "element" ? `e.Parent.Id = parentIdSet${index}.id` : `e.Category.Id = parentIdSet${index}.id`}
@@ -721,60 +719,74 @@ export function createGeometricElementInstanceKeyPaths(props: {
             ${parent.type === "element" ? "" : `AND e.Parent.Id IS NULL`}
           ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
         `,
-    );
+      );
 
-    const ctes = [
-      `InstanceElementsWithClassGroupingNodes(ECInstanceId, ECClassId, ParentId, ModelId, CategoryId, GroupingNodeIndex) AS (
-        ${[...(targetElementsInfoQuery ? [targetElementsInfoQuery] : []), ...targetGroupingNodesElementInfoQueries].join(" UNION ALL ")}
-      )`,
-      `ModelsCategoriesElementsHierarchy(ECInstanceId, ParentId, ModelId, GroupingNodeIndex, Path) AS (
-        SELECT
-          e.ECInstanceId,
-          e.ParentId,
-          e.ModelId,
-          e.GroupingNodeIndex,
-          IIF(e.ParentId IS NULL,
-            '${MODEL_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([m].[ECInstanceId]) AS TEXT) || '${separator}${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([c].[ECInstanceId]) AS TEXT) || '${separator}${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([e].[ECInstanceId]) AS TEXT),
+      const ctes = [
+        `InstanceElementsWithClassGroupingNodes(ECInstanceId, ECClassId, ParentId, ModelId, CategoryId, GroupingNodeIndex) AS (
+          ${[...(targetElementsInfoQuery ? [targetElementsInfoQuery] : []), ...targetGroupingNodesElementInfoQueries].join(" UNION ALL ")}
+        )`,
+        `ModelsCategoriesElementsHierarchy(ECInstanceId, ParentId, ModelId, CategoryId, GroupingNodeIndex, Path) AS (
+          SELECT
+            e.ECInstanceId,
+            e.ParentId,
+            e.ModelId,
+            e.CategoryId,
+            e.GroupingNodeIndex,
             '${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([e].[ECInstanceId]) AS TEXT)
-          )
 
-        FROM InstanceElementsWithClassGroupingNodes e
-         LEFT JOIN ${CLASS_NAME_GeometricModel3d} m ON (e.ParentId IS NULL AND m.ECInstanceId = e.ModelId)
-         LEFT JOIN ${CLASS_NAME_SpatialCategory} c ON (e.ParentId IS NULL AND c.ECInstanceId = e.CategoryId)
+          FROM InstanceElementsWithClassGroupingNodes e
 
-        UNION ALL
+          UNION ALL
 
+          SELECT
+            pe.ECInstanceId,
+            pe.Parent.Id,
+            pe.Model.Id,
+            pe.Category.Id,
+            ce.GroupingNodeIndex,
+            (
+              '${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}'
+              || CAST(IdToHex([pe].[ECInstanceId]) AS TEXT)
+              || IIF(ce.ParentId IS NULL,
+                  '${separator}${MODEL_CLASS_NAME_QUERY_ALIAS}${separator}'
+                  || CAST(IdToHex([ce].[ModelId]) AS TEXT)
+                  || '${separator}${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}'
+                  || CAST(IdToHex(ce.CategoryId) AS TEXT)
+                  ,
+                  ''
+                  )
+              || '${separator}'
+              || ce.Path
+            )
+          FROM ModelsCategoriesElementsHierarchy ce
+          JOIN ${elementClassName} pe ON (pe.ECInstanceId = ce.ParentId OR (pe.ECInstanceId = ce.ModelId AND ce.ParentId IS NULL))
+        )`,
+      ];
+      const ecsql = `
         SELECT
-          pe.ECInstanceId,
-          pe.Parent.Id,
-          pe.Model.Id,
-          ce.GroupingNodeIndex,
-          IIF(pe.Parent.Id IS NULL,
-            '${MODEL_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([m].[ECInstanceId]) AS TEXT) || '${separator}${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([c].[ECInstanceId]) AS TEXT) || '${separator}${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([pe].[ECInstanceId]) AS TEXT) || '${separator}' || ce.Path,
-            '${ELEMENT_CLASS_NAME_QUERY_ALIAS}${separator}' || CAST(IdToHex([pe].[ECInstanceId]) AS TEXT) || '${separator}' || ce.Path
-          )
-        FROM ModelsCategoriesElementsHierarchy ce
-        JOIN ${elementClassName} pe ON (pe.ECInstanceId = ce.ParentId OR pe.ECInstanceId = ce.ModelId AND ce.ParentId IS NULL)
-        LEFT JOIN ${CLASS_NAME_GeometricModel3d} m ON (pe.Parent.Id IS NULL AND m.ECInstanceId = pe.Model.Id)
-        LEFT JOIN ${CLASS_NAME_SpatialCategory} c ON (pe.Parent.Id IS NULL AND c.ECInstanceId = pe.Category.Id)
-      )`,
-    ];
-    const ecsql = `
-      SELECT mce.ModelId, mce.Path, mce.GroupingNodeIndex
-      FROM ModelsCategoriesElementsHierarchy mce
-      WHERE mce.ParentId IS NULL
-    `;
+          (
+            '${MODEL_CLASS_NAME_QUERY_ALIAS}${separator}'
+            || CAST(IdToHex([mce].[ModelId]) AS TEXT)
+            || '${separator}${CATEGORY_CLASS_NAME_QUERY_ALIAS}${separator}'
+            || CAST(IdToHex([mce].[CategoryId]) AS TEXT)
+            || '${separator}'
+            || mce.Path
+          ),
+          mce.GroupingNodeIndex
+        FROM ModelsCategoriesElementsHierarchy mce
+        WHERE mce.ParentId IS NULL
+      `;
 
-    return queryExecutor.createQueryReader(
-      { ctes, ecsql, bindings },
-      { rowFormat: "Indexes", limit: "unbounded", restartToken: `${componentName}/${componentId}/geometric-element-paths/${chunkIndex}` },
-    );
-  }).pipe(
+      return queryExecutor.createQueryReader(
+        { ctes, ecsql, bindings },
+        { rowFormat: "Indexes", limit: "unbounded", restartToken: `${componentName}/${componentId}/geometric-element-paths/${chunkIndex}` },
+      );
+    }),
     catchBeSQLiteInterrupts,
     releaseMainThreadOnItemsCount(300),
-    map((row) => parseQueryRow(row, groupInfos, separator, elementClassName)),
-    mergeMap(({ modelId, elementHierarchyPath, groupingInfo }) =>
-      idsCache.createUpToModelInstanceKeyPaths(modelId).pipe(
+    map((row) => parseElementsQueryRow(row, groupInfos, separator, elementClassName)),
+    mergeMap(({ elementHierarchyPath, groupingInfo }) =>
+      idsCache.createUpToModelInstanceKeyPaths(elementHierarchyPath[0].id).pipe(
         map((modelPath) => {
           const path = [...modelPath, ...elementHierarchyPath];
           return {
@@ -787,27 +799,39 @@ export function createGeometricElementInstanceKeyPaths(props: {
   );
 }
 
-function parseQueryRow(row: ECSqlQueryRow, groupInfos: ElementsGroupInfo[], separator: string, elementClassName: EC.FullClassName) {
-  const rowElements: string[] = row[1].split(separator);
+function parseElementsQueryRow(row: ECSqlQueryRow, groupInfos: ElementsGroupInfo[], separator: string, elementClassName: EC.FullClassName) {
+  const path = parseQueriedPath({ queriedPathRaw: row[0], elementClassName, separator });
+  return {
+    elementHierarchyPath: path,
+    groupingInfo: row[1] === -1 ? undefined : groupInfos[row[1]],
+  };
+}
+
+function parseQueriedPath({
+  queriedPathRaw,
+  elementClassName,
+  separator,
+}: {
+  queriedPathRaw: string;
+  elementClassName: EC.FullClassName;
+  separator: string;
+}): HierarchyNodeIdentifiersPath {
   const path = new Array<InstanceKey>();
-  for (let i = 0; i < rowElements.length; i += 2) {
-    switch (rowElements[i]) {
+  const queriedPath: string[] = queriedPathRaw.split(separator);
+  for (let i = 0; i < queriedPath.length; i += 2) {
+    switch (queriedPath[i]) {
       case ELEMENT_CLASS_NAME_QUERY_ALIAS:
-        path.push({ className: elementClassName, id: rowElements[i + 1] });
+        path.push({ className: elementClassName, id: queriedPath[i + 1] });
         break;
       case CATEGORY_CLASS_NAME_QUERY_ALIAS:
-        path.push({ className: CLASS_NAME_SpatialCategory, id: rowElements[i + 1] });
+        path.push({ className: CLASS_NAME_SpatialCategory, id: queriedPath[i + 1] });
         break;
       case MODEL_CLASS_NAME_QUERY_ALIAS:
-        path.push({ className: CLASS_NAME_GeometricModel3d, id: rowElements[i + 1] });
+        path.push({ className: CLASS_NAME_GeometricModel3d, id: queriedPath[i + 1] });
         break;
     }
   }
-  return {
-    modelId: row[0],
-    elementHierarchyPath: path,
-    groupingInfo: row[2] === -1 ? undefined : groupInfos[row[2]],
-  };
+  return path;
 }
 
 function createInstanceKeyPathsFromTargetItemsObs(

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeIdsCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defer, EMPTY, filter, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, shareReplay } from "rxjs";
+import { defer, EMPTY, filter, forkJoin, from, map, merge, mergeAll, mergeMap, of, reduce, shareReplay, toArray } from "rxjs";
 import { assert, Guid, Id64 } from "@itwin/core-bentley";
 import { IModel } from "@itwin/core-common";
 import { BaseIdsCacheImpl } from "../../common/internal/caches/BaseIdsCache.js";
@@ -319,7 +319,16 @@ export class ModelsTreeIdsCache extends BaseIdsCacheImpl {
 
   public createCategoryInstanceKeyPaths({ categoryIds }: { categoryIds: Id64Array }): Observable<HierarchyNodeIdentifiersPath> {
     const pathsWithSubModels = fromWithRelease({ source: categoryIds, releaseOnCount: 200 }).pipe(
-      mergeMap((id) => forkJoin({ id: of(id), subModels: this.getModels({ subModels: "only", categoryId: id, includeOnlyIfCategoryOfTopMostElement: true }) })),
+      mergeMap((id) =>
+        forkJoin({
+          id: of(id),
+          subModels: this.getModels({ categoryId: id }).pipe(
+            filter(({ categoryIsOfTopMostElement, isSubModel }) => categoryIsOfTopMostElement && isSubModel),
+            map(({ id: modelId }) => modelId),
+            toArray(),
+          ),
+        }),
+      ),
       reduce((acc, { id, subModels }) => {
         for (const subModelId of subModels) {
           const entry = getOrCreate({ map: acc, key: subModelId, createFunc: () => new Set<CategoryId>() });
@@ -360,9 +369,9 @@ export class ModelsTreeIdsCache extends BaseIdsCacheImpl {
     );
     const pathsWithoutSubModels = from(categoryIds).pipe(
       mergeMap((categoryId) =>
-        this.getModels({ categoryId, subModels: "exclude", includeOnlyIfCategoryOfTopMostElement: true }).pipe(
-          mergeAll(),
-          mergeMap((categoryModelId) =>
+        this.getModels({ categoryId }).pipe(
+          filter(({ categoryIsOfTopMostElement, isSubModel }) => categoryIsOfTopMostElement && !isSubModel),
+          mergeMap(({ id: categoryModelId }) =>
             this.createUpToModelInstanceKeyPaths(categoryModelId).pipe(
               map((modelPath) => [
                 ...modelPath,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeNodeInternal.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/ModelsTreeNodeInternal.ts
@@ -23,28 +23,48 @@ export namespace ModelsTreeNodeInternal {
 
   export const isCategoryNode = ModelsTreeNode.isCategoryNode;
 
+  export const isRawCategoryNode = ModelsTreeNode.isCategoryNode;
+
   export const isElementNode = (
     node: Pick<HierarchyNode, "extendedData">,
   ): node is Omit<NonGroupingHierarchyNode, "extendedData"> & { key: InstancesNodeKey } & {
-    extendedData: {
-      modelId: Id64String;
-      categoryId: Id64String;
-      categoryOfTopMostParentElement: CategoryId;
-      topMostParentElementId: Id64String;
-    };
+    extendedData: ElementNodeProps;
+  } => ModelsTreeNode.isElementNode(node);
+
+  export const isRawElementNode = (
+    node: Pick<HierarchyNode, "extendedData">,
+  ): node is Omit<NonGroupingHierarchyNode, "extendedData"> & { key: InstancesNodeKey } & {
+    extendedData: ElementNodeProps & { [key: string]: any };
   } => ModelsTreeNode.isElementNode(node);
 
   export const isElementClassGroupingNode = (
     node: Pick<HierarchyNode, "key">,
   ): node is Omit<GroupingHierarchyNode, "extendedData"> & { key: ClassGroupingNodeKey } & {
-    extendedData: {
-      modelId: Id64String;
-      categoryId: Id64String;
-      categoryOfTopMostParentElement: CategoryId;
-      topMostParentElementId?: Id64String;
-      childrenWhichAreParents: Set<ElementId>;
-    };
+    extendedData: ElementClassGroupingNodeProps;
   } => ModelsTreeNode.isElementClassGroupingNode(node);
 
   export const getType = ModelsTreeNode.getType;
+}
+
+/**
+ * @internal
+ */
+export interface ElementNodeProps {
+  modelId: Id64String;
+  categoryId: Id64String;
+  categoryOfTopMostParentElement: CategoryId;
+  topMostParentElementId: Id64String;
+}
+
+/**
+ * @internal
+ */
+export interface ElementClassGroupingNodeProps {
+  modelId: Id64String;
+  categoryId: Id64String;
+  categoryOfTopMostParentElement: CategoryId;
+  topMostParentElementId?: Id64String;
+  childrenWhichAreParents: Set<ElementId>;
+  hasDirectNonSearchTargets?: boolean;
+  hasSearchTargetAncestor?: boolean;
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/visibility/ModelsTreeVisibilityHandler.ts
@@ -184,10 +184,17 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
     }
 
     if (ModelsTreeNodeInternal.isCategoryNode(node)) {
-      return this.#visibilityHelper.getCategoriesVisibilityStatus({
-        categoryIds: node.key.instanceKeys.map(({ id }) => id),
-        modelId: node.extendedData.modelIds[0],
-      });
+      const categoryIds = node.key.instanceKeys.map(({ id }) => id);
+      const modelIds = node.extendedData.modelIds.length > 0 ? node.extendedData.modelIds : [undefined];
+      return from(modelIds).pipe(
+        mergeMap((modelId) =>
+          this.#visibilityHelper.getCategoriesVisibilityStatus({
+            categoryIds,
+            modelId,
+          }),
+        ),
+        mergeVisibilityStatuses(),
+      );
     }
 
     assert(ModelsTreeNodeInternal.isElementNode(node));
@@ -240,11 +247,17 @@ export class ModelsTreeVisibilityHandler implements Disposable, TreeSpecificVisi
       }
 
       if (ModelsTreeNodeInternal.isCategoryNode(node)) {
-        return this.#visibilityHelper.changeCategoriesVisibilityStatus({
-          categoryIds: node.key.instanceKeys.map(({ id }) => id),
-          modelId: node.extendedData.modelIds[0],
-          on,
-        });
+        const categoryIds = node.key.instanceKeys.map(({ id }) => id);
+        const modelIds = node.extendedData.modelIds.length > 0 ? node.extendedData.modelIds : [undefined];
+        return from(modelIds).pipe(
+          mergeMap((modelId) =>
+            this.#visibilityHelper.changeCategoriesVisibilityStatus({
+              categoryIds,
+              modelId,
+              on,
+            }),
+          ),
+        );
       }
 
       assert(ModelsTreeNodeInternal.isElementNode(node));

--- a/packages/itwin/tree-widget/vitest.config.ts
+++ b/packages/itwin/tree-widget/vitest.config.ts
@@ -5,11 +5,7 @@
 
 import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
-const logsToIgnore = [
-  "CSS variable not found",
-  // TODO: Should be removed after core 5.8 is consumed
-  "there are no unsaved changes",
-];
+const logsToIgnore = ["CSS variable not found", "ECClass 'PresentationRules.Ruleset' does not exist or could not be loaded."];
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
Part of: https://github.com/iTwin/viewer-components-react/pull/1716. 
Extracted changes that are not necessary for child elements category. 
- Consolidated category info into `getCachedCategoryData`, added `isTopMostElementCategory`; `getSubModels` now streams and filters by sub-model/top-most flags.
- Added 2D sub-modelable test schema classes; category test nodes always carry a `modelIds` array.
- Changing visibility of sub-model category does not change the visibility of the same category node that is at the root.