### PR TITLE
[Tree widget]: cleanup tests

### DIFF
--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -715,7 +715,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
               [keys.definitionContainerChild.id]: "hidden",
                 [keys.indirectCategory.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.indirectCategory.id)]: "hidden",
           },
         });
       });
@@ -858,7 +857,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
               [keys.subCategory.id]: "visible",
 
             [keys.category2.id]: "hidden",
-              [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
           },
         });
       });
@@ -1476,7 +1474,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
               [keys.definitionContainerRoot.id]: "partial",
                 [keys.definitionContainerChild.id]: "hidden",
                   [keys.indirectCategory.id]: "hidden",
-                    [getDefaultSubCategoryId(keys.indirectCategory.id)]: "hidden",
                     [keys.indirectElement.id]: "hidden",
 
                 [keys.category.id]: "visible",
@@ -1583,7 +1580,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [keys.element.id]: "hidden",
 
               [keys.category2.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
                 [keys.element2.id]: "hidden",
             },
           });
@@ -1806,7 +1802,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [keys.element.id]: "visible",
 
               [keys.category2.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
                 [keys.element2.id]: "hidden",
             },
           });
@@ -1997,13 +1992,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "hidden",
                   [keys.parentElement.id]: "partial",
                     [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
                       [keys.childElement.id]: "visible",
 
                 [keys.categoryB.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "hidden",
               },
             });
           });
@@ -2029,13 +2022,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "hidden",
                   [keys.parentElement.id]: "partial",
                     [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
                       [keys.childElement.id]: "visible",
 
                 [keys.categoryB.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "hidden",
               },
             });
           });
@@ -2061,13 +2052,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "hidden",
+                  // Category has a sub-category which is hidden
                   [keys.parentElement.id]: "visible",
                     [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
                       [keys.childElement.id]: "visible",
 
                 [keys.categoryB.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "hidden",
               },
             });
           });
@@ -2134,13 +2124,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "hidden",
                   [keys.modeledElement.id]: "partial",
                     [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
                       [keys.subModelElement.id]: "visible",
 
                 [keys.categoryB.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "hidden",
               },
             });
           });
@@ -2165,13 +2153,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "hidden",
                   [keys.modeledElement.id]: "partial",
                     [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
                       [keys.subModelElement.id]: "visible",
 
                 [keys.categoryB.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "hidden",
               },
             });
           });
@@ -2197,13 +2183,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "hidden",
+                  // Category has a sub-category which is hidden
                   [keys.modeledElement.id]: "visible",
                     [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
                       [keys.subModelElement.id]: "visible",
 
                 [keys.categoryB.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "hidden",
               },
             });
           });
@@ -2391,8 +2376,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
               getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.category.id, hasChildren: true }),
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "hidden",
-
                 [ids.category.id]: "visible",
                   [ids.modeledElement.id]: "visible",
               }),
@@ -2404,12 +2387,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   categoryId: ids.category.id,
                   modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
                 }),
-              // Category has partial visibility, since its sub-category is not visible
               // prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "hidden",
-
                 [ids.category.id]: "partial",
+                  // Category has hidden sub-category
                   [ids.modeledElement.id]: "visible",
               }),
             },
@@ -2422,12 +2403,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   elementId: ids.modeledElement.id,
                   hasChildren: false,
                 }),
-              // Category has partial visibility, since its sub-category is not visible
               //prettier-ignore
               expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory?.id ?? ""]: "hidden",
-
                 [ids.category.id]: "partial",
+                  // Category has hidden sub-category
                   [ids.modeledElement.id]: "visible",
               }),
             },
@@ -3158,7 +3137,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
               [keys.definitionContainerChild.id]: "visible",
                 [keys.indirectCategory.id]: "visible",
-                  [getDefaultSubCategoryId(keys.indirectCategory.id)]: "visible",
           },
         });
       });
@@ -3247,7 +3225,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
               [getDefaultSubCategoryId(keys.category.id)]: "visible",
 
             [keys.category2.id]: "visible",
-              [getDefaultSubCategoryId(keys.category2.id)]: "visible",
           },
         });
       });
@@ -3412,13 +3389,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "visible",
                   [keys.parentElement.id]: "partial",
                     [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
                       [keys.childElement.id]: "hidden",
 
                 [keys.categoryB.id]: "visible",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "visible",
               },
             });
           });
@@ -3444,13 +3419,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "visible",
                   [keys.parentElement.id]: "partial",
                     [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
                       [keys.childElement.id]: "hidden",
 
                 [keys.categoryB.id]: "visible",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "visible",
               },
             });
           });
@@ -3476,13 +3449,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "visible",
+                  // Category has a sub-category which is visible
                   [keys.parentElement.id]: "hidden",
                     [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
                       [keys.childElement.id]: "hidden",
 
                 [keys.categoryB.id]: "visible",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "visible",
               },
             });
           });
@@ -3550,13 +3522,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "visible",
                   [keys.modeledElement.id]: "partial",
                     [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
                       [keys.subModelElement.id]: "hidden",
 
                 [keys.categoryB.id]: "visible",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "visible",
               },
             });
           });
@@ -3581,13 +3551,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
               // prettier-ignore
               expectations: {
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "visible",
                   [keys.modeledElement.id]: "partial",
                     [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
                       [keys.subModelElement.id]: "hidden",
 
                 [keys.categoryB.id]: "visible",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "visible",
               },
             });
           });
@@ -3612,14 +3580,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
               viewport,
               // prettier-ignore
               expectations: {
+                // Category has a sub-category which is visible
                 [keys.categoryA.id]: "partial",
-                  [getDefaultSubCategoryId(keys.categoryA.id)]: "visible",
                   [keys.modeledElement.id]: "hidden",
                     [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
                       [keys.subModelElement.id]: "hidden",
 
                 [keys.categoryB.id]: "visible",
-                  [getDefaultSubCategoryId(keys.categoryB.id)]: "visible",
               },
             });
           });
@@ -4045,19 +4012,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       it("showing category changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          element,
-          siblingElement,
-          parentElement1,
-          childElement11,
-          childElement12,
-          parentElement2,
-          childElement21,
-          defaultSubCategory,
-          siblingCategory,
-          defaultSiblingSubCategory,
-        } = createIModelResult;
+        const { category, element, siblingElement, parentElement1, childElement11, childElement12, parentElement2, childElement21, siblingCategory } =
+          createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createCategoryHierarchyNode({
             id: category.id,
@@ -4091,7 +4047,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement1.id]: "partial",
@@ -4103,7 +4058,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });
@@ -4119,9 +4073,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           childElement12,
           parentElement2,
           childElement21,
-          defaultSubCategory,
           siblingCategory,
-          defaultSiblingSubCategory,
           physicalModel,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
@@ -4160,7 +4112,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement1.id]: "partial",
@@ -4172,7 +4123,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });
@@ -4188,9 +4138,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           childElement12,
           parentElement2,
           childElement21,
-          defaultSubCategory,
           siblingCategory,
-          defaultSiblingSubCategory,
           physicalModel,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
@@ -4226,7 +4174,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement1.id]: "partial",
@@ -4238,7 +4185,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });
@@ -4254,9 +4200,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           childElement12,
           parentElement2,
           childElement21,
-          defaultSubCategory,
           siblingCategory,
-          defaultSiblingSubCategory,
           physicalModel,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
@@ -4292,7 +4236,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement1.id]: "hidden",
@@ -4304,7 +4247,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });
@@ -4320,9 +4262,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           childElement12,
           parentElement2,
           childElement21,
-          defaultSubCategory,
           siblingCategory,
-          defaultSiblingSubCategory,
           physicalModel,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
