### PR TITLE
[Tree widget]: pin node version in release pipeline on `next`

### DIFF
--- a/.pipelines/publish.yaml
+++ b/.pipelines/publish.yaml
@@ -19,7 +19,7 @@ variables:
   - name: REPO_URL
     value: github.com/iTwin/viewer-components-react
   - name: NodeVersion
-    value: 24.x
+    value: 24.15.0
   - name: pnpm_config_cache
     value: $(Pipeline.Workspace)/.pnpm-store
 


### PR DESCRIPTION
Pinning node version on 24.15, since pipeline seems to hang: https://github.com/iTwin/itwinjs-core/issues/9325