### PR TITLE
[Tree widget]: remove excessive data from nodes on `next`

### DIFF
--- a/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
+++ b/apps/performance-tests/src/tree-widget/VisibilityUtilities.ts
@@ -335,7 +335,7 @@ export function createCategoryHierarchyNode(categoryId: Id64String, modelId: Id6
     label: "",
     parentKeys: [],
     extendedData: {
-      isCategory: true,
+      type: "category",
       modelIds: [modelId],
       parentElementsPath: [],
     },
@@ -351,7 +351,7 @@ export function createModelHierarchyNode(modelId?: Id64String, hasChildren?: boo
     label: "",
     parentKeys: [],
     extendedData: {
-      isModel: true,
+      type: "model",
       modelId: modelId ?? "0x1",
     },
   };
@@ -372,7 +372,7 @@ export function createElementHierarchyNode(props: {
     label: "",
     parentKeys: [],
     extendedData: {
-      isElement: true,
+      type: "element",
       modelId: props.modelId,
       categoryId: props.categoryId,
       parentElementsPath: [],
@@ -390,7 +390,7 @@ export function createDefinitionContainerHierarchyNode(definitionContainerId: Id
     label: "",
     parentKeys: [],
     extendedData: {
-      isDefinitionContainer: true,
+      type: "definition-container",
     },
   };
 }
@@ -405,7 +405,7 @@ export function createClassificationTableHierarchyNode(classificationTableId: Id
     label: "",
     parentKeys: [],
     extendedData: {
-      type: "ClassificationTable",
+      type: "classification-table",
     },
   };
 }

--- a/change/@itwin-tree-widget-react-5aa66a0b-f747-4387-8bc0-9a691311bc8c.json
+++ b/change/@itwin-tree-widget-react-5aa66a0b-f747-4387-8bc0-9a691311bc8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added `getType` helpers on `ModelsTreeNode`, `CategoriesTreeNode`, and `ClassificationsTreeNode`. It can be used to identify supported hierarchy node types from their metadata.",
+  "packageName": "@itwin/tree-widget-react",
+  "email": "100586436+JonasDov@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/itwin/tree-widget/api/tree-widget-react.api.md
+++ b/packages/itwin/tree-widget/api/tree-widget-react.api.md
@@ -179,6 +179,7 @@ export namespace CategoriesTreeNode {
             categoryId: Id64String;
         };
     };
+    const getType: (node: HierarchyNode_2) => "definition-container" | "category" | "element" | "sub-category" | "model" | "elements-class-group" | undefined;
 }
 
 // @beta (undocumented)
@@ -249,6 +250,7 @@ export namespace ClassificationsTreeNode {
             categoryId: Id64String;
         };
     };
+    const getType: (node: HierarchyNode_2) => "classification-table" | "classification" | "element" | undefined;
 }
 
 // @alpha (undocumented)
@@ -507,7 +509,7 @@ export namespace ModelsTreeNode {
             categoryId: Id64String;
         };
     };
-    const getType: (node: HierarchyNode_2) => "subject" | "model" | "category" | "element" | "elements-class-group";
+    const getType: (node: HierarchyNode_2) => "subject" | "model" | "category" | "element" | "elements-class-group" | undefined;
 }
 
 // @beta (undocumented)

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeNode.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeNode.test.ts
@@ -5,45 +5,90 @@
 
 import { describe, expect, it } from "vitest";
 import { CategoriesTreeNode } from "../../../../tree-widget-react/components/trees/categories-tree/CategoriesTreeNode.js";