@@ -4358,7 +4298,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement1.id]: "hidden",
@@ -4370,7 +4309,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });
@@ -4447,7 +4385,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       it("showing category changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, defaultSubCategory } = createIModelResult;
+        const { category, element, parentElement, childElement, childOfChild1, childOfChild2 } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createCategoryHierarchyNode({
             id: category.id,
@@ -4482,7 +4420,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement.id]: "visible",
@@ -4495,7 +4432,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       it("showing search target parent element changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, defaultSubCategory, physicalModel } = createIModelResult;
+        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, physicalModel } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createElementHierarchyNode({
             elementId: parentElement.id,
@@ -4528,7 +4465,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement.id]: "visible",
@@ -4541,7 +4477,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       it("showing child element of search target parent element changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, defaultSubCategory, physicalModel } = createIModelResult;
+        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, physicalModel } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createElementHierarchyNode({
             elementId: childElement.id,
@@ -4579,7 +4515,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement.id]: "partial",
@@ -4592,7 +4527,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       it("showing nested child search target element with search target ancestor element changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, defaultSubCategory, physicalModel } = createIModelResult;
+        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, physicalModel } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createElementHierarchyNode({
             elementId: childOfChild1.id,
@@ -4632,7 +4567,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [parentElement.id]: "partial",
@@ -4724,8 +4658,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         it("showing intermediate category changes visibility for related nodes in search paths", async () => {
           const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, defaultSubCategoryA, defaultSubCategoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } =
-            createIModelResult;
+          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
           await visibilityHandlerWithSearchPaths.changeVisibility(
             createCategoryHierarchyNode({
               id: categoryB.id,
@@ -4761,7 +4694,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
             // prettier-ignore
             expectations: {
               [categoryA.id]: "partial",
-                [defaultSubCategoryA.id]: "hidden",
                 [parentElement.id]: "partial",
                   [`${parentElement.id}-${categoryB.id}`]: "partial",
                     [childElement1.id]: "visible",
@@ -4769,15 +4701,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [siblingElement.id]: "hidden",
 
               [categoryB.id]: "hidden",
-                [defaultSubCategoryB.id]: "hidden",
             },
           });
         });
 
         it("showing child element under intermediate category changes visibility for related nodes in search paths", async () => {
           const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, defaultSubCategoryA, defaultSubCategoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } =
-            createIModelResult;
+          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
           await visibilityHandlerWithSearchPaths.changeVisibility(
             createElementHierarchyNode({
               elementId: childElement1.id,
@@ -4810,7 +4740,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
             // prettier-ignore
             expectations: {
               [categoryA.id]: "partial",
-                [defaultSubCategoryA.id]: "hidden",
                 [parentElement.id]: "partial",
                   [`${parentElement.id}-${categoryB.id}`]: "partial",
                     [childElement1.id]: "visible",
@@ -4818,15 +4747,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [siblingElement.id]: "hidden",
 
               [categoryB.id]: "hidden",
-                [defaultSubCategoryB.id]: "hidden",
             },
           });
         });
 
         it("showing parent element changes visibility for intermediate category children in search paths", async () => {
           const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, defaultSubCategoryA, defaultSubCategoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } =
-            createIModelResult;
+          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
           await visibilityHandlerWithSearchPaths.changeVisibility(
             createElementHierarchyNode({
               elementId: parentElement.id,
@@ -4862,7 +4789,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
             // prettier-ignore
             expectations: {
               [categoryA.id]: "partial",
-                [defaultSubCategoryA.id]: "hidden",
                 [parentElement.id]: "partial",
                   [`${parentElement.id}-${categoryB.id}`]: "partial",
                     [childElement1.id]: "visible",
@@ -4870,15 +4796,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [siblingElement.id]: "hidden",
 
               [categoryB.id]: "hidden",
-                [defaultSubCategoryB.id]: "hidden",
             },
           });
         });
 
         it("showing root category changes visibility for intermediate category children in search paths", async () => {
           const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, defaultSubCategoryA, defaultSubCategoryB, parentElement, childElement1, childElement2, siblingElement } =
-            createIModelResult;
+          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement } = createIModelResult;
           await visibilityHandlerWithSearchPaths.changeVisibility(
             createCategoryHierarchyNode({
               id: categoryA.id,
@@ -4911,7 +4835,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
             // prettier-ignore
             expectations: {
               [categoryA.id]: "partial",
-                [defaultSubCategoryA.id]: "hidden",
                 [parentElement.id]: "partial",
                   [`${parentElement.id}-${categoryB.id}`]: "partial",
                     [childElement1.id]: "visible",
@@ -4919,7 +4842,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [siblingElement.id]: "hidden",
 
               [categoryB.id]: "hidden",
-                [defaultSubCategoryB.id]: "hidden",
             },
           });
         });
@@ -5002,8 +4924,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         it("showing intermediate category under sub-model changes visibility for related nodes in search paths", async () => {
           const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, defaultSubCategoryA, defaultSubCategoryB, modeledElement, subModel, subModelElement1, subModelElement2 } =
-            createIModelResult;
+          const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2 } = createIModelResult;
           await visibilityHandlerWithSearchPaths.changeVisibility(
             createCategoryHierarchyNode({
               id: categoryB.id,
@@ -5039,22 +4960,19 @@ describe("CategoriesTreeVisibilityHandler", () => {
             // prettier-ignore
             expectations: {
               [categoryA.id]: "partial",
-                [defaultSubCategoryA.id]: "hidden",
                 [modeledElement.id]: "partial",
                   [`${modeledElement.id}-${categoryB.id}`]: "partial",
                     [subModelElement1.id]: "visible",
                     [subModelElement2.id]: "hidden",
 
               [categoryB.id]: "hidden",
-                [defaultSubCategoryB.id]: "hidden",
             },
           });
         });
 
         it("showing element under intermediate category in sub-model changes visibility for related nodes in search paths", async () => {
           const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, defaultSubCategoryA, defaultSubCategoryB, modeledElement, subModel, subModelElement1, subModelElement2 } =
-            createIModelResult;
+          const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2 } = createIModelResult;
           await visibilityHandlerWithSearchPaths.changeVisibility(
             createElementHierarchyNode({
               elementId: subModelElement1.id,
@@ -5087,31 +5005,19 @@ describe("CategoriesTreeVisibilityHandler", () => {
             // prettier-ignore
             expectations: {
               [categoryA.id]: "partial",
-                [defaultSubCategoryA.id]: "hidden",
                 [modeledElement.id]: "partial",
                   [`${modeledElement.id}-${categoryB.id}`]: "partial",
                     [subModelElement1.id]: "visible",
                     [subModelElement2.id]: "hidden",
 
               [categoryB.id]: "hidden",
-                [defaultSubCategoryB.id]: "hidden",
             },
           });
         });
 
         it("showing modeled element changes visibility for intermediate category children in search paths", async () => {
           const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const {
-            categoryA,
-            categoryB,
-            defaultSubCategoryA,
-            defaultSubCategoryB,
-            modeledElement,
-            subModel,
-            subModelElement1,
-            subModelElement2,
-            elementsModel,
-          } = createIModelResult;
+          const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2, elementsModel } = createIModelResult;
           await visibilityHandlerWithSearchPaths.changeVisibility(
             createElementHierarchyNode({
               elementId: modeledElement.id,
@@ -5148,14 +5054,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
             // prettier-ignore
             expectations: {
               [categoryA.id]: "partial",
-                [defaultSubCategoryA.id]: "hidden",
                 [modeledElement.id]: "partial",
                   [`${modeledElement.id}-${categoryB.id}`]: "partial",
                     [subModelElement1.id]: "visible",
                     [subModelElement2.id]: "hidden",
 
               [categoryB.id]: "hidden",
-                [defaultSubCategoryB.id]: "hidden",
             },
           });
         });
@@ -5272,14 +5176,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
           subModelElement,
           siblingCategory,
           siblingElement,
-          defaultSiblingSubCategory,
-          defaultSubCategoryOfSubModelCategory,
-          defaultSubCategory,
           element,
           subModelElement2,
           otherSubModelCategory,
           otherSubModelElement,
-          defaultSubCategoryOfOtherSubModelCategory,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createCategoryHierarchyNode({
@@ -5317,7 +5217,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [modeledElement.id]: "partial",
@@ -5328,14 +5227,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   [otherSubModelElement.id]: "hidden",
 
             [otherSubModelCategory.id]: "hidden",
-              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
 
             [subModelCategory.id]: "hidden",
-              [defaultSubCategoryOfSubModelCategory.id]: "hidden",
           },
         });
       });
@@ -5350,14 +5246,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
           subModelElement,
           siblingCategory,
           siblingElement,
-          defaultSiblingSubCategory,
-          defaultSubCategoryOfSubModelCategory,
-          defaultSubCategory,
           element,
           subModelElement2,
           otherSubModelCategory,
           otherSubModelElement,
-          defaultSubCategoryOfOtherSubModelCategory,
           physicalModel,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
@@ -5394,7 +5286,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [modeledElement.id]: "partial",
@@ -5405,14 +5296,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   [otherSubModelElement.id]: "hidden",
 
             [otherSubModelCategory.id]: "hidden",
-              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
 
             [subModelCategory.id]: "hidden",
-              [defaultSubCategoryOfSubModelCategory.id]: "hidden",
           },
         });
       });
@@ -5427,14 +5315,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
           subModelElement,
           siblingCategory,
           siblingElement,
-          defaultSiblingSubCategory,
-          defaultSubCategoryOfSubModelCategory,
-          defaultSubCategory,
           element,
           subModelElement2,
           otherSubModelCategory,
           otherSubModelElement,
-          defaultSubCategoryOfOtherSubModelCategory,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createCategoryHierarchyNode({
@@ -5471,7 +5355,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [modeledElement.id]: "partial",
@@ -5482,14 +5365,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   [otherSubModelElement.id]: "hidden",
 
             [otherSubModelCategory.id]: "hidden",
-              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
 
             [subModelCategory.id]: "hidden",
-              [defaultSubCategoryOfSubModelCategory.id]: "hidden",
           },
         });
       });
@@ -5504,14 +5384,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
           subModelElement,
           siblingCategory,
           siblingElement,
-          defaultSiblingSubCategory,
-          defaultSubCategoryOfSubModelCategory,
-          defaultSubCategory,
           element,
           subModelElement2,
           otherSubModelCategory,
           otherSubModelElement,
-          defaultSubCategoryOfOtherSubModelCategory,
         } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createElementHierarchyNode({
@@ -5547,7 +5423,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
           // prettier-ignore
           expectations: {
             [category.id]: "partial",
-              [defaultSubCategory.id]: "hidden",
               [element.id]: "hidden",
 
               [modeledElement.id]: "partial",
@@ -5558,14 +5433,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   [otherSubModelElement.id]: "hidden",
 
             [otherSubModelCategory.id]: "hidden",
-              [defaultSubCategoryOfOtherSubModelCategory.id]: "hidden",
 
             [siblingCategory.id]: "hidden",
               [siblingElement.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
 
             [subModelCategory.id]: "hidden",
-              [defaultSubCategoryOfSubModelCategory.id]: "hidden",
           },
         });
       });
