### PR TITLE
[Tree widget]: adjust descendants count cache on `next`

### DIFF
--- a/change/@itwin-tree-widget-react-ba74e66c-c9e4-4f78-8c6f-8603e392ba2a.json
+++ b/change/@itwin-tree-widget-react-ba74e66c-c9e4-4f78-8c6f-8603e392ba2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adjust Descendants count query to not include modelId.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -2275,9 +2275,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) =>
                 createClassGroupingHierarchyNode({
                   categoryId: ids.category.id,
-                  modelElementsMap: new Map([
-                    [ids.model.id, { elementIds: new Set([ids.modeledElement.id]), categoryOfTopMostParentElement: ids.category.id }],
-                  ]),
+                  modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
                 }),
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
@@ -2401,9 +2399,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) =>
                 createClassGroupingHierarchyNode({
                   categoryId: ids.category.id,
-                  modelElementsMap: new Map([
-                    [ids.model.id, { elementIds: new Set([ids.modeledElement.id]), categoryOfTopMostParentElement: ids.category.id }],
-                  ]),
+                  modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
                 }),
               // Category has partial visibility, since its sub-category is not visible
               // prettier-ignore
@@ -2472,9 +2468,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) =>
                 createClassGroupingHierarchyNode({
                   categoryId: ids.category.id,
-                  modelElementsMap: new Map([
-                    [ids.model.id, { elementIds: new Set([ids.modeledElement.id]), categoryOfTopMostParentElement: ids.category.id }],
-                  ]),
+                  modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
                 }),
               // Category has partial visibility, since its sub-category is not visible
               // prettier-ignore

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
@@ -89,7 +89,7 @@ export function createClassGroupingHierarchyNode({
   ...props
 }: {
   categoryId: Id64String | undefined;
-  modelElementsMap: Map<ModelId, { elementIds: Set<ElementId>; categoryOfTopMostParentElement?: Id64String }>;
+  modelElementsMap: Map<ModelId, { elementIds: Set<ElementId> }>;
   className?: EC.FullClassName;
   parentKeys?: Array<InstanceKey | ClassGroupingNodeKey>;
   hasDirectNonSearchTargets?: boolean;

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/DescendantsCountCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/DescendantsCountCache.test.ts
@@ -196,6 +196,36 @@ describe("DescendantsCountCache", () => {
       await Promise.all([...promises, vi.advanceTimersByTimeAsync(20)]);
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);
     });
+
+    it("returns default count for root category request covered only by the cross-product of an in-flight batch", async () => {
+      // The in-flight batch contains { model1, catA } and { model2, catB }. The consolidated root-category query is:
+      //   Model.Id IN (model1, model2) AND Category.Id IN (catA, catB) AND Parent.Id IS NULL
+      // A request for { model1, catB } is treated as "covered" by this batch (model1 and catB both appear), but if
+      // model1 has no root elements in catB, the query returns no row for that pair and a default entry must still be created.
+      let crossProductResultPromise: Promise<Array<{ categoryId: string; count: number }>> | undefined;
+      const requestHolder: { cache?: DescendantsCountCache } = {};
+      using vp = createFakeViewport({
+        queryHandler: () => {
+          // Request { model1: "0x1", catB: "0x4" } while the batch query is in-flight.
+          crossProductResultPromise = firstValueFrom(requestHolder.cache!.getDescendantsCounts({ modelId: "0x1", categoryId: "0x4" }));
+          return [
+            { modelId: "0x1", reqParent: null, reqCategory: "0x2", ownCategory: "0x2", cnt: 1 },
+            { modelId: "0x3", reqParent: null, reqCategory: "0x4", ownCategory: "0x4", cnt: 1 },
+          ];
+        },
+      });
+      const cache = createFakeCache(vp);
+      requestHolder.cache = cache;
+
+      const promise1 = firstValueFrom(cache.getDescendantsCounts({ modelId: "0x1", categoryId: "0x2" }));
+      const promise2 = firstValueFrom(cache.getDescendantsCounts({ modelId: "0x3", categoryId: "0x4" }));
+      await Promise.all([promise1, promise2, vi.advanceTimersByTimeAsync(20)]);
+
+      expect(crossProductResultPromise).toBeDefined();
+      const crossProductResult = await crossProductResultPromise!;
+      expect(crossProductResult).toEqual([{ categoryId: "0x4", count: 0 }]);
+      expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
+    });
   });
 
   describe("query results", () => {

--- a/packages/itwin/tree-widget/src/test/trees/common/internal/DescendantsCountCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/common/internal/DescendantsCountCache.test.ts
@@ -180,7 +180,7 @@ describe("DescendantsCountCache", () => {
       const cache = createFakeCache(vp);
       const promises = new Array<Promise<unknown>>();
       for (let i = 1; i <= 100; ++i) {
-        promises.push(firstValueFrom(cache.getDescendantsCounts({ modelId: `0x${i}`, categoryId: "0x1000" })));
+        promises.push(firstValueFrom(cache.getDescendantsCounts({ modelId: `0x1`, categoryId: "0x1000", parentElementId: `0x${i + 1}` })));
       }
       await Promise.all([...promises, vi.advanceTimersByTimeAsync(20)]);
       expect(vp.iModel.createQueryReader).toHaveBeenCalledOnce();
@@ -191,7 +191,7 @@ describe("DescendantsCountCache", () => {
       const cache = createFakeCache(vp);
       const promises = new Array<Promise<unknown>>();
       for (let i = 1; i <= 101; ++i) {
-        promises.push(firstValueFrom(cache.getDescendantsCounts({ modelId: `0x${i}`, categoryId: "0x1000" })));
+        promises.push(firstValueFrom(cache.getDescendantsCounts({ modelId: `0x1`, categoryId: "0x1000", parentElementId: `0x${i + 1}` })));
       }
       await Promise.all([...promises, vi.advanceTimersByTimeAsync(20)]);
       expect(vp.iModel.createQueryReader).toHaveBeenCalledTimes(2);

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -120,15 +120,6 @@ export function createFakeIdsCache(props?: IdsCacheMockProps): ModelsTreeIdsCach
       }
       return of(result);
     }),
-    getElementsCount: vi.fn(({ categoryId, parentElementId }: { modelId: Id64String; categoryId?: Id64String; parentElementId?: Id64String }) => {
-      if (parentElementId) {
-        return of(props?.elementChildren?.get(parentElementId)?.length ?? 0);
-      }
-      if (categoryId) {
-        return of(props?.categoryElements?.get(categoryId)?.length ?? 0);
-      }
-      return of(0);
-    }),
     getDescendantsCounts: vi.fn(({ categoryId, parentElementId }: { modelId: Id64String; categoryId?: Id64String; parentElementId?: Id64String }) => {
       if (parentElementId) {
         const children = props?.elementChildren?.get(parentElementId) ?? [];

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeIdsCache.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeIdsCache.test.ts
@@ -30,15 +30,15 @@ describe("ModelsTreeIdsCache", () => {
     const categoryId = "0x2";
     const elementCount = 3;
     const stub = vi.fn((query: string) => {
-      if (query.includes("Descendants") && query.includes(`Model.Id = ${modelId}`)) {
+      if (query.includes("Descendants")) {
         return [{ modelId, reqParent: null, reqCategory: categoryId, ownCategory: categoryId, cnt: elementCount }];
       }
       throw new Error(`Unexpected query: ${query}`);
     });
     const cache = createIdsCache(stub);
-    await expect(firstValueFrom(cache.getElementsCount({ modelId, categoryId }))).resolves.toBe(elementCount);
+    await expect(firstValueFrom(cache.getDescendantsCounts({ modelId, categoryId }))).resolves.toEqual([{ categoryId, count: elementCount }]);
     expect(stub).toHaveBeenCalledOnce();
-    await expect(firstValueFrom(cache.getElementsCount({ modelId, categoryId }))).resolves.toBe(elementCount);
+    await expect(firstValueFrom(cache.getDescendantsCounts({ modelId, categoryId }))).resolves.toEqual([{ categoryId, count: elementCount }]);
     expect(stub).toHaveBeenCalledOnce();
   });
 
@@ -49,7 +49,7 @@ describe("ModelsTreeIdsCache", () => {
     const elementCount1 = 3;
     const elementCount2 = 4;
     const stub = vi.fn((query: string) => {
-      if (query.includes("Descendants") && query.includes(`Model.Id = ${modelId}`)) {
+      if (query.includes("Descendants")) {
         return [
           { modelId, reqParent: null, reqCategory: categoryId, ownCategory: categoryId, cnt: elementCount1 },
           { modelId, reqParent: null, reqCategory: categoryId2, ownCategory: categoryId2, cnt: elementCount2 },
@@ -58,11 +58,21 @@ describe("ModelsTreeIdsCache", () => {
       throw new Error(`Unexpected query: ${query}`);
     });
     const cache = createIdsCache(stub);
-    const obs1 = cache.getElementsCount({ modelId, categoryId });
-    const obs2 = cache.getElementsCount({ modelId, categoryId: categoryId2 });
+    const obs1 = cache.getDescendantsCounts({ modelId, categoryId });
+    const obs2 = cache.getDescendantsCounts({ modelId, categoryId: categoryId2 });
     const [count1, count2] = await Promise.all([firstValueFrom(obs1), firstValueFrom(obs2)]);
-    expect(count1).toBe(elementCount1);
-    expect(count2).toBe(elementCount2);
+    expect(count1).toEqual([
+      {
+        categoryId,
+        count: elementCount1,
+      },
+    ]);
+    expect(count2).toEqual([
+      {
+        categoryId: categoryId2,
+        count: elementCount2,
+      },
+    ]);
     expect(stub).toHaveBeenCalledOnce();
   });
 });

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/internal/ClassificationsTreeIdsCache.ts
@@ -56,7 +56,7 @@ interface ClassificationsTreeIdsCacheProps extends BaseIdsCacheImplProps {
 /** @internal */
 export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
   #classificationInfos: Observable<Map<ClassificationId | ClassificationTableId, ClassificationInfo>> | undefined;
-  #filteredElementsData: Observable<Map<ElementId, { modelId: Id64String; categoryId: Id64String; categoryOfTopMostParentElement: CategoryId }>> | undefined;
+  #filteredElementsData: Observable<Map<ElementId, { modelId: Id64String; categoryId: Id64String }>> | undefined;
   #props: ClassificationsTreeIdsCacheProps;
   #componentId: GuidString;
   #componentName: string;
@@ -265,29 +265,13 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
     modelId: Id64String;
     id: ElementId;
     categoryId: Id64String;
-    categoryOfTopMostParentElement: Id64String;
   }> {
     return defer(() => {
       const query = `
         SELECT
           this.Model.Id modelId,
           this.Category.Id categoryId,
-          this.ECInstanceId id,
-          (
-            WITH RECURSIVE
-              ParentWithCategory(id, categoryId, parentId) AS (
-                SELECT e.ECInstanceId, e.Category.Id, e.Parent.Id
-                FROM ${CLASS_NAME_GeometricElement3d} e
-                WHERE e.ECInstanceId = this.ECInstanceId
-                UNION ALL
-                SELECT p.ECInstanceId, p.Category.Id, p.Parent.Id
-                FROM ${CLASS_NAME_GeometricElement3d} p
-                JOIN ParentWithCategory c ON p.ECInstanceId = c.parentId
-              )
-            SELECT IdToHex(categoryId)
-            FROM ParentWithCategory
-            WHERE parentId IS NULL
-          ) categoryOfTopMostParentElement
+          this.ECInstanceId id
         FROM ${CLASS_NAME_GeometricElement3d} this
         JOIN IdSet(?) elementIdSet ON ECInstanceId = elementIdSet.id
         ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
@@ -310,26 +294,21 @@ export class ClassificationsTreeIdsCache extends BaseIdsCacheImpl {
           modelId: row.modelId,
           id: row.id,
           categoryId: row.categoryId,
-          categoryOfTopMostParentElement: row.categoryOfTopMostParentElement,
         };
       }),
     );
   }
 
-  public getFilteredElementsData({
-    elementIds,
-  }: {
-    elementIds: Id64Array;
-  }): Observable<Map<ElementId, { categoryId: Id64String; modelId: Id64String; categoryOfTopMostParentElement: CategoryId }>> {
-    const result = new Map<ElementId, { categoryId: Id64String; modelId: Id64String; categoryOfTopMostParentElement: CategoryId }>();
+  public getFilteredElementsData({ elementIds }: { elementIds: Id64Array }): Observable<Map<ElementId, { categoryId: Id64String; modelId: Id64String }>> {
+    const result = new Map<ElementId, { categoryId: Id64String; modelId: Id64String }>();
     if (Id64.sizeOf(elementIds) === 0) {
       return of(result);
     }
     this.#filteredElementsData ??= this.queryFilteredElementsData({
       elementIds,
     }).pipe(
-      reduce((acc, { modelId, id, categoryId, categoryOfTopMostParentElement }) => {
-        acc.set(id, { modelId, categoryId, categoryOfTopMostParentElement });
+      reduce((acc, { modelId, id, categoryId }) => {
+        acc.set(id, { modelId, categoryId });
         return acc;
       }, result),
       shareReplay(),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/BaseIdsCache.ts
@@ -179,10 +179,6 @@ export class BaseIdsCache {
     return this.#descendantsCountCache.getDescendantsCounts(props);
   }
 
-  public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {
-    return this.#descendantsCountCache.getDescendantsCounts(props).pipe(map((counts) => counts.reduce((sum, entry) => sum + entry.count, 0)));
-  }
-
   // ChildElementsCache methods
 
   public getChildElements(props: Props<ChildElementsCache["getChildElements"]>): ReturnType<ChildElementsCache["getChildElements"]> {
@@ -259,10 +255,6 @@ export class BaseIdsCacheImpl {
 
   public getDescendantsCounts(props: Props<DescendantsCountCache["getDescendantsCounts"]>): ReturnType<DescendantsCountCache["getDescendantsCounts"]> {
     return this.#baseIdsCache.getDescendantsCounts(props);
-  }
-
-  public getElementsCount(props: Props<DescendantsCountCache["getDescendantsCounts"]>): Observable<number> {
-    return this.#baseIdsCache.getElementsCount(props);
   }
 
   public getCategories(props: Props<ElementModelCategoriesCache["getModelCategoryIds"]>): ReturnType<ElementModelCategoriesCache["getModelCategoryIds"]> {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -222,7 +222,7 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     const rootCategoryIds = new Set<CategoryId>();
     const rootCategoryModels = new Set<ModelId>();
     for (const { modelId, categoryId, parentElementId } of batch) {
-      if (parentElementId === undefined) {
+      if (parentElementId === undefined && categoryId !== undefined) {
         rootCategoryIds.add(categoryId);
         rootCategoryModels.add(modelId);
         continue;

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -72,55 +72,73 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
     request: DescendantsCountRequest,
     batch: DescendantsCountRequest[],
   ): { valuesNotInBatch: DescendantsCountRequest; batchContainsValues: boolean } | { valuesNotInBatch: undefined; batchContainsValues: true } {
-    if (batch.some((r) => r.modelId === request.modelId && r.parentElementId === request.parentElementId && r.categoryId === request.categoryId)) {
+    if (request.categoryId && request.parentElementId === undefined) {
+      // This is a root category request.
+      // When multiple root category requests are made under different models, then request will include all models and all categories.
+      // E.g.
+      // request1: { modelId: "model1", categoryId: "category1" }, request2: { modelId: "model2", categoryId: "category2" }
+      // Query: SELECT ... WHERE Model.Id IN (model1, model2) AND Category.Id IN (category1, category2) AND Parent.Id IS NULL
+      let hasRootModelRequest = false;
+      let hasRootCategoryRequest = false;
+      for (const r of batch) {
+        hasRootModelRequest ||= r.modelId === request.modelId && r.parentElementId === undefined;
+        hasRootCategoryRequest ||= r.categoryId === request.categoryId && r.parentElementId === undefined;
+        // batch has a request for the same model and category, no need to add them to the batch.
+        if (hasRootModelRequest && hasRootCategoryRequest) {
+          return { valuesNotInBatch: undefined, batchContainsValues: true };
+        }
+      }
+    } else if (batch.some((r) => r.modelId === request.modelId && r.parentElementId === request.parentElementId && r.categoryId === request.categoryId)) {
       return { valuesNotInBatch: undefined, batchContainsValues: true };
     }
     return { valuesNotInBatch: request, batchContainsValues: false };
   }
 
   protected getQueryData(batch: DescendantsCountRequest[]): Observable<WhereClause> {
-    const groupedCategoryValues = new Map<ElementId, Set<CategoryId>>();
-    const rootCategoryValues = new Set<CategoryId>();
-    const elementValues = new Set<ElementId>();
-    // Requests contain modelId, but there is no need to include them in the query:
-    // - When making element request: it can only exist within a single model;
-    // - When making category request: if count for category under one model is requested, then it will be requested for other models also,
-    // so there is no need to include them in the query.
+    const groupedCategoryIds = new Map<ElementId, Set<CategoryId>>();
+    const rootCategoryIds = new Set<CategoryId>();
+    const rootCategoryModels = new Set<ModelId>();
+    const elementIds = new Set<ElementId>();
     for (const batchEntry of batch) {
       if (batchEntry.categoryId === undefined) {
-        elementValues.add(batchEntry.parentElementId);
+        elementIds.add(batchEntry.parentElementId);
         continue;
       }
-      const { parentElementId, categoryId } = batchEntry;
+      const { parentElementId, categoryId, modelId } = batchEntry;
       if (!parentElementId) {
-        rootCategoryValues.add(categoryId);
+        rootCategoryIds.add(categoryId);
+        rootCategoryModels.add(modelId);
         continue;
       }
-      const parentEntry = getOrCreate({ map: groupedCategoryValues, key: parentElementId, createFunc: () => new Set<CategoryId>() });
+      const parentEntry = getOrCreate({ map: groupedCategoryIds, key: parentElementId, createFunc: () => new Set<CategoryId>() });
       parentEntry.add(categoryId);
     }
     return merge(
-      from(groupedCategoryValues.entries()).pipe(
+      from(groupedCategoryIds.entries()).pipe(
         map(([parentElementId, categoryIds], idx): WhereClause => {
           return {
-            whereClause: `Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) AND Parent.Id = ${parentElementId}`,
+            whereClause: `Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx}) AND Parent.Id = ${parentElementId}`,
             type: "category" as const,
             bindings: [{ type: "idset" as const, value: [...categoryIds] }],
           };
         }),
       ),
-      rootCategoryValues.size > 0
+      rootCategoryIds.size && rootCategoryModels.size > 0
         ? of({
-            whereClause: "Category.Id IN (SELECT categoryIdSet.id FROM IdSet(?) categoryIdSet ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) AND Parent.Id IS NULL",
+            whereClause:
+              "Model.Id IN (SELECT modelIdSet.id FROM IdSet(?) modelIdSet) AND Category.Id IN (SELECT categoryIdSet.id FROM IdSet(?) categoryIdSet) AND Parent.Id IS NULL",
             type: "category" as const,
-            bindings: [{ type: "idset" as const, value: [...rootCategoryValues] }],
+            bindings: [
+              { type: "idset" as const, value: [...rootCategoryModels] },
+              { type: "idset" as const, value: [...rootCategoryIds] },
+            ],
           })
         : EMPTY,
-      elementValues.size > 0
+      elementIds.size > 0
         ? of({
-            whereClause: `Parent.Id IN (SELECT elementIdSet.id FROM IdSet(?) elementIdSet ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES)`,
+            whereClause: `Parent.Id IN (SELECT elementIdSet.id FROM IdSet(?) elementIdSet)`,
             type: "element" as const,
-            bindings: [{ type: "idset" as const, value: [...elementValues] }],
+            bindings: [{ type: "idset" as const, value: [...elementIds] }],
           })
         : EMPTY,
     );
@@ -164,6 +182,7 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
               `
               Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
                 ${baseCases.join(" UNION ALL ")}
+                ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
                 UNION ALL
 
@@ -177,6 +196,7 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
               SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
               FROM Descendants
               GROUP BY modelId, reqParent, reqCategory, ownCategory
+
             `,
             bindings: bindings.length > 0 ? bindings : undefined,
           },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -182,7 +182,6 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
               `
               Descendants(id, modelId, reqParent, reqCategory, ownCategory) AS (
                 ${baseCases.join(" UNION ALL ")}
-                ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
 
                 UNION ALL
 
@@ -196,7 +195,7 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
               SELECT modelId, reqParent, reqCategory, ownCategory, COUNT(*) as cnt
               FROM Descendants
               GROUP BY modelId, reqParent, reqCategory, ownCategory
-
+              ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES
             `,
             bindings: bindings.length > 0 ? bindings : undefined,
           },
@@ -220,11 +219,28 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
   }
 
   protected ensureDefaultCacheEntries(batch: DescendantsCountRequest[]): void {
+    const rootCategoryIds = new Set<CategoryId>();
+    const rootCategoryModels = new Set<ModelId>();
     for (const { modelId, categoryId, parentElementId } of batch) {
+      if (parentElementId === undefined) {
+        rootCategoryIds.add(categoryId);
+        rootCategoryModels.add(modelId);
+        continue;
+      }
       const modelEntry = getOrCreate({ map: this.#cachedValues, key: modelId, createFunc: () => new Map() });
       const parentEntry = getOrCreate({ map: modelEntry, key: parentElementId, createFunc: () => new Map() });
       if (!parentEntry.has(categoryId)) {
         parentEntry.set(categoryId, categoryId === undefined ? [] : [{ categoryId, count: 0 }]);
+      }
+    }
+    // Make sure that default entry exists for all model - root category pairs.
+    for (const modelId of rootCategoryModels) {
+      const modelEntry = getOrCreate({ map: this.#cachedValues, key: modelId, createFunc: () => new Map() });
+      const parentEntry = getOrCreate({ map: modelEntry, key: undefined, createFunc: () => new Map() });
+      for (const categoryId of rootCategoryIds) {
+        if (!parentEntry.has(categoryId)) {
+          parentEntry.set(categoryId, categoryId === undefined ? [] : [{ categoryId, count: 0 }]);
+        }
       }
     }
   }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/common/internal/caches/DescendantsCountCache.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { defer, EMPTY, from, map, merge, mergeMap } from "rxjs";
+import { defer, EMPTY, from, map, merge, of } from "rxjs";
 import { Guid } from "@itwin/core-bentley";
 import { getOrCreate } from "../Utils.js";
 import { BatchingCache } from "./BatchingCache.js";
@@ -79,42 +79,50 @@ export class DescendantsCountCache extends BatchingCache<DescendantsCountRequest
   }
 
   protected getQueryData(batch: DescendantsCountRequest[]): Observable<WhereClause> {
-    const groupedCategoryValues = new Map<ModelId, Map<ElementId | undefined, Set<CategoryId>>>();
-    const groupedElementValues = new Map<ModelId, Set<ElementId>>();
+    const groupedCategoryValues = new Map<ElementId, Set<CategoryId>>();
+    const rootCategoryValues = new Set<CategoryId>();
+    const elementValues = new Set<ElementId>();
+    // Requests contain modelId, but there is no need to include them in the query:
+    // - When making element request: it can only exist within a single model;
+    // - When making category request: if count for category under one model is requested, then it will be requested for other models also,
+    // so there is no need to include them in the query.
     for (const batchEntry of batch) {
       if (batchEntry.categoryId === undefined) {
-        const groupedElementsModelEntry = getOrCreate({ map: groupedElementValues, key: batchEntry.modelId, createFunc: () => new Set<ElementId>() });
-        groupedElementsModelEntry.add(batchEntry.parentElementId);
+        elementValues.add(batchEntry.parentElementId);
         continue;
       }
-      const { modelId, parentElementId, categoryId } = batchEntry;
-      const modelEntry = getOrCreate({ map: groupedCategoryValues, key: modelId, createFunc: () => new Map<ElementId | undefined, Set<CategoryId>>() });
-      const parentEntry = getOrCreate({ map: modelEntry, key: parentElementId, createFunc: () => new Set<CategoryId>() });
+      const { parentElementId, categoryId } = batchEntry;
+      if (!parentElementId) {
+        rootCategoryValues.add(categoryId);
+        continue;
+      }
+      const parentEntry = getOrCreate({ map: groupedCategoryValues, key: parentElementId, createFunc: () => new Set<CategoryId>() });
       parentEntry.add(categoryId);
     }
     return merge(
       from(groupedCategoryValues.entries()).pipe(
-        mergeMap(([modelId, parentMap]) =>
-          from(parentMap.entries()).pipe(
-            map(([parentElementId, categoryIds], idx): WhereClause => {
-              return {
-                whereClause: `Model.Id = ${modelId} AND Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) ${parentElementId === undefined ? "AND Parent.Id IS NULL" : `AND Parent.Id = ${parentElementId}`}`,
-                type: "category" as const,
-                bindings: [{ type: "idset" as const, value: [...categoryIds] }],
-              };
-            }),
-          ),
-        ),
-      ),
-      from(groupedElementValues.entries()).pipe(
-        map(([modelId, parentElementIds], idx): WhereClause => {
+        map(([parentElementId, categoryIds], idx): WhereClause => {
           return {
-            whereClause: `Model.Id = ${modelId} AND Parent.Id IN (SELECT elementIdSet${idx}.id FROM IdSet(?) elementIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES)`,
-            type: "element" as const,
-            bindings: [{ type: "idset" as const, value: [...parentElementIds] }],
+            whereClause: `Category.Id IN (SELECT categoryIdSet${idx}.id FROM IdSet(?) categoryIdSet${idx} ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) AND Parent.Id = ${parentElementId}`,
+            type: "category" as const,
+            bindings: [{ type: "idset" as const, value: [...categoryIds] }],
           };
         }),
       ),
+      rootCategoryValues.size > 0
+        ? of({
+            whereClause: "Category.Id IN (SELECT categoryIdSet.id FROM IdSet(?) categoryIdSet ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES) AND Parent.Id IS NULL",
+            type: "category" as const,
+            bindings: [{ type: "idset" as const, value: [...rootCategoryValues] }],
+          })
+        : EMPTY,
+      elementValues.size > 0
+        ? of({
+            whereClause: `Parent.Id IN (SELECT elementIdSet.id FROM IdSet(?) elementIdSet ECSQLOPTIONS ENABLE_EXPERIMENTAL_FEATURES)`,
+            type: "element" as const,
+            bindings: [{ type: "idset" as const, value: [...elementValues] }],
+          })
+        : EMPTY,
     );
   }
 


### PR DESCRIPTION
- Adjusted descendants count cache to not use modelId in the query (it is not needed). 
- Removed unused `categoryOfTopMostParentElement` prop