### PR TITLE
[Tree widget]: add tests for sub-models on `next`

### DIFF
--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -5147,8 +5147,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
       });
     });
 
-    // TODO: Enable with https://github.com/iTwin/viewer-components-react/issues/1553
-    describe.skip("category with modeled elements hierarchy", () => {
+    describe("category with modeled elements hierarchy", () => {
       let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
       let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
       async function createIModel() {
@@ -5172,6 +5171,15 @@ describe("CategoriesTreeVisibilityHandler", () => {
             const subModelElement2 = insertPhysicalElement({ txn, userLabel: `subModel element 2`, modelId: subModel.id, categoryId: subModelCategory.id });
             const defaultSubCategoryOfSubModelCategory = { id: getDefaultSubCategoryId(subModelCategory.id), className: CLASS_NAME_SubCategory };
 
+            const otherSubModelCategory = insertSpatialCategory({ txn, codeValue: "other subModel category" });
+            const otherSubModelElement = insertPhysicalElement({
+              txn,
+              userLabel: `other subModel element`,
+              modelId: subModel.id,
+              categoryId: otherSubModelCategory.id,
+            });
+            const defaultSubCategoryOfOtherSubModelCategory = { id: getDefaultSubCategoryId(otherSubModelCategory.id), className: CLASS_NAME_SubCategory };
+
             const siblingCategory = insertSpatialCategory({ txn, codeValue: "sibling category" });
             const siblingElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: siblingCategory.id });
             const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
@@ -5187,6 +5195,9 @@ describe("CategoriesTreeVisibilityHandler", () => {
               subModelElement,
               subModelElement2,
               defaultSubCategoryOfSubModelCategory,
+              otherSubModelCategory,
+              otherSubModelElement,
+              defaultSubCategoryOfOtherSubModelCategory,
               siblingCategory,
               siblingElement,
               defaultSiblingSubCategory,
@@ -5219,6 +5230,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
           subCategoriesOfCategories: [
             { categoryId: createIModelResult.category.id, subCategories: createIModelResult.defaultSubCategory.id },
             { categoryId: createIModelResult.subModelCategory.id, subCategories: createIModelResult.defaultSubCategoryOfSubModelCategory.id },
+            {
+              categoryId: createIModelResult.otherSubModelCategory.id,
+              subCategories: createIModelResult.defaultSubCategoryOfOtherSubModelCategory.id,
+            },
             { categoryId: createIModelResult.siblingCategory.id, subCategories: createIModelResult.defaultSiblingSubCategory.id },
           ],
         });
@@ -5247,6 +5262,9 @@ describe("CategoriesTreeVisibilityHandler", () => {
           defaultSubCategory,
           element,
           subModelElement2,
+          otherSubModelCategory,
+          otherSubModelElement,
+          defaultSubCategoryOfOtherSubModelCategory,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createCategoryHierarchyNode({
@@ -5291,6 +5309,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [`${subModel.id}-${subModelCategory.id}`]: "partial",
                   [subModelElement.id]: "visible",
                   [subModelElement2.id]: "hidden",
+                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                  [otherSubModelElement.id]: "hidden",
+
+            [otherSubModelCategory.id]: "hidden",
+              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
@@ -5317,6 +5340,9 @@ describe("CategoriesTreeVisibilityHandler", () => {
           defaultSubCategory,
           element,
           subModelElement2,
+          otherSubModelCategory,
+          otherSubModelElement,
+          defaultSubCategoryOfOtherSubModelCategory,
           physicalModel,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
@@ -5360,6 +5386,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [`${subModel.id}-${subModelCategory.id}`]: "partial",
                   [subModelElement.id]: "visible",
                   [subModelElement2.id]: "hidden",
+                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                  [otherSubModelElement.id]: "hidden",
+
+            [otherSubModelCategory.id]: "hidden",
+              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
@@ -5386,11 +5417,14 @@ describe("CategoriesTreeVisibilityHandler", () => {
           defaultSubCategory,
           element,
           subModelElement2,
+          otherSubModelCategory,
+          otherSubModelElement,
+          defaultSubCategoryOfOtherSubModelCategory,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createCategoryHierarchyNode({
             id: subModelCategory.id,
-            parentKeys: [category, modeledElement],
+            parentKeys: [category, modeledElement, subModel],
             modelIds: [subModel.id],
             search: {
               isSearchTarget: false,
@@ -5429,12 +5463,17 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [`${subModel.id}-${subModelCategory.id}`]: "partial",
                   [subModelElement.id]: "visible",
                   [subModelElement2.id]: "hidden",
+                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                  [otherSubModelElement.id]: "hidden",
+
+            [otherSubModelCategory.id]: "hidden",
+              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
               [defaultSiblingSubCategory.id]: "hidden",
 
-            [subModelCategory.id]: "partial",
+            [subModelCategory.id]: "hidden",
               [defaultSubCategoryOfSubModelCategory.id]: "hidden",
           },
         });
@@ -5455,6 +5494,9 @@ describe("CategoriesTreeVisibilityHandler", () => {
           defaultSubCategory,
           element,
           subModelElement2,
+          otherSubModelCategory,
+          otherSubModelElement,
+          defaultSubCategoryOfOtherSubModelCategory,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createElementHierarchyNode({
@@ -5497,6 +5539,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [`${subModel.id}-${subModelCategory.id}`]: "partial",
                   [subModelElement.id]: "visible",
                   [subModelElement2.id]: "hidden",
+                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                  [otherSubModelElement.id]: "hidden",
+
+            [otherSubModelCategory.id]: "hidden",
+              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
@@ -5543,7 +5543,7 @@ describe("ModelsTreeVisibilityHandler", () => {
               elementId: keys.modelingElement.id,
               modelId: keys.modeledElement.id,
               categoryId: keys.categoryA.id,
-              parentKeys: [keys.model, keys.categoryA, keys.modeledElement, keys.subModel, keys.categoryA],
+              parentKeys: [keys.model, keys.categoryA, keys.modeledElement, keys.subModel],
               search: { isSearchTarget: true },
             }),
             true,

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
@@ -5463,6 +5463,121 @@ describe("ModelsTreeVisibilityHandler", () => {
           });
         });
       });
+
+      describe("path with modeling element of same category as modeled element", () => {
+        let buildIModelResult: Awaited<ReturnType<typeof createSameCategoryModelingElementIModel>>;
+        let visibilityTestData: ReturnType<typeof createFilteredVisibilityTestData>;
+
+        async function createSameCategoryModelingElementIModel() {
+          return buildIModel(async (imodel, testSchema) =>
+            withEditTxn(imodel, (txn) => {
+              const model = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "model" });
+              const categoryA = insertSpatialCategory({ txn, codeValue: "categoryA" });
+              const modeledElement = insertPhysicalElement({
+                txn,
+                userLabel: "modeled element",
+                modelId: model.id,
+                categoryId: categoryA.id,
+                classFullName: testSchema.items.SubModelablePhysicalObject.fullName,
+              });
+              const subModel = insertPhysicalSubModel({ txn, modeledElementId: modeledElement.id });
+              // modeling element uses the same category as the modeled element, so the intermediate category node is not shown.
+              const modelingElement = insertPhysicalElement({ txn, userLabel: "modeling element", modelId: subModel.id, categoryId: categoryA.id });
+
+              return {
+                model,
+                categoryA,
+                modeledElement,
+                subModel,
+                modelingElement,
+                searchPaths: [
+                  {
+                    identifier: model,
+                    children: [
+                      {
+                        identifier: categoryA,
+                        children: [
+                          {
+                            identifier: modeledElement,
+                            children: [{ identifier: subModel, children: [{ identifier: modelingElement }] }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              };
+            }),
+          );
+        }
+
+        beforeAll(async () => {
+          buildIModelResult = await createSameCategoryModelingElementIModel();
+        });
+
+        beforeEach(() => {
+          visibilityTestData = createFilteredVisibilityTestData({
+            imodelConnection: buildIModelResult.imodelConnection,
+            searchPaths: buildIModelResult.searchPaths,
+          });
+          visibilityTestData.viewport.setNeverDrawn({
+            elementIds: new Set([buildIModelResult.modeledElement.id, buildIModelResult.modelingElement.id]),
+          });
+          visibilityTestData.viewport.renderFrame();
+        });
+
+        afterEach(() => {
+          visibilityTestData[Symbol.dispose]();
+        });
+
+        afterAll(async () => {
+          await buildIModelResult.imodelConnection.close();
+        });
+
+        it("showing search target modeling element changes visibility for related nodes in search paths", async () => {
+          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+          const keys = buildIModelResult;
+
+          await visibilityHandlerWithSearchPaths.changeVisibility(
+            createElementHierarchyNode({
+              elementId: keys.modelingElement.id,
+              modelId: keys.modeledElement.id,
+              categoryId: keys.categoryA.id,
+              parentKeys: [keys.model, keys.categoryA, keys.modeledElement, keys.subModel, keys.categoryA],
+              search: { isSearchTarget: true },
+            }),
+            true,
+          );
+
+          await validateModelsTreeHierarchyVisibility({
+            provider: providerWithSearchPaths,
+            handler: visibilityHandlerWithSearchPaths,
+            viewport,
+            // prettier-ignore
+            expectations: {
+              [IModel.rootSubjectId]: "partial",
+                [keys.model.id]: "partial",
+                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                    [keys.modeledElement.id]: "partial",
+                      [keys.modelingElement.id]: "visible",
+            },
+          });
+
+          await validateModelsTreeHierarchyVisibility({
+            provider: defaultProvider,
+            handler: defaultVisibilityHandler,
+            viewport,
+            // prettier-ignore
+            expectations: {
+              [IModel.rootSubjectId]: "partial",
+                [keys.model.id]: "partial",
+                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                    [keys.modeledElement.id]: "partial",
+                      [keys.modelingElement.id]: "visible",
+            },
+          });
+        });
+      });
     });
 
     it("element of an excluded class still participates in visibility", async () => {


### PR DESCRIPTION
closes https://github.com/iTwin/viewer-components-react/issues/1553

This was fixed while implementing child categories changes. Added tests and removed `.skip`.