@@ -5632,7 +5504,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       it("showing definition container changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { definitionContainer, category, siblingCategory, defaultSubCategory, defaultSiblingSubCategory, subCategory } = createIModelResult;
+        const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createDefinitionContainerHierarchyNode({
             id: definitionContainer.id,
@@ -5668,14 +5540,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [subCategory.id]: "hidden",
 
               [siblingCategory.id]: "hidden",
-                [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });
 
       it("showing category changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { definitionContainer, category, siblingCategory, defaultSubCategory, defaultSiblingSubCategory, subCategory } = createIModelResult;
+        const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createCategoryHierarchyNode({
             id: category.id,
@@ -5712,14 +5583,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [subCategory.id]: "hidden",
 
               [siblingCategory.id]: "hidden",
-                [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });
 
       it("showing search target sub-category changes visibility for related nodes in search paths", async () => {
         const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { definitionContainer, category, siblingCategory, defaultSubCategory, defaultSiblingSubCategory, subCategory } = createIModelResult;
+        const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
         await visibilityHandlerWithSearchPaths.changeVisibility(
           createSubCategoryHierarchyNode({
             id: defaultSubCategory.id,
@@ -5754,7 +5624,6 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 [subCategory.id]: "hidden",
 
               [siblingCategory.id]: "hidden",
-                [defaultSiblingSubCategory.id]: "hidden",
           },
         });
       });

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -91,16 +91,18 @@ describe("CategoriesTreeVisibilityHandler", () => {
     hierarchyConfig,
     subCategoriesOfCategories,
     visibleByDefault,
+    viewType,
   }: {
     imodelConnection: IModelConnection;
     hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration;
     subCategoriesOfCategories?: Array<{ categoryId: Id64String; subCategories: Id64Arg }>;
     visibleByDefault?: boolean;
+    viewType: "2d" | "3d";
   }) {
     const imodelAccess = createIModelAccess(imodelConnection);
-    const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView("3d").elementClass, type: "3d" });
-    const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-    const viewport = createTreeWidgetTestingViewport({ iModel: imodelConnection, subCategoriesOfCategories, viewType: "3d", visibleByDefault });
+    const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView(viewType).elementClass, type: viewType });
+    const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: viewType, baseIdsCache });
+    const viewport = createTreeWidgetTestingViewport({ iModel: imodelConnection, subCategoriesOfCategories, viewType, visibleByDefault });
 
     return {
       imodelAccess,
@@ -116,9 +118,10 @@ describe("CategoriesTreeVisibilityHandler", () => {
     imodelAccess: ReturnType<typeof createIModelAccess>;
     searchPaths?: HierarchySearchTree[];
     hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration;
+    viewType?: "2d" | "3d";
   }) {
     return createIModelHierarchyProvider({
-      hierarchyDefinition: new CategoriesTreeDefinition({ ...props, viewType: "3d" }),
+      hierarchyDefinition: new CategoriesTreeDefinition({ ...props, viewType: props.viewType ?? "3d" }),
       imodelAccess: props.imodelAccess,
       ...(props.searchPaths ? { search: { paths: props.searchPaths } } : undefined),
     });
@@ -128,18 +131,20 @@ describe("CategoriesTreeVisibilityHandler", () => {
     imodelConnection,
     subCategoriesOfCategories,
     visibleByDefault,
+    viewType,
     ...restProps
   }: {
     imodelConnection: IModelConnection;
     hierarchyConfig?: CategoriesTreeHierarchyConfiguration;
     subCategoriesOfCategories?: Array<{ categoryId: Id64String; subCategories: Id64Arg }>;
     visibleByDefault?: boolean;
+    viewType?: "2d" | "3d";
   }) {
     const hierarchyConfig = mergeWithDefaults({
       defaults: defaultHierarchyConfiguration,
       overrides: restProps.hierarchyConfig,
     });
-    const commonProps = await createCommonProps({ imodelConnection, hierarchyConfig, subCategoriesOfCategories, visibleByDefault });
+    const commonProps = await createCommonProps({ imodelConnection, hierarchyConfig, subCategoriesOfCategories, visibleByDefault, viewType: viewType ?? "3d" });
     const handler = createCategoriesTreeVisibilityHandler({
       viewport: commonProps.viewport,
       idsCache: commonProps.idsCache,
@@ -147,7 +152,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
       searchPaths: undefined,
       hierarchyConfig,
     });
-    const provider = createProvider({ ...commonProps, hierarchyConfig });
+    const provider = createProvider({ ...commonProps, hierarchyConfig, viewType });
 
     return {
       handler,
@@ -1960,6 +1965,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
             visibilityTestData = await createVisibilityTestData({
               imodelConnection: buildIModelResult.imodelConnection,
               hierarchyConfig: { elements: { nodes: "include" } },
+              viewType,
             });
           });
 
@@ -2093,6 +2099,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
             visibilityTestData = await createVisibilityTestData({
               imodelConnection: buildIModelResult.imodelConnection,
               hierarchyConfig: { elements: { nodes: "include" } },
+              viewType,
             });
           });
 
@@ -3357,6 +3364,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
               imodelConnection: buildIModelResult.imodelConnection,
               hierarchyConfig: { elements: { nodes: "include" } },
               visibleByDefault: true,
+              viewType,
             });
           });
 
@@ -3491,6 +3499,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
               imodelConnection: buildIModelResult.imodelConnection,
               hierarchyConfig: { elements: { nodes: "include" } },
               visibleByDefault: true,
+              viewType,
             });
           });
 
@@ -3705,8 +3714,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
         viewport,
         hierarchyConfig,
       });