+import { CLASS_NAME_GeometricElement3d } from "../../../../tree-widget-react/components/trees/common/internal/ClassNameDefinitions.js";
+
+import type { HierarchyNode } from "@itwin/presentation-hierarchies";
 
 describe("CategoriesTreeNode", () => {
-  const randomNode = {
+  const createNode = (type?: string): HierarchyNode => ({
+    key: { type: "instances", instanceKeys: [] },
+    parentKeys: [],
+    label: "",
+    children: false,
+    extendedData: type ? { type } : {},
+  });
+
+  const unknownNode = createNode();
+  const categoryNode = createNode("category");
+  const subCategoryNode = createNode("sub-category");
+  const definitionContainerNode = createNode("definition-container");
+  const modelNode = createNode("model");
+  const elementNode = createNode("element");
+  const classGroupingNode: HierarchyNode = {
+    key: {
+      type: "class-grouping",
+      className: CLASS_NAME_GeometricElement3d,
+    },
+    parentKeys: [],
+    label: "",
+    children: false,
+    groupedInstanceKeys: [],
     extendedData: {},
-  };
-  const categoryNode = {
-    extendedData: {
-      isCategory: 1,
-    },
-  };
-  const subCategoryNode = {
-    extendedData: {
-      isSubCategory: 1,
-    },
-  };
-  const definitionContainerNode = {
-    extendedData: {
-      isDefinitionContainer: 1,
-    },
   };
 
   it("isCategoryNode", () => {
-    expect(CategoriesTreeNode.isCategoryNode(randomNode)).toBe(false);
+    expect(CategoriesTreeNode.isCategoryNode(unknownNode)).toBe(false);
     expect(CategoriesTreeNode.isCategoryNode(categoryNode)).toBe(true);
     expect(CategoriesTreeNode.isCategoryNode(subCategoryNode)).toBe(false);
     expect(CategoriesTreeNode.isCategoryNode(definitionContainerNode)).toBe(false);
+    expect(CategoriesTreeNode.isCategoryNode(classGroupingNode)).toBe(false);
   });
 
   it("isSubCategoryNode", () => {
-    expect(CategoriesTreeNode.isSubCategoryNode(randomNode)).toBe(false);
+    expect(CategoriesTreeNode.isSubCategoryNode(unknownNode)).toBe(false);
     expect(CategoriesTreeNode.isSubCategoryNode(categoryNode)).toBe(false);
     expect(CategoriesTreeNode.isSubCategoryNode(subCategoryNode)).toBe(true);
     expect(CategoriesTreeNode.isSubCategoryNode(definitionContainerNode)).toBe(false);
+    expect(CategoriesTreeNode.isSubCategoryNode(classGroupingNode)).toBe(false);
   });
 
   it("isDefinitionContainerNode", () => {
-    expect(CategoriesTreeNode.isDefinitionContainerNode(randomNode)).toBe(false);
+    expect(CategoriesTreeNode.isDefinitionContainerNode(unknownNode)).toBe(false);
     expect(CategoriesTreeNode.isDefinitionContainerNode(categoryNode)).toBe(false);
     expect(CategoriesTreeNode.isDefinitionContainerNode(subCategoryNode)).toBe(false);
     expect(CategoriesTreeNode.isDefinitionContainerNode(definitionContainerNode)).toBe(true);
+    expect(CategoriesTreeNode.isDefinitionContainerNode(classGroupingNode)).toBe(false);
+  });
+
+  it("isModelNode", () => {
+    expect(CategoriesTreeNode.isModelNode(unknownNode)).toBe(false);
+    expect(CategoriesTreeNode.isModelNode(categoryNode)).toBe(false);
+    expect(CategoriesTreeNode.isModelNode(modelNode)).toBe(true);
+    expect(CategoriesTreeNode.isModelNode(elementNode)).toBe(false);
+    expect(CategoriesTreeNode.isModelNode(classGroupingNode)).toBe(false);
+  });
+
+  it("isElementNode", () => {
+    expect(CategoriesTreeNode.isElementNode(unknownNode)).toBe(false);
+    expect(CategoriesTreeNode.isElementNode(categoryNode)).toBe(false);
+    expect(CategoriesTreeNode.isElementNode(modelNode)).toBe(false);
+    expect(CategoriesTreeNode.isElementNode(elementNode)).toBe(true);
+    expect(CategoriesTreeNode.isElementNode(classGroupingNode)).toBe(false);
+  });
+
+  it("isElementClassGroupingNode", () => {
+    expect(CategoriesTreeNode.isElementClassGroupingNode(unknownNode)).toBe(false);
+    expect(CategoriesTreeNode.isElementClassGroupingNode(categoryNode)).toBe(false);
+    expect(CategoriesTreeNode.isElementClassGroupingNode(classGroupingNode)).toBe(true);
+  });
+
+  it("getType returns the matching type", () => {
+    expect(CategoriesTreeNode.getType(categoryNode)).toBe("category");
+    expect(CategoriesTreeNode.getType(subCategoryNode)).toBe("sub-category");
+    expect(CategoriesTreeNode.getType(definitionContainerNode)).toBe("definition-container");
+    expect(CategoriesTreeNode.getType(modelNode)).toBe("model");
+    expect(CategoriesTreeNode.getType(elementNode)).toBe("element");
+    expect(CategoriesTreeNode.getType(classGroupingNode)).toBe("elements-class-group");
+    expect(CategoriesTreeNode.getType(unknownNode)).toBeUndefined();
   });
 });

--- a/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
@@ -52,7 +52,7 @@ export function createCategoryHierarchyNode(props: {
       ? props.parentKeys.map((parentKey) => ("type" in parentKey ? parentKey : { type: "instances", instanceKeys: [parentKey] }))
       : [],
     extendedData: {
-      isCategory: true,
+      type: "category",
       parentElementsPath: props.parentElementsPath ?? [],
       modelIds: props.modelIds ?? [],
       hasSubCategories: props.hasSubCategories,
@@ -76,7 +76,7 @@ export function createSubCategoryHierarchyNode(props: {
     label: "",
     parentKeys: props.parentKeys ? props.parentKeys.map((key) => ({ type: "instances", instanceKeys: [key] })) : [],
     extendedData: {
-      isSubCategory: true,
+      type: "sub-category",
       categoryId: props.categoryId,
     },
   };
@@ -134,7 +134,7 @@ export function createDefinitionContainerHierarchyNode(props: {
     parentKeys: props.parentKeys ? props.parentKeys.map((key) => ({ type: "instances", instanceKeys: [key] })) : [],
     search: props.search,
     extendedData: {
-      isDefinitionContainer: true,
+      type: "definition-container",
     },
   };
 }
@@ -165,7 +165,7 @@ export function createElementHierarchyNode(props: {
     extendedData: {
       modelId: props.modelId,
       categoryId: props.categoryId,
-      isElement: true,
+      type: "element",
       parentElementsPath: props.parentElementsPath ?? [],
     },
   };
@@ -183,7 +183,7 @@ export function createModelHierarchyNode(props: { id: Id64String; hasChildren?: 
     label: "",
     parentKeys: [],
     extendedData: {
-      isModel: true,
+      type: "model",
       modelId: props.id,
     },
   };

--- a/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeNode.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/classifications-tree/ClassificationsTreeNode.test.ts
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+import { ClassificationsTreeNode } from "../../../tree-widget-react/components/trees/classifications-tree/ClassificationsTreeNode.js";
+
+import type { HierarchyNode } from "@itwin/presentation-hierarchies";
+
+describe("ClassificationsTreeNode", () => {
+  const createNode = (type?: string): HierarchyNode => ({
+    key: { type: "instances", instanceKeys: [] },
+    parentKeys: [],
+    label: "",
+    children: false,
+    extendedData: type ? { type } : {},
+  });
+
+  const unknownNode = createNode();
+  const classificationTableNode = createNode("classification-table");
+  const classificationNode = createNode("classification");
+  const elementNode = createNode("element");
+
+  it("isClassificationTableNode", () => {
+    expect(ClassificationsTreeNode.isClassificationTableNode(unknownNode)).toBe(false);
+    expect(ClassificationsTreeNode.isClassificationTableNode(classificationTableNode)).toBe(true);
+    expect(ClassificationsTreeNode.isClassificationTableNode(classificationNode)).toBe(false);
+    expect(ClassificationsTreeNode.isClassificationTableNode(elementNode)).toBe(false);
+  });
+
+  it("isClassificationNode", () => {
+    expect(ClassificationsTreeNode.isClassificationNode(unknownNode)).toBe(false);
+    expect(ClassificationsTreeNode.isClassificationNode(classificationTableNode)).toBe(false);
+    expect(ClassificationsTreeNode.isClassificationNode(classificationNode)).toBe(true);
+    expect(ClassificationsTreeNode.isClassificationNode(elementNode)).toBe(false);
+  });
+
+  it("isGeometricElementNode", () => {
+    expect(ClassificationsTreeNode.isGeometricElementNode(unknownNode)).toBe(false);
+    expect(ClassificationsTreeNode.isGeometricElementNode(classificationTableNode)).toBe(false);
+    expect(ClassificationsTreeNode.isGeometricElementNode(classificationNode)).toBe(false);
+    expect(ClassificationsTreeNode.isGeometricElementNode(elementNode)).toBe(true);
+  });
+
+  it("getType returns the matching type", () => {
+    expect(ClassificationsTreeNode.getType(classificationTableNode)).toBe("classification-table");
+    expect(ClassificationsTreeNode.getType(classificationNode)).toBe("classification");
+    expect(ClassificationsTreeNode.getType(elementNode)).toBe("element");
+    expect(ClassificationsTreeNode.getType(unknownNode)).toBeUndefined();
+  });
+});

--- a/packages/itwin/tree-widget/src/test/trees/classifications-tree/HierarchyNodeUtils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/classifications-tree/HierarchyNodeUtils.ts
@@ -28,7 +28,7 @@ export function createClassificationTableHierarchyNode({
     parentKeys: [],
     children: !!hasChildren,
     extendedData: {
-      type: "ClassificationTable",
+      type: "classification-table",
     },
     search,
   };
@@ -54,7 +54,7 @@ export function createClassificationHierarchyNode({
     parentKeys: parentKeys ? parentKeys.map((key) => ({ type: "instances", instanceKeys: [key] })) : [],
     children: !!hasChildren,
     extendedData: {
-      type: "Classification",
+      type: "classification",
     },
     search,
   };
@@ -84,40 +84,10 @@ export function createPhysicalElementHierarchyNode({
     label: "",
     children: false,
     extendedData: {
-      type: "GeometricElement3d",
+      type: "element",
       modelId,
       categoryId,
       parentElementsPath: parentElementsPath ?? [],
-    },
-    search,
-  };
-}
-
-export function createDrawingElementHierarchyNode({
-  id,
-  modelId,
-  categoryId,
-  search,
-  parentKeys,
-}: {
-  id: Id64String;
-  modelId: Id64String;
-  categoryId: Id64String;
-  search?: NonGroupingHierarchyNode["search"];
-  parentKeys?: InstanceKey[];
-}): NonGroupingHierarchyNode {
-  return {
-    key: {
-      type: "instances",
-      instanceKeys: [{ className: "BisCore.DrawingGraphic", id }],
-    },
-    parentKeys: parentKeys ? parentKeys.map((key) => ({ type: "instances", instanceKeys: [key] })) : [],
-    label: "",
-    children: false,
-    extendedData: {
-      type: "GeometricElement2d",
-      modelId,
-      categoryId,
     },
     search,
   };

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeHierarchyLevelFiltering.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeHierarchyLevelFiltering.test.ts
@@ -27,7 +27,13 @@ import { CLASS_NAME_Subject } from "../../../tree-widget-react/components/trees/
 import { buildIModel } from "../../IModelUtils.js";
 import { collect } from "../Common.js";
 import { NodeValidators, validateHierarchyLevel } from "../HierarchyValidation.js";
-import { createModelsTreeProvider } from "./Utils.js";
+import {
+  createCategoryHierarchyNode,
+  createElementHierarchyNode,
+  createModelHierarchyNode,
+  createModelsTreeProvider,
+  createSubjectHierarchyNode,
+} from "./Utils.js";
 
 import type { GenericInstanceFilter, GenericInstanceFilterRule } from "@itwin/core-common";
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -173,14 +179,7 @@ describe("Models tree", () => {
       );
       const { imodelConnection, ...keys } = buildIModelResult;
       using provider = createModelsTreeProvider({ imodelConnection });
-      const parentNode = {
-        key: {
-          type: "instances" as const,
-          instanceKeys: [keys.rootSubject],
-        },
-        parentKeys: [],
-        label: "",
-      };
+      const parentNode = createSubjectHierarchyNode({ ids: keys.rootSubject.id });
 
       // validate hierarchy level without filter
       validateHierarchyLevel({
@@ -272,19 +271,12 @@ describe("Models tree", () => {
       );
       const { imodelConnection, ...keys } = buildIModelResult;
       using provider = createModelsTreeProvider({ imodelConnection });
-      const parentNode = {
-        key: {
-          type: "instances" as const,
-          instanceKeys: [keys.model],
-        },
-        parentKeys: [
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.rootSubject],
-          },
-        ],
-        label: "",
-      };
+      const parentNode = createModelHierarchyNode({
+        modelId: keys.model.id,
+        hasChildren: true,
+        className: keys.model.className,
+        parentKeys: [keys.rootSubject],
+      });
 
       // validate hierarchy level without filter
       validateHierarchyLevel({
@@ -340,28 +332,12 @@ describe("Models tree", () => {
       );
       const { imodelConnection, ...keys } = buildIModelResult;
       using provider = createModelsTreeProvider({ imodelConnection });
-      const parentNode = {
-        key: {
-          type: "instances" as const,
-          instanceKeys: [keys.category],
-        },
-        parentKeys: [
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.rootSubject],
-          },
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.model],
-          },
-        ],
-        extendedData: {
-          isCategory: true,
-          modelIds: [keys.model.id],
-          parentElementsPath: [],
-        },
-        label: "",
-      };
+      const parentNode = createCategoryHierarchyNode({
+        modelId: keys.model.id,
+        categoryId: keys.category.id,
+        hasChildren: true,
+        parentKeys: [keys.rootSubject, keys.model],
+      });
 
       // validate hierarchy level without filter
       validateHierarchyLevel({
@@ -435,33 +411,13 @@ describe("Models tree", () => {
       );
       const { imodelConnection, ...keys } = buildIModelResult;
       using provider = createModelsTreeProvider({ imodelConnection });
-      const parentNode = {
-        key: {
-          type: "instances" as const,
-          instanceKeys: [keys.parentElement],
-        },
-        extendedData: {
-          parentElementsPath: [],
-          categoryId: keys.category.id,
-          modelId: keys.model.id,
-          isElement: true,
-        },
-        parentKeys: [
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.rootSubject],
-          },
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.model],
-          },
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.category],
-          },
-        ],
-        label: "",
-      };
+      const parentNode = createElementHierarchyNode({
+        modelId: keys.model.id,
+        categoryId: keys.category.id,
+        elementId: keys.parentElement.id,
+        hasChildren: true,
+        parentKeys: [keys.rootSubject, keys.model, keys.category],
+      });
 
       // validate hierarchy level without filter
       validateHierarchyLevel({
@@ -542,33 +498,14 @@ describe("Models tree", () => {
       );
       const { imodelConnection, ...keys } = buildIModelResult;
       using provider = createModelsTreeProvider({ imodelConnection });
-      const parentNode = {
-        key: {
-          type: "instances" as const,
-          instanceKeys: [keys.modeledElement],
-        },
-        extendedData: {
-          parentElementsPath: [],
-          categoryId: keys.category.id,
-          modelId: keys.model.id,
-          isElement: true,
-        },
-        parentKeys: [
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.rootSubject],
-          },
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.model],
-          },
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.category],
-          },
-        ],
-        label: "",
-      };
+      const parentNode = createElementHierarchyNode({
+        modelId: keys.model.id,
+        categoryId: keys.category.id,
+        elementId: keys.modeledElement.id,
+        hasChildren: true,
+        parentKeys: [keys.rootSubject, keys.model, keys.category],
+        className: keys.modeledElement.className,
+      });
 
       // validate hierarchy level without filter
       validateHierarchyLevel({
@@ -636,28 +573,12 @@ describe("Models tree", () => {
       );
       const { imodelConnection, ...keys } = buildIModelResult;
       using provider = createModelsTreeProvider({ imodelConnection });
-      const parentNode = {
-        key: {
-          type: "instances" as const,
-          instanceKeys: [keys.category],
-        },
-        parentKeys: [
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.rootSubject],
-          },
-          {
-            type: "instances" as const,
-            instanceKeys: [keys.model],
-          },
-        ],
-        extendedData: {
-          modelIds: [keys.model.id],
-          isCategory: true,
-          parentElementsPath: [],
-        },
-        label: "",
-      };
+      const parentNode = createCategoryHierarchyNode({
+        modelId: keys.model.id,
+        hasChildren: true,
+        parentKeys: [keys.rootSubject, keys.model],
+        categoryId: keys.category.id,
+      });
       validateHierarchyLevel({
         nodes: await collect(provider.getNodes({ parentNode })),
         expect: [NodeValidators.createForClassGroupingNode({ className: keys.element.className })],
@@ -718,14 +639,9 @@ describe("Models tree", () => {
         );
         const { imodelConnection, ...keys } = buildIModelResult;
         using provider = createModelsTreeProvider({ imodelConnection, hierarchyConfig: { models: { withoutElements: "include" } } });
-        const parentNode = {
-          key: {
-            type: "instances" as const,
-            instanceKeys: [keys.rootSubject],
-          },
-          parentKeys: [],
-          label: "",
-        };
+        const parentNode = createSubjectHierarchyNode({
+          ids: keys.rootSubject.id,
+        });
 
         // validate hierarchy level without filter
         validateHierarchyLevel({
@@ -789,28 +705,12 @@ describe("Models tree", () => {
         );
         const { imodelConnection, ...keys } = buildIModelResult;
         using provider = createModelsTreeProvider({ imodelConnection, hierarchyConfig: { elements: { baseClass: keys.element1.className } } });
-        const parentNode = {
-          key: {
-            type: "instances" as const,
-            instanceKeys: [keys.category],
-          },
-          parentKeys: [
-            {
-              type: "instances" as const,
-              instanceKeys: [keys.rootSubject],
-            },
-            {
-              type: "instances" as const,
-              instanceKeys: [keys.model],
-            },
-          ],
-          extendedData: {
-            modelIds: [keys.model.id],
-            parentElementsPath: [],
-            isCategory: true,
-          },
-          label: "",
-        };
+        const parentNode = createCategoryHierarchyNode({
+          modelId: keys.model.id,
+          categoryId: keys.category.id,
+          hasChildren: true,
+          parentKeys: [keys.rootSubject, keys.model],
+        });
 
         // validate hierarchy level without filter
         validateHierarchyLevel({

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeNode.test.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/ModelsTreeNode.test.ts
@@ -1,0 +1,88 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from "vitest";
+import { CLASS_NAME_GeometricElement3d } from "../../../tree-widget-react/components/trees/common/internal/ClassNameDefinitions.js";
+import { ModelsTreeNode } from "../../../tree-widget-react/components/trees/models-tree/ModelsTreeNode.js";
+
+import type { HierarchyNode } from "@itwin/presentation-hierarchies";
+
+describe("ModelsTreeNode", () => {
+  const createNode = (type?: string): HierarchyNode => ({
+    key: { type: "instances", instanceKeys: [] },
+    parentKeys: [],
+    label: "",
+    children: false,
+    extendedData: type ? { type } : {},
+  });
+
+  const unknownNode = createNode();
+  const subjectNode = createNode("subject");
+  const modelNode = createNode("model");
+  const categoryNode = createNode("category");
+  const elementNode = createNode("element");
+  const classGroupingNode: HierarchyNode = {
+    key: {
+      type: "class-grouping",
+      className: CLASS_NAME_GeometricElement3d,
+    },
+    parentKeys: [],
+    label: "",
+    children: false,
+    groupedInstanceKeys: [],
+    extendedData: {},
+  };
+
+  it("isSubjectNode", () => {
+    expect(ModelsTreeNode.isSubjectNode(unknownNode)).toBe(false);
+    expect(ModelsTreeNode.isSubjectNode(subjectNode)).toBe(true);
+    expect(ModelsTreeNode.isSubjectNode(modelNode)).toBe(false);
+    expect(ModelsTreeNode.isSubjectNode(categoryNode)).toBe(false);
+    expect(ModelsTreeNode.isSubjectNode(elementNode)).toBe(false);
+    expect(ModelsTreeNode.isSubjectNode(classGroupingNode)).toBe(false);
+  });
+
+  it("isModelNode", () => {
+    expect(ModelsTreeNode.isModelNode(unknownNode)).toBe(false);
+    expect(ModelsTreeNode.isModelNode(subjectNode)).toBe(false);
+    expect(ModelsTreeNode.isModelNode(modelNode)).toBe(true);
+    expect(ModelsTreeNode.isModelNode(categoryNode)).toBe(false);
+    expect(ModelsTreeNode.isModelNode(elementNode)).toBe(false);
+    expect(ModelsTreeNode.isModelNode(classGroupingNode)).toBe(false);
+  });
+
+  it("isCategoryNode", () => {
+    expect(ModelsTreeNode.isCategoryNode(unknownNode)).toBe(false);
+    expect(ModelsTreeNode.isCategoryNode(subjectNode)).toBe(false);
+    expect(ModelsTreeNode.isCategoryNode(modelNode)).toBe(false);
+    expect(ModelsTreeNode.isCategoryNode(categoryNode)).toBe(true);
+    expect(ModelsTreeNode.isCategoryNode(elementNode)).toBe(false);
+    expect(ModelsTreeNode.isCategoryNode(classGroupingNode)).toBe(false);
+  });
+
+  it("isElementNode", () => {
+    expect(ModelsTreeNode.isElementNode(unknownNode)).toBe(false);
+    expect(ModelsTreeNode.isElementNode(subjectNode)).toBe(false);
+    expect(ModelsTreeNode.isElementNode(modelNode)).toBe(false);
+    expect(ModelsTreeNode.isElementNode(categoryNode)).toBe(false);
+    expect(ModelsTreeNode.isElementNode(elementNode)).toBe(true);
+    expect(ModelsTreeNode.isElementNode(classGroupingNode)).toBe(false);
+  });
+
+  it("isElementClassGroupingNode", () => {
+    expect(ModelsTreeNode.isElementClassGroupingNode(unknownNode)).toBe(false);
+    expect(ModelsTreeNode.isElementClassGroupingNode(subjectNode)).toBe(false);
+    expect(ModelsTreeNode.isElementClassGroupingNode(classGroupingNode)).toBe(true);
+  });
+
+  it("getType returns the matching type", () => {
+    expect(ModelsTreeNode.getType(subjectNode)).toBe("subject");
+    expect(ModelsTreeNode.getType(modelNode)).toBe("model");
+    expect(ModelsTreeNode.getType(categoryNode)).toBe("category");
+    expect(ModelsTreeNode.getType(elementNode)).toBe("element");
+    expect(ModelsTreeNode.getType(classGroupingNode)).toBe("elements-class-group");
+    expect(ModelsTreeNode.getType(unknownNode)).toBeUndefined();
+  });
+});

--- a/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
+++ b/packages/itwin/tree-widget/src/test/trees/models-tree/Utils.ts
@@ -174,7 +174,7 @@ export function createSubjectHierarchyNode(props?: { ids?: Id64Arg; parentKeys?:
     label: "",
     parentKeys: props?.parentKeys ? props.parentKeys.map((parentKey) => ({ type: "instances", instanceKeys: [parentKey] })) : [],
     extendedData: {
-      isSubject: true,
+      type: "subject",
     },
   };
 }
@@ -183,18 +183,19 @@ export function createModelHierarchyNode(props?: {
   hasChildren?: boolean;
   parentKeys?: InstanceKey[];
   search?: NonGroupingHierarchyNode["search"];
+  className?: EC.FullClassNameDotNotation;
 }): NonGroupingHierarchyNode {
   return {
     key: {
       type: "instances",
-      instanceKeys: [{ className: CLASS_NAME_Model, id: props?.modelId ?? "" }],
+      instanceKeys: [{ className: props?.className ?? CLASS_NAME_Model, id: props?.modelId ?? "" }],
     },
     children: !!props?.hasChildren,
     label: "",
     parentKeys: props?.parentKeys ? props.parentKeys.map((parentKey) => ({ type: "instances", instanceKeys: [parentKey] })) : [],
     search: props?.search,
     extendedData: {
-      isModel: true,
+      type: "model",
       modelId: props?.modelId ?? "0x1",
     },
   };
@@ -227,7 +228,7 @@ export function createCategoryHierarchyNode({
     parentKeys: parentKeys ? parentKeys.map((parentKey) => ("type" in parentKey ? parentKey : { type: "instances", instanceKeys: [parentKey] })) : [],
     search,
     extendedData: {
-      isCategory: true,
+      type: "category",
       modelIds: [modelId ?? "0x1"],
       parentElementsPath: parentElementsPath ?? [],
     },
@@ -241,11 +242,12 @@ export function createElementHierarchyNode(props: {
   parentKeys?: Array<InstanceKey | ClassGroupingNodeKey>;
   search?: NonGroupingHierarchyNode["search"];
   parentElementsPath?: ParentElementsPath;
+  className?: EC.FullClassNameDotNotation;
 }): NonGroupingHierarchyNode {
   return {
     key: {
       type: "instances",
-      instanceKeys: [{ className: CLASS_NAME_GeometricElement3d, id: props.elementId ?? "" }],
+      instanceKeys: [{ className: props.className ?? CLASS_NAME_GeometricElement3d, id: props.elementId ?? "" }],
     },
     children: !!props.hasChildren,
     label: "",
@@ -254,7 +256,7 @@ export function createElementHierarchyNode(props: {
       ? props.parentKeys.map((parentKey) => ("type" in parentKey ? parentKey : { type: "instances", instanceKeys: [parentKey] }))
       : [],
     extendedData: {
-      isElement: true,
+      type: "element",
       modelId: props.modelId,
       categoryId: props.categoryId,
       parentElementsPath: props.parentElementsPath ?? [],

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeDefinition.ts
@@ -304,9 +304,6 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
         modelElementsMap,
         ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
         ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
-        // `imageId` is assigned to instance nodes at query time, but grouping ones need to
-        // be handled during post-processing
-        imageId: "icon-ec-class",
       },
     };
   };
@@ -388,7 +385,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                 hideNodeInHierarchy: true,
                 hasChildren: true,
                 extendedData: {
-                  isModel: true,
+                  type: "model",
                   modeledElementCategory: { selector: `IdToHex(${parentNode.extendedData.categoryId})` },
                 },
               })}
@@ -567,8 +564,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                 }),
               },
               extendedData: {
-                isDefinitionContainer: true,
-                imageId: "icon-definition-container",
+                type: "definition-container",
               },
               hasChildren: true,
               supportsFiltering: true,
@@ -654,6 +650,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                     }
                   : false,
               extendedData: {
+                type: "category",
                 description: { selector: "this.Description" },
                 modelIds: { selector: createIdsSelector(new Array<ModelId>()) },
                 hasSubCategories:
@@ -726,8 +723,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
                 },
                 extendedData: {
                   categoryId: { selector: "printf('0x%x', this.Parent.Id)" },
-                  isSubCategory: true,
-                  imageId: "icon-layers-isolate",
+                  type: "sub-category",
                 },
                 supportsFiltering: false,
               })}
@@ -792,8 +788,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
       extendedData: {
         modelId: { selector: "IdToHex(this.Model.Id)" },
         categoryId: { selector: "IdToHex(this.Category.Id)" },
-        imageId: "icon-item",
-        isElement: true,
+        type: "element",
       },
       supportsFiltering: true,
     });
@@ -826,8 +821,7 @@ export class CategoriesTreeDefinition implements HierarchyDefinition {
       grouping: { byLabel: { action: "merge", groupId: "category" } },
       hasChildren,
       extendedData: {
-        imageId: "icon-layers",
-        isCategory: true,
+        type: "category",
         ...extendedData,
       },
       supportsFiltering: true,

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeIcon.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeIcon.tsx
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Icon } from "@stratakit/foundations";
+import categorySvg from "@stratakit/icons/bis-category-3d.svg";
+import subcategorySvg from "@stratakit/icons/bis-category-subcategory.svg";
+import classSvg from "@stratakit/icons/bis-class.svg";
+import definitionContainerSvg from "@stratakit/icons/bis-definitions-container.svg";
+import elementSvg from "@stratakit/icons/bis-element.svg";
+import { CategoriesTreeNode } from "./CategoriesTreeNode.js";
+
+import type { TreeNode } from "@itwin/presentation-hierarchies-react";
+
+/** @beta */
+export function CategoriesTreeIcon({ node }: { node: TreeNode }) {
+  const nodeType = CategoriesTreeNode.getType(node.nodeData);
+  if (nodeType === undefined) {
+    return undefined;
+  }
+
+  const getIcon = () => {
+    switch (nodeType) {
+      case "category":
+        return categorySvg;
+      case "sub-category":
+        return subcategorySvg;
+      case "definition-container":
+        return definitionContainerSvg;
+      case "element":
+        return elementSvg;
+      case "elements-class-group":
+        return classSvg;
+      default:
+        return undefined;
+    }
+  };
+
+  return <Icon href={getIcon()} />;
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeNode.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/CategoriesTreeNode.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { HierarchyNode } from "@itwin/presentation-hierarchies";
+import { HierarchyNode, HierarchyNodeKey } from "@itwin/presentation-hierarchies";
 
 import type { Id64Array, Id64String } from "@itwin/core-bentley";
 import type { ClassGroupingNodeKey, GroupingHierarchyNode, InstancesNodeKey, NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
@@ -15,7 +15,7 @@ import type { ClassGroupingNodeKey, GroupingHierarchyNode, InstancesNodeKey, Non
 export namespace CategoriesTreeNode {
   /** Checks if the given node represents a `BisCore.DefinitionContainer` element. */
   export const isDefinitionContainerNode = (node: Pick<HierarchyNode, "extendedData">): node is NonGroupingHierarchyNode & { key: InstancesNodeKey } =>
-    !!node.extendedData && "isDefinitionContainer" in node.extendedData && !!node.extendedData.isDefinitionContainer;
+    node.extendedData?.type === "definition-container";
 
   /**
    * Checks if the given node represents a `BisCore.Category` element.
@@ -33,11 +33,11 @@ export namespace CategoriesTreeNode {
       hasSubCategories?: boolean;
       modelIds: Id64Array;
     };
-  } => !!node.extendedData && "isCategory" in node.extendedData && !!node.extendedData.isCategory;
+  } => node.extendedData?.type === "category";
 
   /** Checks if the given node represents a `BisCore.Model`. */
   export const isModelNode = (node: Pick<HierarchyNode, "extendedData">): node is NonGroupingHierarchyNode & { key: InstancesNodeKey } =>
-    !!node.extendedData && "isModel" in node.extendedData && !!node.extendedData.isModel;
+    node.extendedData?.type === "model";
 
   /**
    * Checks if the given node represents a `BisCore.GeometricElement` element.
@@ -53,7 +53,7 @@ export namespace CategoriesTreeNode {
       modelId: Id64String;
       categoryId: Id64String;
     };
-  } => !!node.extendedData && "isElement" in node.extendedData && !!node.extendedData.isElement;
+  } => node.extendedData?.type === "element";
 
   /**
    * Checks if the given node is a class grouping node of `BisCore.GeometricElement` nodes.
@@ -83,5 +83,30 @@ export namespace CategoriesTreeNode {
     extendedData: {
       categoryId: Id64String;
     };
-  } => !!node.extendedData && "isSubCategory" in node.extendedData && !!node.extendedData.isSubCategory;
+  } => node.extendedData?.type === "sub-category";
+
+  /** Returns type of the node. */
+  export const getType = (
+    node: HierarchyNode,
+  ): "definition-container" | "category" | "element" | "sub-category" | "model" | "elements-class-group" | undefined => {
+    if (HierarchyNodeKey.isClassGrouping(node.key)) {
+      return "elements-class-group";
+    }
+    if (isCategoryNode(node)) {
+      return "category";
+    }
+    if (isDefinitionContainerNode(node)) {
+      return "definition-container";
+    }
+    if (isSubCategoryNode(node)) {
+      return "sub-category";
+    }
+    if (isElementNode(node)) {
+      return "element";
+    }
+    if (isModelNode(node)) {
+      return "model";
+    }
+    return undefined;
+  };
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/categories-tree/UseCategoriesTree.tsx
@@ -5,18 +5,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { Icon } from "@stratakit/foundations";
 import categorySvg from "@stratakit/icons/bis-category-3d.svg";
-import subcategorySvg from "@stratakit/icons/bis-category-subcategory.svg";
-import classSvg from "@stratakit/icons/bis-class.svg";
-import definitionContainerSvg from "@stratakit/icons/bis-definitions-container.svg";
-import elementSvg from "@stratakit/icons/bis-element.svg";
 import { EmptyTreeContent, NoSearchMatches, SearchUnknownError, TooManySearchMatches } from "../common/components/EmptyTree.js";
 import { useSharedTreeContextInternal } from "../common/internal/SharedTreeContextProviderInternal.js";
 import { useGuid } from "../common/internal/useGuid.js";
 import { useCachedVisibility } from "../common/internal/useTreeHooks/UseCachedVisibility.js";
 import { getClassesByView, mergeWithDefaults, stableStringify } from "../common/internal/Utils.js";
 import { CategoriesTreeDefinition, defaultHierarchyConfiguration } from "./CategoriesTreeDefinition.js";
+import { CategoriesTreeIcon } from "./CategoriesTreeIcon.js";
 import { CategoriesTreeIdsCache } from "./internal/CategoriesTreeIdsCache.js";
 import { useSearchPaths } from "./internal/UseSearchPaths.js";
 import { CategoriesTreeVisibilityHandler } from "./internal/visibility/CategoriesTreeVisibilityHandler.js";
@@ -25,7 +21,6 @@ import { createCategoriesSearchResultsTree } from "./internal/visibility/SearchR
 import type { ReactNode } from "react";
 import type { GuidString, Id64Array } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
-import type { TreeNode } from "@itwin/presentation-hierarchies-react";
 import type { EC } from "@itwin/presentation-shared";
 import type { CategoryInfo } from "../common/CategoriesVisibilityUtils.js";
 import type { VisibilityTreeProps } from "../common/components/VisibilityTree.js";
@@ -168,32 +163,6 @@ function getEmptyTreeContentComponent(searchText?: string, error?: CategoriesTre
     return emptyTreeContent;
   }
   return <EmptyTreeContent icon={categorySvg} />;
-}
-
-/** @beta */
-export function CategoriesTreeIcon({ node }: { node: TreeNode }) {
-  if (node.nodeData.extendedData?.imageId === undefined) {
-    return undefined;
-  }
-
-  const getIcon = () => {
-    switch (node.nodeData.extendedData!.imageId) {
-      case "icon-layers":
-        return categorySvg;
-      case "icon-layers-isolate":
-        return subcategorySvg;
-      case "icon-definition-container":
-        return definitionContainerSvg;
-      case "icon-item":
-        return elementSvg;
-      case "icon-ec-class":
-        return classSvg;
-      default:
-        return undefined;
-    }
-  };
-
-  return <Icon href={getIcon()} />;
 }
 
 function useCategoriesCachedVisibility(props: {

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeDefinition.ts
@@ -23,7 +23,7 @@ import {
 } from "rxjs";
 import { assert, Guid } from "@itwin/core-bentley";
 import { createPredicateBasedHierarchyDefinition } from "@itwin/presentation-hierarchies";
-import { createBisInstanceLabelSelectClauseFactory, ECSql, parseFullClassName } from "@itwin/presentation-shared";
+import { createBisInstanceLabelSelectClauseFactory, ECSql } from "@itwin/presentation-shared";
 import { eachValueFrom } from "../../utils/EachValueFrom.js";
 import {
   CLASS_NAME_Classification,
@@ -217,7 +217,7 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
                   `,
                 },
                 extendedData: {
-                  type: "ClassificationTable",
+                  type: "classification-table",
                 },
                 supportsFiltering: true,
               })}
@@ -271,7 +271,7 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
                     },
                     hasChildren: childClassificationsWithChildren.length > 0 ? { selector: createClassificationHasChildrenSelector("this") } : false,
                     extendedData: {
-                      type: "Classification",
+                      type: "classification",
                     },
                     supportsFiltering: true,
                   })}
@@ -358,7 +358,7 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
                         },
                         hasChildren: childClassificationsWithChildren.length > 0 ? { selector: createClassificationHasChildrenSelector("this") } : false,
                         extendedData: {
-                          type: "Classification",
+                          type: "classification",
                         },
                         supportsFiltering: true,
                       })}
@@ -420,7 +420,6 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
     nodeSelectClauseFactory: NodesQueryClauseFactory;
     instanceLabelSelectClauseFactory: IInstanceLabelSelectClauseFactory;
   }): Promise<string> {
-    const { className: elementClassName } = parseFullClassName(CLASS_NAME_GeometricElement3d);
     return nodeSelectClauseFactory.createSelectClause({
       ecClassId: { selector: "this.ECClassId" },
       ecInstanceId: { selector: "this.ECInstanceId" },
@@ -446,7 +445,7 @@ export class ClassificationsTreeDefinition implements HierarchyDefinition {
         `,
       },
       extendedData: {
-        type: elementClassName,
+        type: "element",
         modelId: { selector: "IdToHex(this.Model.Id)" },
         categoryId: { selector: "IdToHex(this.Category.Id)" },
       },

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeIcon.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeIcon.tsx
@@ -4,32 +4,28 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Icon } from "@stratakit/foundations";
-import icon2d from "@stratakit/icons/2d.svg";
 import icon3d from "@stratakit/icons/3d.svg";
 import iconBisDefinitionsContainer from "@stratakit/icons/bis-definitions-container.svg";
-import iconBisElement from "@stratakit/icons/bis-element.svg";
+import { ClassificationsTreeNode } from "./ClassificationsTreeNode.js";
 
 import type { TreeNode } from "@itwin/presentation-hierarchies-react";
 
 /** @beta */
 export function ClassificationsTreeIcon({ node }: { node: TreeNode }) {
-  if (node.nodeData.extendedData?.type === undefined) {
+  const nodeType = ClassificationsTreeNode.getType(node.nodeData);
+  if (nodeType === undefined) {
     return undefined;
   }
 
   const getIcon = () => {
     // FIXME: icons...
-    switch (node.nodeData.extendedData!.type) {
-      case "ClassificationTable":
+    switch (nodeType) {
+      case "classification-table":
         return iconBisDefinitionsContainer;
-      case "Classification":
+      case "classification":
         return iconBisDefinitionsContainer;
-      case "GeometricElement3d":
+      case "element":
         return icon3d;
-      case "GeometricElement2d":
-        return icon2d;
-      default:
-        return iconBisElement;
     }
   };
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeNode.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/classifications-tree/ClassificationsTreeNode.ts
@@ -13,11 +13,11 @@ import type { HierarchyNode, InstancesNodeKey, NonGroupingHierarchyNode } from "
 export namespace ClassificationsTreeNode {
   /** Checks if the given node represents a `ClassificationSystems.ClassificationTable` element. */
   export const isClassificationTableNode = (node: Pick<HierarchyNode, "extendedData">): node is NonGroupingHierarchyNode & { key: InstancesNodeKey } =>
-    node.extendedData?.type === "ClassificationTable";
+    node.extendedData?.type === "classification-table";
 
   /** Checks if the given node represents a `ClassificationSystems.Classification` element. */
   export const isClassificationNode = (node: Pick<HierarchyNode, "extendedData">): node is NonGroupingHierarchyNode & { key: InstancesNodeKey } =>
-    node.extendedData?.type === "Classification";
+    node.extendedData?.type === "classification";
 
   /**
    * Checks if the given node represents a `BisCore.GeometricElement3d` element.
@@ -34,6 +34,20 @@ export namespace ClassificationsTreeNode {
       categoryId: Id64String;
     };
   } => {
-    return node.extendedData?.type === "GeometricElement3d";
+    return node.extendedData?.type === "element";
+  };
+
+  /** Returns type of the node. */
+  export const getType = (node: HierarchyNode): "classification-table" | "classification" | "element" | undefined => {
+    if (isClassificationTableNode(node)) {
+      return "classification-table";
+    }
+    if (isClassificationNode(node)) {
+      return "classification";
+    }
+    if (isGeometricElementNode(node)) {
+      return "element";
+    }
+    return undefined;
   };
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/index.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/index.ts
@@ -4,12 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 export { ModelsTreeComponent } from "./models-tree/ModelsTreeComponent.js";
-export { useModelsTree, ModelsTreeIcon } from "./models-tree/UseModelsTree.js";
+export { useModelsTree } from "./models-tree/UseModelsTree.js";
+export { ModelsTreeIcon } from "./models-tree/ModelsTreeIcon.js";
 export { useModelsTreeButtonProps } from "./models-tree/ModelsTreeButtons.js";
 export { ModelsTreeNode } from "./models-tree/ModelsTreeNode.js";
 
 export { CategoriesTreeComponent } from "./categories-tree/CategoriesTreeComponent.js";
-export { useCategoriesTree, CategoriesTreeIcon } from "./categories-tree/UseCategoriesTree.js";
+export { useCategoriesTree } from "./categories-tree/UseCategoriesTree.js";
+export { CategoriesTreeIcon } from "./categories-tree/CategoriesTreeIcon.js";
 export { useCategoriesTreeButtonProps } from "./categories-tree/CategoriesTreeButtons.js";
 export { CategoriesTreeNode } from "./categories-tree/CategoriesTreeNode.js";
 

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeDefinition.ts
@@ -347,9 +347,6 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         childrenWhichAreParents,
         ...(hasDirectNonSearchTargets ? { hasDirectNonSearchTargets } : {}),
         ...(hasSearchTargetAncestor ? { hasSearchTargetAncestor } : {}),
-        // `imageId` is assigned to instance nodes at query time, but grouping ones need to
-        // be handled during post-processing
-        imageId: "icon-ec-class",
       },
     };
   };
@@ -423,8 +420,8 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                 },
                 grouping: { byLabel: { action: "merge", groupId: "subject" } },
                 extendedData: {
-                  imageId: { selector: `IIF(this.ECInstanceId = ${IModel.rootSubjectId}, 'icon-imodel-hollow-2', 'icon-folder')` },
-                  isSubject: true,
+                  isRootSubject: { selector: `IIF(this.ECInstanceId = ${IModel.rootSubjectId}, true, false)` },
+                  type: "subject",
                 },
                 autoExpand: { selector: `IIF(this.ECInstanceId = ${IModel.rootSubjectId}, true, false)` },
                 supportsFiltering: this.supportsFiltering(),
@@ -491,8 +488,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                         }
                       : true,
                   extendedData: {
-                    imageId: "icon-model",
-                    isModel: true,
+                    type: "model",
                   },
                   supportsFiltering: this.supportsFiltering(),
                 })}
@@ -532,7 +528,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
                 hideNodeInHierarchy: true,
                 hasChildren: true,
                 extendedData: {
-                  isModel: true,
+                  type: "model",
                   modeledElementCategory: { selector: `IdToHex(${parentNode.extendedData.categoryId})` },
                 },
               })}
@@ -696,10 +692,9 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
         `,
       },
       extendedData: {
-        isElement: true,
+        type: "element",
         modelId: { selector: "IdToHex(this.Model.Id)" },
         categoryId: { selector: "IdToHex(this.Category.Id)" },
-        imageId: "icon-item",
       },
       supportsFiltering: this.supportsFiltering(),
     });
@@ -730,8 +725,7 @@ export class ModelsTreeDefinition implements HierarchyDefinition {
       grouping: { byLabel: { action: "merge", groupId: "category" } },
       hasChildren: true,
       extendedData: {
-        imageId: "icon-layers",
-        isCategory: true,
+        type: "category",
         ...extendedData,
       },
       supportsFiltering: this.supportsFiltering(),

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeIcon.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeIcon.tsx
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Icon } from "@stratakit/foundations";
+import categorySvg from "@stratakit/icons/bis-category-3d.svg";
+import classSvg from "@stratakit/icons/bis-class.svg";
+import elementSvg from "@stratakit/icons/bis-element.svg";
+import subjectSvg from "@stratakit/icons/bis-subject.svg";
+import imodelSvg from "@stratakit/icons/imodel.svg";
+import modelSvg from "@stratakit/icons/model-cube.svg";
+import { ModelsTreeNode } from "./ModelsTreeNode.js";
+
+import type { TreeNode } from "@itwin/presentation-hierarchies-react";
+
+/** @beta */
+export function ModelsTreeIcon({ node }: { node: TreeNode }) {
+  const nodeType = ModelsTreeNode.getType(node.nodeData);
+  if (nodeType === undefined) {
+    return undefined;
+  }
+
+  const getIcon = () => {
+    switch (nodeType) {
+      case "category":
+        return categorySvg;
+      case "element":
+        return elementSvg;
+      case "elements-class-group":
+        return classSvg;
+      case "subject":
+        if (node.nodeData.extendedData?.isRootSubject) {
+          return imodelSvg;
+        }
+        return subjectSvg;
+      case "model":
+        return modelSvg;
+    }
+  };
+
+  return <Icon href={getIcon()} />;
+}

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeNode.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/ModelsTreeNode.ts
@@ -15,11 +15,11 @@ import type { ClassGroupingNodeKey, GroupingHierarchyNode, InstancesNodeKey, Non
 export namespace ModelsTreeNode {
   /** Checks if the given node represents a `BisCore.Subject` element. */
   export const isSubjectNode = (node: Pick<HierarchyNode, "extendedData">): node is NonGroupingHierarchyNode & { key: InstancesNodeKey } =>
-    !!node.extendedData?.isSubject;
+    node.extendedData?.type === "subject";
 
   /** Checks if the given node represents a `BisCore.Model`. */
   export const isModelNode = (node: Pick<HierarchyNode, "extendedData">): node is NonGroupingHierarchyNode & { key: InstancesNodeKey } =>
-    !!node.extendedData?.isModel;
+    node.extendedData?.type === "model";
 
   /**
    * Checks if the given node represents a `BisCore.Category` element.
@@ -33,7 +33,7 @@ export namespace ModelsTreeNode {
     extendedData: {
       modelIds: Id64String[];
     };
-  } => !!node.extendedData?.isCategory;
+  } => node.extendedData?.type === "category";
 
   /**
    * Checks if the given node represents a `BisCore.GeometricElement` element.
@@ -49,7 +49,7 @@ export namespace ModelsTreeNode {
       modelId: Id64String;
       categoryId: Id64String;
     };
-  } => !!node.extendedData && "isElement" in node.extendedData && !!node.extendedData.isElement;
+  } => node.extendedData?.type === "element";
 
   /**
    * Checks if the given node is a class grouping node of `BisCore.GeometricElement` nodes.
@@ -68,7 +68,7 @@ export namespace ModelsTreeNode {
   } => HierarchyNode.isClassGroupingNode(node);
 
   /** Returns type of the node. */
-  export const getType = (node: HierarchyNode): "subject" | "model" | "category" | "element" | "elements-class-group" => {
+  export const getType = (node: HierarchyNode): "subject" | "model" | "category" | "element" | "elements-class-group" | undefined => {
     if (HierarchyNodeKey.isClassGrouping(node.key)) {
       return "elements-class-group";
     }
@@ -81,6 +81,9 @@ export namespace ModelsTreeNode {
     if (isCategoryNode(node)) {
       return "category";
     }
-    return "element";
+    if (isElementNode(node)) {
+      return "element";
+    }
+    return undefined;
   };
 }

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/UseModelsTree.tsx
@@ -5,11 +5,6 @@
 
 import { useCallback, useMemo } from "react";
 import { createECSqlQueryExecutor } from "@itwin/presentation-core-interop";
-import { Icon } from "@stratakit/foundations";
-import categorySvg from "@stratakit/icons/bis-category-3d.svg";
-import classSvg from "@stratakit/icons/bis-class.svg";
-import elementSvg from "@stratakit/icons/bis-element.svg";
-import subjectSvg from "@stratakit/icons/bis-subject.svg";
 import modelSvg from "@stratakit/icons/model-cube.svg";
 import {
   EmptyTreeContent,
@@ -29,6 +24,7 @@ import { useSearchPaths } from "./internal/UseSearchPaths.js";
 import { ModelsTreeVisibilityHandler } from "./internal/visibility/ModelsTreeVisibilityHandler.js";
 import { createModelsSearchResultsTree } from "./internal/visibility/SearchResultsTree.js";
 import { defaultHierarchyConfiguration, ModelsTreeDefinition } from "./ModelsTreeDefinition.js";
+import { ModelsTreeIcon } from "./ModelsTreeIcon.js";
 import { ModelsTreeNode } from "./ModelsTreeNode.js";
 
 import type { ReactNode } from "react";
@@ -200,7 +196,11 @@ export function useModelsTree({
       if (!nodeTypeSelectionPredicate) {
         return true;
       }
-      return nodeTypeSelectionPredicate({ node, type: ModelsTreeNode.getType(node.nodeData) });
+      const type = ModelsTreeNode.getType(node.nodeData);
+      if (type === undefined) {
+        return false;
+      }
+      return nodeTypeSelectionPredicate({ node, type });
     },
     [nodeTypeSelectionPredicate],
   );
@@ -293,32 +293,6 @@ function InstanceFocusError({ error }: { error: ModelsTreeSearchError }) {
     return <TooManyInstancesFocused base={"modelsTree"} />;
   }
   return <UnknownInstanceFocusError base={"modelsTree"} />;
-}
-
-/** @beta */
-export function ModelsTreeIcon({ node }: { node: TreeNode }) {
-  if (node.nodeData.extendedData?.imageId === undefined) {
-    return undefined;
-  }
-
-  const getIcon = () => {
-    switch (node.nodeData.extendedData!.imageId) {
-      case "icon-layers":
-        return categorySvg;
-      case "icon-item":
-        return elementSvg;
-      case "icon-ec-class":
-        return classSvg;
-      case "icon-folder":
-        return subjectSvg;
-      case "icon-model":
-        return modelSvg;
-      default:
-        return undefined;
-    }
-  };
-
-  return <Icon href={getIcon()} />;
 }
 
 function useModelsTreeIdsCache({

--- a/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/UseSearchPaths.ts
+++ b/packages/itwin/tree-widget/src/tree-widget-react/components/trees/models-tree/internal/UseSearchPaths.ts
@@ -12,6 +12,7 @@ import { SearchLimitExceededError } from "../../common/TreeErrors.js";
 import { useTelemetryContext } from "../../common/UseTelemetryContext.js";
 import { joinHierarchySearchTrees } from "../../common/Utils.js";
 import { ModelsTreeDefinition } from "../ModelsTreeDefinition.js";
+import { ModelsTreeNode } from "../ModelsTreeNode.js";
 
 import type { GuidString, Id64Array, Id64String } from "@itwin/core-bentley";
 import type { GroupingHierarchyNode, InstancesNodeKey } from "@itwin/presentation-hierarchies";
@@ -303,9 +304,11 @@ async function collectFocusedItems(loadFocusedItems: () => AsyncIterableIterator
     }
 
     const parentKey = groupingNode.nonGroupingAncestor.key;
-    const type = groupingNode.nonGroupingAncestor.extendedData?.isCategory ? "category" : "element";
-    const modelIds = ((groupingNode.nonGroupingAncestor.extendedData?.modelIds as Id64String[][]) ?? []).flatMap((ids) => ids);
-    groupingNodeInfos.push({ groupingNode, parentType: type, parentKey, modelIds });
+    if (ModelsTreeNode.isCategoryNode(groupingNode.nonGroupingAncestor)) {
+      groupingNodeInfos.push({ groupingNode, parentType: "category", parentKey, modelIds: groupingNode.nonGroupingAncestor.extendedData.modelIds });
+      continue;
+    }
+    groupingNodeInfos.push({ groupingNode, parentType: "element", parentKey, modelIds: [] });
   }
   focusedItems.push(
     ...groupingNodeInfos.map(({ parentKey, parentType, groupingNode, modelIds }) => ({


### PR DESCRIPTION
- Adjusted Models/Categories/Classifications trees `extendedData`. Previously Models/Categories trees used `is<NodeType>: boolean` flag, to determine which type of node it is, and classifications tree used `type: "<NodeType>"` flag for the same purpose. Unified all trees to use `type: "<NodeType>"`.
- Expanded `ModelsTreeNode`/`CategoriesTreeNode`/`ClassificationsTreeNode` with `getType` which returns node type.
- Removed `imageId` prop from Models/Categories tree node's `extendedData`. We can determine node icon using the `type` flag.
- In models tree noticed that root subjects don't have an icon when `{ subjects: { root: "include" } }` config is used. For these nodes imodel icon will be used.
- Added tests for newly added `getType` functions.
- Extracted `CategoriesTreeIcon` and `ModelsTreeIcon` functions into separate files.
- Adjusted `collectFocusedItems` to use `ModelsTreeNode` api.