-      const defaultProvider = createProvider({ idsCache, imodelAccess, hierarchyConfig });
-      const providerWithSearchPaths = createProvider({ idsCache, imodelAccess, searchPaths, hierarchyConfig });
+      const defaultProvider = createProvider({ idsCache, imodelAccess, hierarchyConfig, viewType: view });
+      const providerWithSearchPaths = createProvider({ idsCache, imodelAccess, searchPaths, hierarchyConfig, viewType: view });
       return {
         defaultVisibilityHandler,
         visibilityHandlerWithSearchPaths,

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/VisibilityValidation.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/VisibilityValidation.ts
@@ -10,7 +10,12 @@ import { CategoriesTreeNodeInternal } from "../../../../tree-widget-react/compon
 import type { HierarchyNode } from "@itwin/presentation-hierarchies";
 import type { ValidateNodeProps } from "../../common/VisibilityValidation.js";
 
-export async function validateNodeVisibility({ node, handler, expectations }: ValidateNodeProps & { node: HierarchyNode }) {
+export async function validateNodeVisibility({
+  node,
+  handler,
+  expectations,
+  validatedIds,
+}: ValidateNodeProps & { node: HierarchyNode; validatedIds: Set<string> }) {
   const actualVisibility = await handler.getVisibilityStatus(node);
 
   if (expectations === "all-hidden" || expectations === "all-visible") {
@@ -24,6 +29,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
     let hiddenCount = 0;
 
     for (const elementId of elementIds) {
+      validatedIds.add(elementId);
       if (expectations[elementId] === "visible") {
         ++visibleCount;
       } else if (expectations[elementId] === "hidden") {
@@ -46,6 +52,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
 
   if (CategoriesTreeNode.isSubCategoryNode(node)) {
     const { id } = node.key.instanceKeys[0];
+    validatedIds.add(id);
     // One subCategory gets added when category is inserted
     if (expectations[id] === "disabled") {
       expect(actualVisibility.isDisabled, `Node, ${JSON.stringify(node)}`).toBe(true);
@@ -66,6 +73,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
     if (parentOrModelId !== undefined) {
       idToUse = `${parentOrModelId}-${id}`;
     }
+    validatedIds.add(idToUse);
     if (expectations[idToUse] === "disabled") {
       expect(actualVisibility.isDisabled, `Node, ${JSON.stringify(node)}`).toBe(true);
     } else {
@@ -75,6 +83,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
   }
   if (CategoriesTreeNode.isModelNode(node) || CategoriesTreeNode.isDefinitionContainerNode(node) || CategoriesTreeNode.isElementNode(node)) {
     const { id } = node.key.instanceKeys[0];
+    validatedIds.add(id);
     if (expectations[id] === "disabled") {
       expect(actualVisibility.isDisabled, `Node, ${JSON.stringify(node)}`).toBe(true);
     } else {

--- a/packages/tree-widget/src/test/trees/classifications-tree/VisibilityValidation.ts
+++ b/packages/tree-widget/src/test/trees/classifications-tree/VisibilityValidation.ts
@@ -14,7 +14,7 @@ export async function validateNodeVisibility({
   handler,
   expectations,
   validatedIds,
-}: ValidateNodeProps & { node: HierarchyNode; validatedIds: Set<string> }) {
+}: ValidateNodeProps & { node: HierarchyNode; validatedIds?: Set<string> }) {
   const actualVisibility = await handler.getVisibilityStatus(node);
 
   if (expectations === "all-hidden" || expectations === "all-visible") {
@@ -28,7 +28,7 @@ export async function validateNodeVisibility({
     ClassificationsTreeNode.isGeometricElementNode(node)
   ) {
     const { id } = node.key.instanceKeys[0];
-    validatedIds.add(id);
+    validatedIds?.add(id);
     if (expectations[id] === "disabled") {
       expect(actualVisibility.isDisabled, `Node, ${JSON.stringify(node)}`).toBe(true);
     } else {

--- a/packages/tree-widget/src/test/trees/classifications-tree/VisibilityValidation.ts
+++ b/packages/tree-widget/src/test/trees/classifications-tree/VisibilityValidation.ts
@@ -9,7 +9,12 @@ import { ClassificationsTreeNode } from "../../../tree-widget-react/components/t
 import type { HierarchyNode } from "@itwin/presentation-hierarchies";
 import type { ValidateNodeProps } from "../common/VisibilityValidation.js";
 
-export async function validateNodeVisibility({ node, handler, expectations }: ValidateNodeProps & { node: HierarchyNode }) {
+export async function validateNodeVisibility({
+  node,
+  handler,
+  expectations,
+  validatedIds,
+}: ValidateNodeProps & { node: HierarchyNode; validatedIds: Set<string> }) {
   const actualVisibility = await handler.getVisibilityStatus(node);
 
   if (expectations === "all-hidden" || expectations === "all-visible") {
@@ -23,6 +28,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
     ClassificationsTreeNode.isGeometricElementNode(node)
   ) {
     const { id } = node.key.instanceKeys[0];
+    validatedIds.add(id);
     if (expectations[id] === "disabled") {
       expect(actualVisibility.isDisabled, `Node, ${JSON.stringify(node)}`).toBe(true);
     } else {

--- a/packages/tree-widget/src/test/trees/common/VisibilityValidation.ts
+++ b/packages/tree-widget/src/test/trees/common/VisibilityValidation.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { EMPTY, expand, from, mergeMap } from "rxjs";
+import { EMPTY, expand, from, map, mergeMap, takeLast } from "rxjs";
 import { toVoidPromise } from "../../../tree-widget-react/components/trees/common/internal/Rxjs.js";
 
 import type { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
@@ -27,15 +27,26 @@ export async function validateHierarchyVisibility({
   ...props
 }: ValidateNodeProps & {
   provider: HierarchyProvider;
-  validateNodeVisibility: (props: ValidateNodeProps & { node: HierarchyNode }) => Promise<void>;
+  validateNodeVisibility: (props: ValidateNodeProps & { node: HierarchyNode; validatedIds: Set<string> }) => Promise<void>;
 }) {
   props.viewport.renderFrame();
   // This promise allows handler change event to fire if it was scheduled.
   await new Promise((resolve) => setTimeout(resolve));
+  const validatedIds = new Set<string>();
   await toVoidPromise(
     from(provider.getNodes({ parentNode: undefined })).pipe(
       expand((node) => (node.children ? provider.getNodes({ parentNode: node }) : EMPTY)),
-      mergeMap(async (node) => validateNodeVisibility({ ...props, node })),
+      mergeMap(async (node) => validateNodeVisibility({ ...props, node, validatedIds })),
+      takeLast(1),
+      map(() => {
+        if (props.expectations === "all-hidden" || props.expectations === "all-visible") {
+          return;
+        }
+        const unnecessaryExpectations = Object.keys(props.expectations).filter((id) => !validatedIds.has(id));
+        if (unnecessaryExpectations.length > 0) {
+          throw new Error(`Too many expectations provided, unused ids: ${unnecessaryExpectations.join(", ")}`);
+        }
+      }),
     ),
   );
 }

--- a/packages/tree-widget/src/test/trees/common/VisibilityValidation.ts
+++ b/packages/tree-widget/src/test/trees/common/VisibilityValidation.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import { EMPTY, expand, from, map, mergeMap, takeLast } from "rxjs";
+import { EMPTY, expand, from, mergeMap, tap } from "rxjs";
 import { toVoidPromise } from "../../../tree-widget-react/components/trees/common/internal/Rxjs.js";
 
 import type { HierarchyNode, HierarchyProvider } from "@itwin/presentation-hierarchies";
@@ -37,15 +37,16 @@ export async function validateHierarchyVisibility({
     from(provider.getNodes({ parentNode: undefined })).pipe(
       expand((node) => (node.children ? provider.getNodes({ parentNode: node }) : EMPTY)),
       mergeMap(async (node) => validateNodeVisibility({ ...props, node, validatedIds })),
-      takeLast(1),
-      map(() => {
-        if (props.expectations === "all-hidden" || props.expectations === "all-visible") {
-          return;
-        }
-        const unnecessaryExpectations = Object.keys(props.expectations).filter((id) => !validatedIds.has(id));
-        if (unnecessaryExpectations.length > 0) {
-          throw new Error(`Too many expectations provided, unused ids: ${unnecessaryExpectations.join(", ")}`);
-        }
+      tap({
+        complete: () => {
+          if (props.expectations === "all-hidden" || props.expectations === "all-visible") {
+            return;
+          }
+          const unnecessaryExpectations = Object.keys(props.expectations).filter((id) => !validatedIds.has(id));
+          if (unnecessaryExpectations.length > 0) {
+            throw new Error(`Too many expectations provided, unused ids: ${unnecessaryExpectations.join(", ")}`);
+          }
+        },
       }),
     ),
   );

--- a/packages/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
+++ b/packages/tree-widget/src/test/trees/models-tree/internal/ModelsTreeVisibilityHandler.test.ts
@@ -1899,13 +1899,12 @@ describe("ModelsTreeVisibilityHandler", () => {
               }),
             // prettier-ignore
             expectations: (ids: IModelWithSubModelIds) => ({
-              [ids.subjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryId}`]: "partial",
-                    [ids.parentElementId!]: "partial",
-                      [ids.modeledElementId]: "visible",
-                        [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
-                          [ids.subModelElementId!]: "visible",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryId}`]: "partial",
+                  [ids.parentElementId!]: "partial",
+                    [ids.modeledElementId]: "visible",
+                      [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
+                        [ids.subModelElementId!]: "visible",
             }),
           },
           {
@@ -1919,13 +1918,12 @@ describe("ModelsTreeVisibilityHandler", () => {
               }),
             // prettier-ignore
             expectations: (ids: IModelWithSubModelIds) => ({
-              [ids.subjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryId}`]: "partial",
-                    [ids.parentElementId!]: "partial",
-                      [ids.modeledElementId]: "visible",
-                        [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
-                          [ids.subModelElementId!]: "visible",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryId}`]: "partial",
+                  [ids.parentElementId!]: "partial",
+                    [ids.modeledElementId]: "visible",
+                      [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
+                        [ids.subModelElementId!]: "visible",
             }),
           },
           {
@@ -1937,13 +1935,12 @@ describe("ModelsTreeVisibilityHandler", () => {
               }),
             // prettier-ignore
             expectations: (ids: IModelWithSubModelIds) => ({
-              [ids.subjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryId}`]: "partial",
-                    [ids.parentElementId!]: "partial",
-                      [ids.modeledElementId]: "partial",
-                        [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
-                          [ids.subModelElementId!]: "visible",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryId}`]: "partial",
+                  [ids.parentElementId!]: "partial",
+                    [ids.modeledElementId]: "partial",
+                      [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
+                        [ids.subModelElementId!]: "visible",
             }),
           },
           {
@@ -1956,13 +1953,12 @@ describe("ModelsTreeVisibilityHandler", () => {
               }),
             // prettier-ignore
             expectations: (ids: IModelWithSubModelIds) => ({
-              [ids.subjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryId}`]: "partial",
-                    [ids.parentElementId!]: "partial",
-                      [ids.modeledElementId]: "partial",
-                        [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
-                          [ids.subModelElementId!]: "visible",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryId}`]: "partial",
+                  [ids.parentElementId!]: "partial",
+                    [ids.modeledElementId]: "partial",
+                      [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
+                        [ids.subModelElementId!]: "visible",
             }),
           },
           {
@@ -1975,13 +1971,12 @@ describe("ModelsTreeVisibilityHandler", () => {
               }),
             // prettier-ignore
             expectations: (ids: IModelWithSubModelIds) => ({
-              [ids.subjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryId}`]: "partial",
-                    [ids.parentElementId!]: "partial",
-                      [ids.modeledElementId]: "partial",
-                        [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
-                          [ids.subModelElementId!]: "visible",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryId}`]: "partial",
+                  [ids.parentElementId!]: "partial",
+                    [ids.modeledElementId]: "partial",
+                      [`${ids.modeledElementId}-${ids.subModelCategoryId}`]: "visible",
+                        [ids.subModelElementId!]: "visible",
             }),
           },
         ],
@@ -2257,14 +2252,13 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "visible",
-              [`${ids.model}-${ids.categoryId}`]: "visible",
-                [ids.element]: "visible",
+          [ids.model]: "visible",
+            [`${ids.model}-${ids.categoryId}`]: "visible",
+              [ids.element]: "visible",
 
-            [ids.otherModel]: "hidden",
-              [`${ids.otherModel}-${ids.categoryId}`]: "hidden",
-                [ids.otherElement]: "hidden",
+          [ids.otherModel]: "hidden",
+            [`${ids.otherModel}-${ids.categoryId}`]: "hidden",
+              [ids.otherElement]: "hidden",
         },
       });
     });
@@ -2295,12 +2289,11 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.categoryId}`]: "partial",
-                [ids.hiddenElement]: "hidden",
-                [ids.element1]: "visible",
-                [ids.element2]: "visible",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.categoryId}`]: "partial",
+              [ids.hiddenElement]: "hidden",
+              [ids.element1]: "visible",
+              [ids.element2]: "visible",
         },
       });
     });
@@ -2463,15 +2456,14 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.category}`]: "partial",
-                [ids.elementToShow]: "visible",
-                [ids.elements1]: "hidden",
-                [ids.elements2]: "hidden",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.category}`]: "partial",
+              [ids.elementToShow]: "visible",
+              [ids.elements1]: "hidden",
+              [ids.elements2]: "hidden",
 
-              [`${ids.model}-${ids.otherCategory}`]: "hidden",
-                [ids.otherElement]: "hidden",
+            [`${ids.model}-${ids.otherCategory}`]: "hidden",
+              [ids.otherElement]: "hidden",
         },
       });
     });
@@ -2528,18 +2520,17 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.category}`]: "partial",
-                [elementToShow]: "visible",
-                [ids.modelElements[1]]: "hidden",
-                [ids.modelElements[2]]: "hidden",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.category}`]: "partial",
+              [elementToShow]: "visible",
+              [ids.modelElements[1]]: "hidden",
+              [ids.modelElements[2]]: "hidden",
 
-            [ids.otherModel]: "hidden",
-              [`${ids.otherModel}-${ids.category}`]: "hidden",
-                [ids.otherModelElements[0]]: "hidden",
-                [ids.otherModelElements[1]]: "hidden",
-                [ids.otherModelElements[2]]: "hidden",
+          [ids.otherModel]: "hidden",
+            [`${ids.otherModel}-${ids.category}`]: "hidden",
+              [ids.otherModelElements[0]]: "hidden",
+              [ids.otherModelElements[1]]: "hidden",
+              [ids.otherModelElements[2]]: "hidden",
         },
       });
     });
@@ -2569,15 +2560,14 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.categoryId}`]: "partial",
-                [ids.exclusiveElement]: "visible",
-                [ids.element]: "hidden",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.categoryId}`]: "partial",
+              [ids.exclusiveElement]: "visible",
+              [ids.element]: "hidden",
 
-            [ids.otherModel]: "hidden",
-              [`${ids.otherModel}-${ids.categoryId}`]: "hidden",
-                [ids.otherElement]: "hidden",
+          [ids.otherModel]: "hidden",
+            [`${ids.otherModel}-${ids.categoryId}`]: "hidden",
+              [ids.otherElement]: "hidden",
         },
       });
     });
@@ -2608,16 +2598,15 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.categoryId}`]: "partial",
-                [ids.exclusiveElement]: "partial",
-                  [`${ids.exclusiveElement}-${ids.childCategoryId}`]: "hidden",
-                    [ids.childElement]: "hidden",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.categoryId}`]: "partial",
+              [ids.exclusiveElement]: "partial",
+                [`${ids.exclusiveElement}-${ids.childCategoryId}`]: "hidden",
+                  [ids.childElement]: "hidden",
 
-            [ids.otherModel]: "hidden",
-              [`${ids.otherModel}-${ids.categoryId}`]: "hidden",
-                [ids.otherElement]: "hidden",
+          [ids.otherModel]: "hidden",
+            [`${ids.otherModel}-${ids.categoryId}`]: "hidden",
+              [ids.otherElement]: "hidden",
         },
       });
     });
@@ -2687,13 +2676,12 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.category}`]: "hidden",
-                [ids.element]: "hidden",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.category}`]: "hidden",
+              [ids.element]: "hidden",
 
-              [`${ids.model}-${ids.otherCategory}`]: "visible",
-                [ids.otherElement]: "visible",
+            [`${ids.model}-${ids.otherCategory}`]: "visible",
+              [ids.otherElement]: "visible",
         },
       });
     });
@@ -2732,15 +2720,14 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.category}`]: "visible",
-                [ids.parentElement]: "visible",
-                  [ids.child]: "visible",
-                    [ids.childOfChild]: "visible",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.category}`]: "visible",
+              [ids.parentElement]: "visible",
+                [ids.child]: "visible",
+                  [ids.childOfChild]: "visible",
 
-              [`${ids.model}-${ids.otherCategory}`]: "hidden",
-                [ids.otherElement]: "hidden",
+            [`${ids.model}-${ids.otherCategory}`]: "hidden",
+              [ids.otherElement]: "hidden",
         },
       });
     });
@@ -2781,15 +2768,14 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              [`${ids.model}-${ids.category}`]: "hidden",
-                [ids.parentElement]: "hidden",
-                  [ids.child]: "hidden",
-                    [ids.childOfChild]: "hidden",
+          [ids.model]: "partial",
+            [`${ids.model}-${ids.category}`]: "hidden",
+              [ids.parentElement]: "hidden",
+                [ids.child]: "hidden",
+                  [ids.childOfChild]: "hidden",
 
-              [`${ids.model}-${ids.otherCategory}`]: "visible",
-                [ids.otherElement]: "visible",
+            [`${ids.model}-${ids.otherCategory}`]: "visible",
+              [ids.otherElement]: "visible",
         },
       });
     });
@@ -2849,12 +2835,11 @@ describe("ModelsTreeVisibilityHandler", () => {
         viewport,
         // prettier-ignore
         expectations: {
-          [IModel.rootSubjectId]: "partial",
-            [ids.model]: "partial",
-              // Validation uses first category id to check expected visibility
-              [`${ids.model}-${ids.category1}`]: "partial",
-                [ids.element1]: "hidden",
-                [ids.element2]: "visible",
+          [ids.model]: "partial",
+            // Validation uses first category id to check expected visibility
+            [`${ids.model}-${ids.category1}`]: "partial",
+              [ids.element1]: "hidden",
+              [ids.element2]: "visible",
         },
       });
       await handler.changeVisibility(
@@ -2999,15 +2984,14 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                [`${modelId}-${category1Id}`]: "visible",
-                  [parentElementId]: "visible",
-                    [`${parentElementId}-${childCategoryId}`]: "visible",
-                      [childElementWithDifferentCategoryId]: "visible",
+            [modelId]: "partial",
+              [`${modelId}-${category1Id}`]: "visible",
+                [parentElementId]: "visible",
+                  [`${parentElementId}-${childCategoryId}`]: "visible",
+                    [childElementWithDifferentCategoryId]: "visible",
 
-                [`${modelId}-${category2Id}`]: "hidden",
-                  [element2Id]: "hidden",
+              [`${modelId}-${category2Id}`]: "hidden",
+                [element2Id]: "hidden",
           },
         });
       });
@@ -3063,15 +3047,14 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                [`${modelId}-${sharedCategoryId}`]: "visible",
-                  [elementWithSharedCategoryId]: "visible",
+            [modelId]: "partial",
+              [`${modelId}-${sharedCategoryId}`]: "visible",
+                [elementWithSharedCategoryId]: "visible",
 
-                [`${modelId}-${parentCategoryId}`]: "partial",
-                  [parentElementId]: "partial",
-                    [`${parentElementId}-${sharedCategoryId}`]: "visible",
-                      [childElementWithSharedCategoryId]: "visible",
+              [`${modelId}-${parentCategoryId}`]: "partial",
+                [parentElementId]: "partial",
+                  [`${parentElementId}-${sharedCategoryId}`]: "visible",
+                    [childElementWithSharedCategoryId]: "visible",
           },
         });
       });
@@ -3115,15 +3098,14 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                [`${modelId}-${categoryId}`]: "visible",
-                  [elementId]: "visible",
+            [modelId]: "partial",
+              [`${modelId}-${categoryId}`]: "visible",
+                [elementId]: "visible",
 
-                [`${modelId}-${unrelatedCategoryId}`]: "hidden",
-                  [unrelatedParentElementId]: "hidden",
-                    [`${unrelatedParentElementId}-${categoryId}`]: "hidden",
-                      [childOfUnrelatedElementId]: "hidden",
+              [`${modelId}-${unrelatedCategoryId}`]: "hidden",
+                [unrelatedParentElementId]: "hidden",
+                  [`${unrelatedParentElementId}-${categoryId}`]: "hidden",
+                    [childOfUnrelatedElementId]: "hidden",
           },
         });
       });
@@ -3167,12 +3149,11 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                [`${modelId}-${parentCategoryId}`]: "partial",
-                  [parentElementId]: "partial",
-                    [`${parentElementId}-${childCategoryId}`]: "visible",
-                      [childElementWithDifferentCategoryId]: "visible",
+            [modelId]: "partial",
+              [`${modelId}-${parentCategoryId}`]: "partial",
+                [parentElementId]: "partial",
+                  [`${parentElementId}-${childCategoryId}`]: "visible",
+                    [childElementWithDifferentCategoryId]: "visible",
           },
         });
       });
@@ -3218,12 +3199,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryAId}`]: "partial",
-                    [ids.parentElementId]: "partial",
-                      [`${ids.parentElementId}-${ids.categoryBId}`]: "visible",
-                        [ids.childElementId]: "visible",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryAId}`]: "partial",
+                  [ids.parentElementId]: "partial",
+                    [`${ids.parentElementId}-${ids.categoryBId}`]: "visible",
+                      [ids.childElementId]: "visible",
             },
           });
         });
@@ -3266,12 +3246,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryAId}`]: "partial",
-                    [ids.parentElementId]: "partial",
-                      [`${ids.parentElementId}-${ids.categoryBId}`]: "visible",
-                        [ids.childElementId]: "visible",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryAId}`]: "partial",
+                  [ids.parentElementId]: "partial",
+                    [`${ids.parentElementId}-${ids.categoryBId}`]: "visible",
+                      [ids.childElementId]: "visible",
             },
           });
         });
@@ -3356,12 +3335,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryAId}`]: "partial",
-                    [ids.parentElementId]: "partial",
-                      [`${ids.parentElementId}-${ids.categoryBId}`]: "hidden",
-                        [ids.childElementId]: "hidden",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryAId}`]: "partial",
+                  [ids.parentElementId]: "partial",
+                    [`${ids.parentElementId}-${ids.categoryBId}`]: "hidden",
+                      [ids.childElementId]: "hidden",
             },
           });
         });
@@ -3404,12 +3382,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [ids.modelId]: "partial",
-                  [`${ids.modelId}-${ids.categoryAId}`]: "partial",
-                    [ids.parentElementId]: "partial",
-                      [`${ids.parentElementId}-${ids.categoryBId}`]: "hidden",
-                        [ids.childElementId]: "hidden",
+              [ids.modelId]: "partial",
+                [`${ids.modelId}-${ids.categoryAId}`]: "partial",
+                  [ids.parentElementId]: "partial",
+                    [`${ids.parentElementId}-${ids.categoryBId}`]: "hidden",
+                      [ids.childElementId]: "hidden",
             },
           });
         });
@@ -3460,12 +3437,11 @@ describe("ModelsTreeVisibilityHandler", () => {
               viewport,
               // prettier-ignore
               expectations: {
-                [IModel.rootSubjectId]: "partial",
-                  [ids.modelId]: "partial",
-                    [`${ids.modelId}-${ids.categoryAId}`]: "partial",
-                      [ids.modeledElementId]: "partial",
-                        [`${ids.modeledElementId}-${ids.categoryBId}`]: "visible",
-                          [ids.subModelElementId]: "visible",
+                [ids.modelId]: "partial",
+                  [`${ids.modelId}-${ids.categoryAId}`]: "partial",
+                    [ids.modeledElementId]: "partial",
+                      [`${ids.modeledElementId}-${ids.categoryBId}`]: "visible",
+                        [ids.subModelElementId]: "visible",
               },
             });
           });
@@ -3513,12 +3489,11 @@ describe("ModelsTreeVisibilityHandler", () => {
               viewport,
               // prettier-ignore
               expectations: {
-                [IModel.rootSubjectId]: "partial",
-                  [ids.modelId]: "partial",
-                    [`${ids.modelId}-${ids.categoryAId}`]: "partial",
-                      [ids.modeledElementId]: "partial",
-                        [`${ids.modeledElementId}-${ids.categoryBId}`]: "visible",
-                          [ids.subModelElementId]: "visible",
+                [ids.modelId]: "partial",
+                  [`${ids.modelId}-${ids.categoryAId}`]: "partial",
+                    [ids.modeledElementId]: "partial",
+                      [`${ids.modeledElementId}-${ids.categoryBId}`]: "visible",
+                        [ids.subModelElementId]: "visible",
               },
             });
           });
@@ -3568,12 +3543,11 @@ describe("ModelsTreeVisibilityHandler", () => {
               viewport,
               // prettier-ignore
               expectations: {
-                [IModel.rootSubjectId]: "partial",
-                  [ids.modelId]: "partial",
-                    [`${ids.modelId}-${ids.categoryAId}`]: "partial",
-                      [ids.modeledElementId]: "partial",
-                        [`${ids.modeledElementId}-${ids.categoryBId}`]: "hidden",
-                          [ids.subModelElementId]: "hidden",
+                [ids.modelId]: "partial",
+                  [`${ids.modelId}-${ids.categoryAId}`]: "partial",
+                    [ids.modeledElementId]: "partial",
+                      [`${ids.modeledElementId}-${ids.categoryBId}`]: "hidden",
+                        [ids.subModelElementId]: "hidden",
               },
             });
           });
@@ -3668,15 +3642,14 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                [`${modelId}-${firstCategoryId}`]: "partial",
-                  [elements1[0]]: "hidden",
-                  [elements1[1]]: "visible",
+            [modelId]: "partial",
+              [`${modelId}-${firstCategoryId}`]: "partial",
+                [elements1[0]]: "hidden",
+                [elements1[1]]: "visible",
 
-                [`${modelId}-${secondCategoryId}`]: "hidden",
-                  [elements2[0]]: "hidden",
-                  [elements2[1]]: "hidden",
+              [`${modelId}-${secondCategoryId}`]: "hidden",
+                [elements2[0]]: "hidden",
+                [elements2[1]]: "hidden",
           },
         });
 
@@ -3706,15 +3679,14 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [modelId]: "partial",
-                [`${modelId}-${firstCategoryId}`]: "partial",
-                  [elements1[0]]: "visible",
-                  [elements1[1]]: "hidden",
+            [modelId]: "partial",
+              [`${modelId}-${firstCategoryId}`]: "partial",
+                [elements1[0]]: "visible",
+                [elements1[1]]: "hidden",
 
-                [`${modelId}-${secondCategoryId}`]: "visible",
-                  [elements2[0]]: "visible",
-                  [elements2[1]]: "visible",
+              [`${modelId}-${secondCategoryId}`]: "visible",
+                [elements2[0]]: "visible",
+                [elements2[1]]: "visible",
           },
         });
 
@@ -3800,16 +3772,16 @@ describe("ModelsTreeVisibilityHandler", () => {
             modelCategories.push(configurationCategoryId);
             const elements = new Array<Id64String>();
 
-            for (let childIdx = 0; childIdx < 3; ++childIdx) {
+            for (let childIdx = 0; childIdx < 2; ++childIdx) {
               const props: GeometricElement3dProps = {
                 model: configurationModelId,
                 category: configurationCategoryId,
                 code: new Code({ scope: partitionId, spec: "", value: `Configuration_${customClassName}_${childIdx}` }),
-                classFullName: childIdx !== 2 ? customClassName : "Generic:PhysicalObject",
+                classFullName: customClassName,
               };
               elements.push(txn.insertElement(props));
             }
-            const [customClassElement1, customClassElement2, nonCustomClassElement] = elements;
+            const [customClassElement1, customClassElement2] = elements;
 
             const hierarchyConfig: RequiredModelsTreeHierarchyConfiguration = mergeWithDefaults({
               defaults: defaultHierarchyConfiguration,
@@ -3825,7 +3797,6 @@ describe("ModelsTreeVisibilityHandler", () => {
               elements,
               customClassElement1,
               customClassElement2,
-              nonCustomClassElement,
               modelCategories,
               emptyModelId,
               customClassName,
@@ -3887,7 +3858,6 @@ describe("ModelsTreeVisibilityHandler", () => {
                   [`${ids.configurationModelId}-${ids.configurationCategoryId}`]: "hidden",
                   [ids.customClassElement1]: "hidden",
                   [ids.customClassElement2]: "hidden",
-                  [ids.nonCustomClassElement]: "hidden",
             },
           });
         });
@@ -3914,7 +3884,6 @@ describe("ModelsTreeVisibilityHandler", () => {
                   [`${ids.configurationModelId}-${ids.configurationCategoryId}`]: "visible",
                     [ids.customClassElement1]: "visible",
                     [ids.customClassElement2]: "visible",
-                    [ids.nonCustomClassElement]: "visible",
             },
           });
         });
@@ -3949,7 +3918,6 @@ describe("ModelsTreeVisibilityHandler", () => {
                   [`${ids.configurationModelId}-${ids.configurationCategoryId}`]: "partial",
                     [ids.customClassElement1]: "visible",
                     [ids.customClassElement2]: "hidden",
-                    [ids.nonCustomClassElement]: "hidden",
             },
           });
         });
@@ -3993,7 +3961,6 @@ describe("ModelsTreeVisibilityHandler", () => {
                   [`${ids.configurationModelId}-${ids.configurationCategoryId}`]: "visible",
                     [ids.customClassElement1]: "visible",
                     [ids.customClassElement2]: "visible",
-                    [ids.nonCustomClassElement]: "hidden",
             },
           });
         });
@@ -4029,15 +3996,14 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model1]: "partial",
-                [`${ids.model1}-${ids.category1}`]: "partial",
-                  [ids.element1]: "hidden",
-                  [ids.element2]: "visible",
+            [ids.model1]: "partial",
+              [`${ids.model1}-${ids.category1}`]: "partial",
+                [ids.element1]: "hidden",
+                [ids.element2]: "visible",
 
-              [ids.otherModel]: "hidden",
-                [`${ids.otherModel}-${ids.otherCategory}`]: "hidden",
-                  [ids.otherElement]: "hidden",
+            [ids.otherModel]: "hidden",
+              [`${ids.otherModel}-${ids.otherCategory}`]: "hidden",
+                [ids.otherElement]: "hidden",
           },
         });
         await handler.changeVisibility(createModelHierarchyNode({ modelId: ids.model1 }), true);
@@ -4048,15 +4014,14 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model1]: "visible",
-                [`${ids.model1}-${ids.category1}`]: "visible",
-                  [ids.element1]: "visible",
-                  [ids.element2]: "visible",
+            [ids.model1]: "visible",
+              [`${ids.model1}-${ids.category1}`]: "visible",
+                [ids.element1]: "visible",
+                [ids.element2]: "visible",
 
-              [ids.otherModel]: "hidden",
-                [`${ids.otherModel}-${ids.otherCategory}`]: "hidden",
-                  [ids.otherElement]: "hidden",
+            [ids.otherModel]: "hidden",
+              [`${ids.otherModel}-${ids.otherCategory}`]: "hidden",
+                [ids.otherElement]: "hidden",
           },
         });
       });
@@ -4088,14 +4053,13 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model]: "partial",
-                [`${ids.model}-${ids.category1}`]: "partial",
-                  [ids.element1]: "hidden",
-                  [ids.element2]: "visible",
+            [ids.model]: "partial",
+              [`${ids.model}-${ids.category1}`]: "partial",
+                [ids.element1]: "hidden",
+                [ids.element2]: "visible",
 
-                [`${ids.model}-${ids.otherCategory}`]: "hidden",
-                  [ids.otherElement]: "hidden",
+              [`${ids.model}-${ids.otherCategory}`]: "hidden",
+                [ids.otherElement]: "hidden",
           },
         });
         await handler.changeVisibility(createCategoryHierarchyNode({ modelId: ids.model, categoryId: ids.category1, hasChildren: true }), true);
@@ -4106,14 +4070,13 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model]: "partial",
-                [`${ids.model}-${ids.category1}`]: "visible",
-                  [ids.element1]: "visible",
-                  [ids.element2]: "visible",
+            [ids.model]: "partial",
+              [`${ids.model}-${ids.category1}`]: "visible",
+                [ids.element1]: "visible",
+                [ids.element2]: "visible",
 
-                [`${ids.model}-${ids.otherCategory}`]: "hidden",
-                  [ids.otherElement]: "hidden",
+              [`${ids.model}-${ids.otherCategory}`]: "hidden",
+                [ids.otherElement]: "hidden",
           },
         });
       });
@@ -4151,12 +4114,11 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model]: "partial",
-                [`${ids.model}-${ids.category}`]: "partial",
-                  [ids.element1]: "hidden",
-                  [ids.element2]: "visible",
-                  [ids.elementOfOtherClass]: "hidden",
+            [ids.model]: "partial",
+              [`${ids.model}-${ids.category}`]: "partial",
+                [ids.element1]: "hidden",
+                [ids.element2]: "visible",
+                [ids.elementOfOtherClass]: "hidden",
           },
         });
         await handler.changeVisibility(
@@ -4170,12 +4132,11 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model]: "partial",
-                [`${ids.model}-${ids.category}`]: "partial",
-                  [ids.element1]: "visible",
-                  [ids.element2]: "visible",
-                  [ids.elementOfOtherClass]: "hidden",
+            [ids.model]: "partial",
+              [`${ids.model}-${ids.category}`]: "partial",
+                [ids.element1]: "visible",
+                [ids.element2]: "visible",
+                [ids.elementOfOtherClass]: "hidden",
           },
         });
       });
@@ -4206,12 +4167,11 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model]: "partial",
-                [`${ids.model}-${ids.category}`]: "partial",
-                  [ids.element1]: "hidden",
-                  [ids.element2]: "visible",
-                  [ids.element3]: "hidden",
+            [ids.model]: "partial",
+              [`${ids.model}-${ids.category}`]: "partial",
+                [ids.element1]: "hidden",
+                [ids.element2]: "visible",
+                [ids.element3]: "hidden",
           },
         });
         await handler.changeVisibility(createElementHierarchyNode({ elementId: ids.element1, categoryId: ids.category, modelId: ids.model }), true);
@@ -4222,12 +4182,11 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [ids.model]: "partial",
-                [`${ids.model}-${ids.category}`]: "partial",
-                  [ids.element1]: "visible",
-                  [ids.element2]: "visible",
-                  [ids.element3]: "hidden",
+            [ids.model]: "partial",
+              [`${ids.model}-${ids.category}`]: "partial",
+                [ids.element1]: "visible",
+                [ids.element2]: "visible",
+                [ids.element3]: "hidden",
           },
         });
       });
@@ -4315,12 +4274,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.category.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [keys.searchTargetChildElement.id]: "visible",
-                      [keys.childElement.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.category.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [keys.searchTargetChildElement.id]: "visible",
+                    [keys.childElement.id]: "hidden",
             },
           });
         });
@@ -4376,12 +4334,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.category.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [keys.searchTargetChildElement.id]: "visible",
-                      [keys.childElement.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.category.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [keys.searchTargetChildElement.id]: "visible",
+                    [keys.childElement.id]: "hidden",
             },
           });
         });
@@ -4437,12 +4394,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.category.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [keys.searchTargetChildElement.id]: "visible",
-                      [keys.childElement.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.category.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [keys.searchTargetChildElement.id]: "visible",
+                    [keys.childElement.id]: "hidden",
             },
           });
         });
@@ -4503,12 +4459,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.category.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [keys.searchTargetChildElement.id]: "hidden",
-                      [keys.childElement.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.category.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [keys.searchTargetChildElement.id]: "hidden",
+                    [keys.childElement.id]: "visible",
             },
           });
         });
@@ -4571,12 +4526,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.category.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [keys.searchTargetChildElement.id]: "hidden",
-                      [keys.childElement.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.category.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [keys.searchTargetChildElement.id]: "hidden",
+                    [keys.childElement.id]: "visible",
             },
           });
         });
@@ -4635,12 +4589,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.category.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [keys.searchTargetChildElement.id]: "hidden",
-                      [keys.childElement.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.category.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [keys.searchTargetChildElement.id]: "hidden",
+                    [keys.childElement.id]: "visible",
             },
           });
         });
@@ -4692,14 +4645,13 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "visible",
-                  [`${keys.model.id}-${keys.category.id}`]: "visible",
-                    [keys.searchTargetElement.id]: "visible",
+              [keys.model.id]: "visible",
+                [`${keys.model.id}-${keys.category.id}`]: "visible",
+                  [keys.searchTargetElement.id]: "visible",
 
-                [keys.otherModel.id]: "hidden",
-                  [`${keys.otherModel.id}-${keys.otherCategory.id}`]: "hidden",
-                    [keys.otherElement.id]: "hidden",
+              [keys.otherModel.id]: "hidden",
+                [`${keys.otherModel.id}-${keys.otherCategory.id}`]: "hidden",
+                  [keys.otherElement.id]: "hidden",
             },
           });
         });
@@ -4772,23 +4724,22 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[0].id}`]: "partial",
-                    [keys.searchTargetElements[0]]: "visible",
-                    [keys.nonSearchTargetElements[0]]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[0].id}`]: "partial",
+                  [keys.searchTargetElements[0]]: "visible",
+                  [keys.nonSearchTargetElements[0]]: "hidden",
 
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[1].id}`]: "partial",
-                    [keys.searchTargetElements[1]]: "visible",
-                    [keys.nonSearchTargetElements[1]]: "hidden",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[1].id}`]: "partial",
+                  [keys.searchTargetElements[1]]: "visible",
+                  [keys.nonSearchTargetElements[1]]: "hidden",
 
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[2].id}`]: "partial",
-                    [keys.searchTargetElements[2]]: "visible",
-                    [keys.nonSearchTargetElements[2]]: "hidden",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[2].id}`]: "partial",
+                  [keys.searchTargetElements[2]]: "visible",
+                  [keys.nonSearchTargetElements[2]]: "hidden",
 
-                [keys.otherModel.id]: "hidden",
-                  [`${keys.otherModel.id}-${keys.otherCategory.id}`]: "hidden",
-                    [keys.otherElement.id]: "hidden",
+              [keys.otherModel.id]: "hidden",
+                [`${keys.otherModel.id}-${keys.otherCategory.id}`]: "hidden",
+                  [keys.otherElement.id]: "hidden",
             },
           });
         });
@@ -4813,16 +4764,15 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[0].id}`]: "visible",
-                    [keys.searchTargetElements[0]]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[0].id}`]: "visible",
+                  [keys.searchTargetElements[0]]: "visible",
 
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[1].id}`]: "hidden",
-                    [keys.searchTargetElements[1]]: "hidden",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[1].id}`]: "hidden",
+                  [keys.searchTargetElements[1]]: "hidden",
 
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[2].id}`]: "hidden",
-                    [keys.searchTargetElements[2]]: "hidden",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[2].id}`]: "hidden",
+                  [keys.searchTargetElements[2]]: "hidden",
             },
           });
 
@@ -4832,23 +4782,22 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[0].id}`]: "partial",
-                    [keys.searchTargetElements[0]]: "visible",
-                    [keys.nonSearchTargetElements[0]]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[0].id}`]: "partial",
+                  [keys.searchTargetElements[0]]: "visible",
+                  [keys.nonSearchTargetElements[0]]: "hidden",
 
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[1].id}`]: "hidden",
-                    [keys.searchTargetElements[1]]: "hidden",
-                    [keys.nonSearchTargetElements[1]]: "hidden",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[1].id}`]: "hidden",
+                  [keys.searchTargetElements[1]]: "hidden",
+                  [keys.nonSearchTargetElements[1]]: "hidden",
 
-                  [`${keys.model.id}-${keys.categoriesOfSearchTargets[2].id}`]: "hidden",
-                    [keys.searchTargetElements[2]]: "hidden",
-                    [keys.nonSearchTargetElements[2]]: "hidden",
+                [`${keys.model.id}-${keys.categoriesOfSearchTargets[2].id}`]: "hidden",
+                  [keys.searchTargetElements[2]]: "hidden",
+                  [keys.nonSearchTargetElements[2]]: "hidden",
 
-                [keys.otherModel.id]: "hidden",
-                  [`${keys.otherModel.id}-${keys.otherCategory.id}`]: "hidden",
-                    [keys.otherElement.id]: "hidden",
+              [keys.otherModel.id]: "hidden",
+                [`${keys.otherModel.id}-${keys.otherCategory.id}`]: "hidden",
+                  [keys.otherElement.id]: "hidden",
             },
           });
         });
@@ -4940,19 +4889,18 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.parentSubject.id]: "partial",
-                  [keys.subjectIds[0]]: "visible",
-                    [keys.modelIds[0]]: "visible",
-                      [`${keys.modelIds[0]}-${keys.categoryIds[0]}`]: "visible",
-                        [keys.elementsOfModels[0][0]]: "visible",
-                        [keys.elementsOfModels[0][1]]: "visible",
+              [keys.parentSubject.id]: "partial",
+                [keys.subjectIds[0]]: "visible",
+                  [keys.modelIds[0]]: "visible",
+                    [`${keys.modelIds[0]}-${keys.categoryIds[0]}`]: "visible",
+                      [keys.elementsOfModels[0][0]]: "visible",
+                      [keys.elementsOfModels[0][1]]: "visible",
 
-                [keys.subjectIds[1]]: "hidden",
-                  [keys.modelIds[1]]: "hidden",
-                    [`${keys.modelIds[1]}-${keys.categoryIds[1]}`]: "hidden",
-                      [keys.elementsOfModels[1][0]]: "hidden",
-                      [keys.elementsOfModels[1][1]]: "hidden",
+              [keys.subjectIds[1]]: "hidden",
+                [keys.modelIds[1]]: "hidden",
+                  [`${keys.modelIds[1]}-${keys.categoryIds[1]}`]: "hidden",
+                    [keys.elementsOfModels[1][0]]: "hidden",
+                    [keys.elementsOfModels[1][1]]: "hidden",
             },
           });
 
@@ -4962,19 +4910,18 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.parentSubject.id]: "partial",
-                  [keys.subjectIds[0]]: "visible",
-                    [keys.modelIds[0]]: "visible",
-                      [`${keys.modelIds[0]}-${keys.categoryIds[0]}`]: "visible",
-                        [keys.elementsOfModels[0][0]]: "visible",
-                        [keys.elementsOfModels[0][1]]: "visible",
+              [keys.parentSubject.id]: "partial",
+                [keys.subjectIds[0]]: "visible",
+                  [keys.modelIds[0]]: "visible",
+                    [`${keys.modelIds[0]}-${keys.categoryIds[0]}`]: "visible",
+                      [keys.elementsOfModels[0][0]]: "visible",
+                      [keys.elementsOfModels[0][1]]: "visible",
 
-                [keys.subjectIds[1]]: "hidden",
-                  [keys.modelIds[1]]: "hidden",
-                    [`${keys.modelIds[1]}-${keys.categoryIds[1]}`]: "hidden",
-                      [keys.elementsOfModels[1][0]]: "hidden",
-                      [keys.elementsOfModels[1][1]]: "hidden",
+              [keys.subjectIds[1]]: "hidden",
+                [keys.modelIds[1]]: "hidden",
+                  [`${keys.modelIds[1]}-${keys.categoryIds[1]}`]: "hidden",
+                    [keys.elementsOfModels[1][0]]: "hidden",
+                    [keys.elementsOfModels[1][1]]: "hidden",
             },
           });
         });
@@ -5047,11 +4994,10 @@ describe("ModelsTreeVisibilityHandler", () => {
           viewport,
           // prettier-ignore
           expectations: {
-            [IModel.rootSubjectId]: "partial",
-              [keys.model]: "partial",
-                [`${keys.model}-${keys.category}`]: "partial",
-                  [keys.firstElement]: "visible",
-                  [keys.element2]: "hidden",
+            [keys.model]: "partial",
+              [`${keys.model}-${keys.category}`]: "partial",
+                [keys.firstElement]: "visible",
+                [keys.element2]: "hidden",
           },
         });
       });
@@ -5141,12 +5087,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
-                        [keys.childElement1.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
+                      [keys.childElement1.id]: "visible",
             },
           });
 
@@ -5156,13 +5101,12 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "partial",
-                        [keys.childElement1.id]: "visible",
-                        [keys.childElement2.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "partial",
+                      [keys.childElement1.id]: "visible",
+                      [keys.childElement2.id]: "hidden",
             },
           });
         });
@@ -5189,12 +5133,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
-                        [keys.childElement1.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
+                      [keys.childElement1.id]: "visible",
             },
           });
 
@@ -5204,13 +5147,12 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "partial",
-                        [keys.childElement1.id]: "visible",
-                        [keys.childElement2.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "partial",
+                      [keys.childElement1.id]: "visible",
+                      [keys.childElement2.id]: "hidden",
             },
           });
         });
@@ -5247,13 +5189,12 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.parentElement.id]: "partial",
-                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "partial",
-                        [keys.childElement1.id]: "visible",
-                        [keys.childElement2.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.parentElement.id]: "partial",
+                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "partial",
+                      [keys.childElement1.id]: "visible",
+                      [keys.childElement2.id]: "hidden",
             },
           });
         });
@@ -5355,12 +5296,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.modeledElement.id]: "partial",
-                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
-                        [keys.subModelElement1.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.modeledElement.id]: "partial",
+                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
+                      [keys.subModelElement1.id]: "visible",
             },
           });
 
@@ -5370,13 +5310,12 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.modeledElement.id]: "partial",
-                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "partial",
-                        [keys.subModelElement1.id]: "visible",
-                        [keys.subModelElement2.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.modeledElement.id]: "partial",
+                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "partial",
+                      [keys.subModelElement1.id]: "visible",
+                      [keys.subModelElement2.id]: "hidden",
             },
           });
         });
@@ -5402,12 +5341,11 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.modeledElement.id]: "partial",
-                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
-                        [keys.subModelElement1.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.modeledElement.id]: "partial",
+                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
+                      [keys.subModelElement1.id]: "visible",
             },
           });
 
@@ -5417,13 +5355,12 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.modeledElement.id]: "partial",
-                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "partial",
-                        [keys.subModelElement1.id]: "visible",
-                        [keys.subModelElement2.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.modeledElement.id]: "partial",
+                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "partial",
+                      [keys.subModelElement1.id]: "visible",
+                      [keys.subModelElement2.id]: "hidden",
             },
           });
         });
@@ -5462,13 +5399,12 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.modeledElement.id]: "partial",
-                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "partial",
-                        [keys.subModelElement1.id]: "visible",
-                        [keys.subModelElement2.id]: "hidden",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.modeledElement.id]: "partial",
+                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "partial",
+                      [keys.subModelElement1.id]: "visible",
+                      [keys.subModelElement2.id]: "hidden",
             },
           });
         });
@@ -5565,11 +5501,10 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.modeledElement.id]: "partial",
-                      [keys.modelingElement.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.modeledElement.id]: "partial",
+                    [keys.modelingElement.id]: "visible",
             },
           });
 
@@ -5579,11 +5514,10 @@ describe("ModelsTreeVisibilityHandler", () => {
             viewport,
             // prettier-ignore
             expectations: {
-              [IModel.rootSubjectId]: "partial",
-                [keys.model.id]: "partial",
-                  [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
-                    [keys.modeledElement.id]: "partial",
-                      [keys.modelingElement.id]: "visible",
+              [keys.model.id]: "partial",
+                [`${keys.model.id}-${keys.categoryA.id}`]: "partial",
+                  [keys.modeledElement.id]: "partial",
+                    [keys.modelingElement.id]: "visible",
             },
           });
         });

--- a/packages/tree-widget/src/test/trees/models-tree/internal/VisibilityValidation.ts
+++ b/packages/tree-widget/src/test/trees/models-tree/internal/VisibilityValidation.ts
@@ -10,7 +10,12 @@ import { ModelsTreeNode } from "../../../../tree-widget-react/components/trees/m
 import type { HierarchyNode } from "@itwin/presentation-hierarchies";
 import type { ValidateNodeProps } from "../../common/VisibilityValidation.js";
 
-export async function validateNodeVisibility({ node, handler, expectations }: ValidateNodeProps & { node: HierarchyNode }) {
+export async function validateNodeVisibility({
+  node,
+  handler,
+  expectations,
+  validatedIds,
+}: ValidateNodeProps & { node: HierarchyNode; validatedIds: Set<string> }) {
   const actualVisibility = await handler.getVisibilityStatus(node);
 
   if (expectations === "all-hidden" || expectations === "all-visible") {
@@ -24,6 +29,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
     let hiddenCount = 0;
 
     for (const elementId of elementIds) {
+      validatedIds.add(elementId);
       if (expectations[elementId] === "visible") {
         ++visibleCount;
       } else if (expectations[elementId] === "hidden") {
@@ -46,6 +52,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
 
   if (ModelsTreeNode.isSubjectNode(node) || ModelsTreeNode.isElementNode(node) || ModelsTreeNode.isModelNode(node)) {
     const { id } = node.key.instanceKeys[0];
+    validatedIds.add(id);
     if (expectations[id] === "disabled") {
       expect(actualVisibility.isDisabled, `Node, ${JSON.stringify(node)}`).toBe(true);
     } else {
@@ -61,6 +68,7 @@ export async function validateNodeVisibility({ node, handler, expectations }: Va
         ? node.extendedData.parentElementsPath[node.extendedData.parentElementsPath.length - 1].elementIds[0]
         : node.extendedData.modelIds[0];
     const idToUse = `${parentOrModelId}-${id}`;
+    validatedIds.add(idToUse);
     if (expectations[idToUse] === "disabled") {
       expect(actualVisibility.isDisabled, `Node, ${JSON.stringify(node)}`).toBe(true);
     } else {


### PR DESCRIPTION
Made visibility tests use only ids which are present in trees nodes: some tests provided default sub-category id when it was not shown in the categories tree, and some tests provided root subject id when root subject was not shown in the models tree.