### PR TITLE
[Tree widget]: adjust categories tree tests on `next`

### DIFF
--- a/packages/tree-widget/src/test/IModelUtils.ts
+++ b/packages/tree-widget/src/test/IModelUtils.ts
@@ -11,7 +11,7 @@ import type { ImportSchemaResult } from "test-utilities";
 import type { IModelDb } from "@itwin/core-backend";
 import type { IModelConnection } from "@itwin/core-frontend";
 
-function getTestName(): string {
+function getUniqueIModelName(): string {
   const testName = expect.getState().currentTestName?.replace(/[^\w]/gi, "-").replace(/-+/g, "-").toLowerCase() ?? "unknown";
   // `currentTestName` is the same for every `buildIModel` call made within a single test (or `undefined`/"unknown" when called
   // outside of a test, e.g. in `beforeAll`), and can also collide across different test files running in parallel. Appending a
@@ -33,7 +33,7 @@ export async function buildIModel<TResult extends object>(
   setup: (imodel: IModelDb, testSchema: TestSchemaDefinition) => Promise<TResult>,
 ): Promise<{ imodelConnection: IModelConnection } & TResult & AsyncDisposable>;
 export async function buildIModel<TResult extends object | undefined>(setup?: (imodel: IModelDb, testSchema: TestSchemaDefinition) => Promise<TResult>) {
-  const testName = getTestName();
+  const testName = getUniqueIModelName();
   const res = await buildNamedIModel(testName, async (imodel) => {
     const testSchema = (await importSchema({
       imodel,

--- a/packages/tree-widget/src/test/IModelUtils.ts
+++ b/packages/tree-widget/src/test/IModelUtils.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
+import { randomUUID } from "node:crypto";
 import { buildIModel as buildNamedIModel, importSchema } from "test-utilities";
 import { expect } from "vitest";
 
@@ -11,7 +12,11 @@ import type { IModelDb } from "@itwin/core-backend";
 import type { IModelConnection } from "@itwin/core-frontend";
 
 function getTestName(): string {
-  return expect.getState().currentTestName?.replace(/[^\w]/gi, "-").replace(/-+/g, "-").toLowerCase() ?? "unknown";
+  const testName = expect.getState().currentTestName?.replace(/[^\w]/gi, "-").replace(/-+/g, "-").toLowerCase() ?? "unknown";
+  // `currentTestName` is the same for every `buildIModel` call made within a single test (or `undefined`/"unknown" when called
+  // outside of a test, e.g. in `beforeAll`), and can also collide across different test files running in parallel. Appending a
+  // random suffix avoids different imodels colliding on the same backing file, which would corrupt already open connections.
+  return `${testName}-${randomUUID()}`;
 }
 
 export namespace TestSchema {

--- a/packages/tree-widget/src/test/trees/Common.ts
+++ b/packages/tree-widget/src/test/trees/Common.ts
@@ -105,7 +105,7 @@ export function createFakeViewport(
   return result;
 }
 
-type IModelAccess = ECSchemaProvider &
+export type IModelAccess = ECSchemaProvider &
   LimitingECSqlQueryExecutor &
   ECClassHierarchyInspector & {
     imodelKey: string;

--- a/packages/tree-widget/src/test/trees/TreeUtils.ts
+++ b/packages/tree-widget/src/test/trees/TreeUtils.ts
@@ -12,8 +12,6 @@ import type { TreeNode } from "@itwin/presentation-hierarchies-react";
 import type { CategoryId, ElementId, ModelId, SubCategoryId } from "../../tree-widget-react/shared/internal/Types.js";
 import type { TreeWidgetViewport } from "../../tree-widget-react/shared/TreeWidgetViewport.js";
 
-export const CLASS_NAME_DefinitionModel = "BisCore.DefinitionModel";
-
 export function createTreeNode(partial?: Partial<TreeNode>): TreeNode {
   return {
     id: "test-node",

--- a/packages/tree-widget/src/test/trees/categories-tree/CategoriesTreeDefinition.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/CategoriesTreeDefinition.test.ts
@@ -3,20 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  HierarchyCacheMode,
-  initializeCore,
-  insertDefinitionContainer,
-  insertDrawingCategory,
-  insertDrawingGraphic,
-  insertDrawingModelWithPartition,
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertSpatialCategory,
-  insertSubCategory,
-  insertSubModel,
-  terminateCore,
-} from "test-utilities";
+import { HierarchyCacheMode, initializeCore, insertDefinitionContainer, insertSubCategory, insertSubModel, terminateCore } from "test-utilities";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { withEditTxn } from "@itwin/core-backend";
 import { IModel, IModelReadRpcInterface } from "@itwin/core-common";
@@ -25,13 +12,13 @@ import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
 import { BaseIdsCache } from "../../../tree-widget-react/shared/internal/caches/BaseIdsCache.js";
+import { CLASS_NAME_DefinitionModel } from "../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
 import { getClassesByView, mergeWithDefaults } from "../../../tree-widget-react/shared/internal/Utils.js";
 import { CategoriesTreeDefinition, defaultHierarchyConfiguration } from "../../../tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.js";
 import { CategoriesTreeIdsCache } from "../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 import { buildIModel, TestSchema } from "../../IModelUtils.js";
 import { createIModelAccess } from "../Common.js";
 import { NodeValidators, validateHierarchy } from "../HierarchyValidation.js";
-import { CLASS_NAME_DefinitionModel } from "../TreeUtils.js";
 import { getInsertFunctionByViewType } from "./internal/Utils.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -61,299 +48,359 @@ describe("Categories tree", () => {
       await terminateCore();
     });
 
-    it("does not show private 3d categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
+    ["2d" as const, "3d" as const].forEach((viewType) => {
+      describe(`${viewType} view`, () => {
+        const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
+        it("does not show private categories", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
 
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
+              const category = insertCategory({ txn, codeValue: "cat" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
 
-          const privateCategory = insertSpatialCategory({ txn, codeValue: "Private Test SpatialCategory", isPrivate: true });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: privateCategory.id });
+              const privateCategory = insertCategory({ txn, codeValue: "private cat", isPrivate: true });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: privateCategory.id });
 
-          return { category, privateCategory };
-        }),
-      );
+              return { category, privateCategory };
+            }),
+          );
 
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
 
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: false,
-          }),
-        ],
-      });
-    });
-
-    it("does not show definition container when it doesn't contain category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { category };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: false,
-          }),
-        ],
-      });
-    });
-
-    it("does not show definition container when it contains definition container without categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModel.id });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-        }),
-      );
-
-      const { imodelConnection } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [],
-      });
-    });
-
-    it("does not show definition container or category when category is private", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id, isPrivate: true });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-        }),
-      );
-
-      const { imodelConnection } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [],
-      });
-    });
-
-    it("does not show definition container or category when category does not have elements", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModel.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: false,
-          }),
-        ],
-      });
-    });
-
-    it("shows definition container and category when category does not have elements and categories.withoutElements is set to 'include'", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-
-          const emptyCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModel.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category, emptyCategory, definitionContainer };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d", { categories: { withoutElements: "include" } });
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.definitionContainer],
-            supportsFiltering: true,
-            children: [
+          await validateHierarchy({
+            provider,
+            expect: [
               NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.emptyCategory],
+                instanceKeys: [keys.category],
+                supportsFiltering: true,
                 children: false,
               }),
             ],
-          }),
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: false,
-          }),
-        ],
-      });
-    });
-
-    it("does not show definition container or category when definition container is private", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer", isPrivate: true });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-        }),
-      );
-
-      const { imodelConnection } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [],
-      });
-    });
-
-    it("does not show definition containers or categories when definition container contains another definition container that is private", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const definitionContainerChild = insertDefinitionContainer({
-            txn,
-            codeValue: "DefinitionContainerChild",
-            isPrivate: true,
-            modelId: definitionModel.id,
           });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
+        });
 
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
+        it("does not show definition container when it doesn't contain category", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
 
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-        }),
-      );
+              const category = insertCategory({ txn, codeValue: "cat" });
 
-      const { imodelConnection } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
 
-      await validateHierarchy({
-        provider,
-        expect: [],
-      });
-    });
+              return { category };
+            }),
+          );
 
-    it("shows definition container when it contains category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
 
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { definitionContainer, category };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.definitionContainer],
-            supportsFiltering: true,
-            children: [
+          await validateHierarchy({
+            provider,
+            expect: [
               NodeValidators.createForInstanceNode({
                 instanceKeys: [keys.category],
-                label: "SpatialCategory",
+                supportsFiltering: true,
                 children: false,
               }),
             ],
-          }),
-        ],
-      });
-    });
+          });
+        });
 
-    it("shows element when 'elements' is set to 'include'", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+        it("does not show definition container when it contains definition container without categories", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "child dc", modelId: definitionModel.id });
+              insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
+            }),
+          );
 
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
+          const { imodelConnection } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
 
-          const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
+          await validateHierarchy({
+            provider,
+            expect: [],
+          });
+        });
 
-          return { definitionContainer, category, element };
-        }),
-      );
+        it("does not show definition container or category when category is private", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
 
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d", { elements: { nodes: "include" } });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id, isPrivate: true });
 
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.definitionContainer],
-            supportsFiltering: true,
-            children: [
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            }),
+          );
+
+          const { imodelConnection } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [],
+          });
+        });
+
+        it("does not show definition container or category when category does not have elements", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+              insertCategory({ txn, codeValue: "cat1", modelId: definitionModel.id });
+              const category = insertCategory({ txn, codeValue: "cat" });
+
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+              return { category };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [
               NodeValidators.createForInstanceNode({
                 instanceKeys: [keys.category],
-                label: "SpatialCategory",
+                supportsFiltering: true,
+                children: false,
+              }),
+            ],
+          });
+        });
+
+        it("shows definition container and category when category does not have elements and categories.withoutElements is set to 'include'", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+              const emptyCategory = insertCategory({ txn, codeValue: "cat1", modelId: definitionModel.id });
+              const category = insertCategory({ txn, codeValue: "cat" });
+
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+              return { category, emptyCategory, definitionContainer };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType, { categories: { withoutElements: "include" } });
+
+          await validateHierarchy({
+            provider,
+            expect: [
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.category],
+                supportsFiltering: true,
+                children: false,
+              }),
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.definitionContainer],
+                supportsFiltering: true,
                 children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.element.className,
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.emptyCategory],
+                    children: false,
+                  }),
+                ],
+              }),
+            ],
+          });
+        });
+
+        it("does not show definition container or category when definition container is private", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc", isPrivate: true });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            }),
+          );
+
+          const { imodelConnection } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [],
+          });
+        });
+
+        it("does not show definition containers or categories when definition container contains another definition container that is private", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const definitionContainerChild = insertDefinitionContainer({
+                txn,
+                codeValue: "child dc",
+                isPrivate: true,
+                modelId: definitionModel.id,
+              });
+              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
+
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModelChild.id });
+
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            }),
+          );
+
+          const { imodelConnection } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [],
+          });
+        });
+
+        it("shows definition container when it contains category", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { definitionContainer, category };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.definitionContainer],
+                supportsFiltering: true,
+                children: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    label: "cat",
+                    children: false,
+                  }),
+                ],
+              }),
+            ],
+          });
+        });
+
+        it("shows element when 'elements' is set to 'include'", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+
+              const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { definitionContainer, category, element };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
+
+          await validateHierarchy({
+            provider,
+            expect: [
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.definitionContainer],
+                supportsFiltering: true,
+                children: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    label: "cat",
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.element.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.element],
+                            children: false,
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          });
+        });
+
+        it("shows element and subCategories when elements is set to 'include'", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+
+              const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+              const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
+
+              return { definitionContainer, category, element, subCategory };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
+
+          await validateHierarchy({
+            provider,
+            expect: [
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.definitionContainer],
+                supportsFiltering: true,
+                children: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    label: "cat",
                     children: [
                       NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.element],
+                        label: "cat",
+                        children: false,
+                      }),
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.element.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.element],
+                            children: false,
+                          }),
+                        ],
+                      }),
+                      NodeValidators.createForInstanceNode({
+                        instanceKeys: [keys.subCategory],
                         children: false,
                       }),
                     ],
@@ -361,52 +408,170 @@ describe("Categories tree", () => {
                 ],
               }),
             ],
-          }),
-        ],
-      });
-    });
+          });
+        });
 
-    it("shows element and subCategories when elements is set to 'include'", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+        it("shows element and hides subCategories when elements is set to 'include' and subCategories is set to 'exclude'", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
 
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
 
-          const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test SpatialSubCategory", modelId: definitionModel.id });
+              const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+              const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
 
-          return { definitionContainer, category, element, subCategory };
-        }),
-      );
+              return { definitionContainer, category, element, subCategory };
+            }),
+          );
 
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d", { elements: { nodes: "include" } });
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" }, subCategories: { nodes: "exclude" } });
 
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.definitionContainer],
-            supportsFiltering: true,
-            children: [
+          await validateHierarchy({
+            provider,
+            expect: [
               NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.category],
-                label: "SpatialCategory",
+                instanceKeys: [keys.definitionContainer],
+                supportsFiltering: true,
                 children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.element.className,
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    label: "cat",
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.element.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.element],
+                            children: false,
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          });
+        });
+
+        it("shows all definition containers when they contain category directly or indirectly", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "child dc", modelId: definitionModel.id });
+              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
+
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModelChild.id });
+
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { definitionContainer, definitionContainerChild, category };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.definitionContainer],
+                supportsFiltering: true,
+                children: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.definitionContainerChild],
+                    label: "child dc",
                     children: [
                       NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.element],
+                        instanceKeys: [keys.category],
+                        label: "cat",
                         children: false,
                       }),
                     ],
                   }),
+                ],
+              }),
+            ],
+          });
+        });
+
+        it("shows root categories and definition container", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+              const category = insertCategory({ txn, codeValue: "cat" });
+              const childCategory = insertCategory({ txn, codeValue: "ScChild", modelId: definitionModel.id });
+
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: childCategory.id });
+
+              return { category, definitionContainer, childCategory };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.category],
+                supportsFiltering: true,
+                children: false,
+              }),
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.definitionContainer],
+                supportsFiltering: true,
+                children: [
                   NodeValidators.createForInstanceNode({
-                    label: "SpatialCategory",
+                    instanceKeys: [keys.childCategory],
+                    label: "ScChild",
+                    children: false,
+                  }),
+                ],
+              }),
+            ],
+          });
+        });
+
+        it("does not show private subCategories", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+              const category = insertCategory({ txn, codeValue: "cat" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat" });
+              const privateSubCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "private subCat", isPrivate: true });
+
+              return { category, subCategory, privateSubCategory };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          using provider = createCategoryTreeProvider(imodelConnection, viewType);
+
+          await validateHierarchy({
+            provider,
+            expect: [
+              NodeValidators.createForInstanceNode({
+                instanceKeys: [keys.category],
+                supportsFiltering: true,
+                children: [
+                  NodeValidators.createForInstanceNode({
+                    label: "cat",
                     children: false,
                   }),
                   NodeValidators.createForInstanceNode({
@@ -416,808 +581,29 @@ describe("Categories tree", () => {
                 ],
               }),
             ],
-          }),
-        ],
-      });
-    });
-
-    it("shows element and hides subCategories when elements is set to 'include' and subCategories is set to 'exclude'", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-
-          const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test SpatialSubCategory", modelId: definitionModel.id });
-
-          return { definitionContainer, category, element, subCategory };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d", { elements: { nodes: "include" }, subCategories: { nodes: "exclude" } });
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.definitionContainer],
-            supportsFiltering: true,
-            children: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.category],
-                label: "SpatialCategory",
-                children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.element.className,
-                    children: [
-                      NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.element],
-                        children: false,
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-            ],
-          }),
-        ],
-      });
-    });
-
-    it("shows all definition containers when they contain category directly or indirectly", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModel.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { definitionContainer, definitionContainerChild, category };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.definitionContainer],
-            supportsFiltering: true,
-            children: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.definitionContainerChild],
-                label: "DefinitionContainerChild",
-                children: [
-                  NodeValidators.createForInstanceNode({
-                    instanceKeys: [keys.category],
-                    label: "SpatialCategory",
-                    children: false,
-                  }),
-                ],
-              }),
-            ],
-          }),
-        ],
-      });
-    });
-
-    it("shows root categories and definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-          const childCategory = insertSpatialCategory({ txn, codeValue: "ScChild", modelId: definitionModel.id });
-
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: childCategory.id });
-
-          return { category, definitionContainer, childCategory };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.definitionContainer],
-            supportsFiltering: true,
-            children: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.childCategory],
-                label: "ScChild",
-                children: false,
-              }),
-            ],
-          }),
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: false,
-          }),
-        ],
-      });
-    });
-
-    it("does not show private 3d subCategories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test SpatialSubCategory" });
-          const privateSubCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Private Test SpatialSubCategory", isPrivate: true });
-
-          return { category, subCategory, privateSubCategory };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "3d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: [
-              NodeValidators.createForInstanceNode({
-                label: "Test SpatialCategory",
-                children: false,
-              }),
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.subCategory],
-                children: false,
-              }),
-            ],
-          }),
-        ],
-      });
-    });
-
-    it("does not show private 2d categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const drawingModel = insertDrawingModelWithPartition({ txn, codeValue: "TestDrawingModel" });
-
-          const category = insertDrawingCategory({ txn, codeValue: "Test Drawing Category" });
-          insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: category.id });
-
-          const privateCategory = insertDrawingCategory({ txn, codeValue: "Private Test DrawingCategory", isPrivate: true });
-          insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: privateCategory.id });
-
-          return { category, privateCategory };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "2d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: false,
-          }),
-        ],
-      });
-    });
-
-    it("does not show private 2d subCategories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const drawingModel = insertDrawingModelWithPartition({ txn, codeValue: "TestDrawingModel" });
-
-          const category = insertDrawingCategory({ txn, codeValue: "Test Drawing Category" });
-          insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: category.id });
-
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test DrawingSubCategory" });
-          const privateSubCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Private Test DrawingSubCategory", isPrivate: true });
-
-          return { category, subCategory, privateSubCategory };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using provider = createCategoryTreeProvider(imodelConnection, "2d");
-
-      await validateHierarchy({
-        provider,
-        expect: [
-          NodeValidators.createForInstanceNode({
-            instanceKeys: [keys.category],
-            supportsFiltering: true,
-            children: [
-              NodeValidators.createForInstanceNode({
-                label: "Test Drawing Category",
-                children: false,
-              }),
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.subCategory],
-                children: false,
-              }),
-            ],
-          }),
-        ],
-      });
-    });
-
-    ["3d" as const, "2d" as const].forEach((viewType) => {
-      const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
-      describe(`Intermediate ${viewType} categories`, () => {
-        it("does not show intermediate category when child element has same category as parent", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const elementsModel = insertElementsModel({ txn, codeValue: "Elements Model" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              const parentElement = insertElement({ txn, userLabel: "parent element", modelId: elementsModel.id, categoryId: category.id });
-              const childElement = insertElement({
-                txn,
-                userLabel: "child element",
-                modelId: elementsModel.id,
-                categoryId: category.id,
-                parentId: parentElement.id,
-              });
-              return { category, parentElement, childElement };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
-
-          await validateHierarchy({
-            provider,
-            expect: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.category],
-                children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.parentElement.className,
-                    children: [
-                      NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.parentElement],
-                        children: [
-                          NodeValidators.createForClassGroupingNode({
-                            className: keys.childElement.className,
-                            children: [
-                              NodeValidators.createForInstanceNode({
-                                instanceKeys: [keys.childElement],
-                                children: false,
-                              }),
-                            ],
-                          }),
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-            ],
           });
         });
 
-        it("shows intermediate category when child element has different category than parent", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const elementsModel = insertElementsModel({ txn, codeValue: "Elements Model" });
-              const categoryA = insertCategory({ txn, codeValue: "category A" });
-              const categoryB = insertCategory({ txn, codeValue: "category B" });
-              const parentElement = insertElement({ txn, userLabel: "parent element", modelId: elementsModel.id, categoryId: categoryA.id });
-              const childElement = insertElement({
-                txn,
-                userLabel: "child element",
-                modelId: elementsModel.id,
-                categoryId: categoryB.id,
-                parentId: parentElement.id,
-              });
-              return { categoryA, categoryB, parentElement, childElement };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
-
-          await validateHierarchy({
-            provider,
-            expect: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.categoryA],
-                children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.parentElement.className,
-                    children: [
-                      NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.parentElement],
-                        children: [
-                          NodeValidators.createForInstanceNode({
-                            instanceKeys: [keys.categoryB],
-                            children: [
-                              NodeValidators.createForClassGroupingNode({
-                                className: keys.childElement.className,
-                                children: [
-                                  NodeValidators.createForInstanceNode({
-                                    instanceKeys: [keys.childElement],
-                                    children: false,
-                                  }),
-                                ],
-                              }),
-                            ],
-                          }),
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.categoryB],
-                children: false,
-              }),
-            ],
-          });
-        });
-
-        it("does not show intermediate category when modeling element has the same category as modeled element", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const elementsModel = insertElementsModel({ txn, codeValue: "Elements Model" });
-              const categoryA = insertCategory({ txn, codeValue: "category A" });
-              const modeledElement = insertModeledElement({
-                txn,
-                modelId: elementsModel.id,
-                categoryId: categoryA.id,
-              });
-              const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-              const modelingElement = insertElement({
-                txn,
-                modelId: subModel.id,
-                categoryId: categoryA.id,
-              });
-              return { categoryA, modeledElement, modelingElement };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
-
-          await validateHierarchy({
-            provider,
-            expect: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.categoryA],
-                children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.modeledElement.className,
-                    children: [
-                      NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.modeledElement],
-                        children: [
-                          NodeValidators.createForClassGroupingNode({
-                            className: keys.modelingElement.className,
-                            children: [
-                              NodeValidators.createForInstanceNode({
-                                instanceKeys: [keys.modelingElement],
-                                children: false,
-                              }),
-                            ],
-                          }),
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-            ],
-          });
-        });
-
-        it("shows intermediate category when modeling element has different category than modeled element", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const elementsModel = insertElementsModel({ txn, codeValue: "Elements Model" });
-              const categoryA = insertCategory({ txn, codeValue: "category A" });
-              const categoryB = insertCategory({ txn, codeValue: "category B" });
-              const modeledElement = insertModeledElement({
-                txn,
-                userLabel: "modeled element",
-                modelId: elementsModel.id,
-                categoryId: categoryA.id,
-              });
-              const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-              const modelingElement = insertElement({
-                txn,
-                userLabel: "modeling element",
-                modelId: subModel.id,
-                categoryId: categoryB.id,
-              });
-              return { categoryA, categoryB, modeledElement, modelingElement };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
-
-          await validateHierarchy({
-            provider,
-            expect: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.categoryA],
-                children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.modeledElement.className,
-                    children: [
-                      NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.modeledElement],
-                        children: [
-                          NodeValidators.createForInstanceNode({
-                            instanceKeys: [keys.categoryB],
-                            children: [
-                              NodeValidators.createForClassGroupingNode({
-                                className: keys.modelingElement.className,
-                                children: [
-                                  NodeValidators.createForInstanceNode({
-                                    instanceKeys: [keys.modelingElement],
-                                    children: false,
-                                  }),
-                                ],
-                              }),
-                            ],
-                          }),
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.categoryB],
-                children: false,
-              }),
-            ],
-          });
-        });
-
-        it("shows intermediate category for deeply nested elements with different categories", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const elementsModel = insertElementsModel({ txn, codeValue: "Elements Model" });
-              const categoryA = insertCategory({ txn, codeValue: "category A" });
-              const categoryB = insertCategory({ txn, codeValue: "category B" });
-              const parentElement = insertElement({ txn, userLabel: "parent element", modelId: elementsModel.id, categoryId: categoryA.id });
-              const childElement = insertElement({
-                txn,
-                userLabel: "child element",
-                modelId: elementsModel.id,
-                categoryId: categoryB.id,
-                parentId: parentElement.id,
-              });
-              const grandchildElement = insertElement({
-                txn,
-                userLabel: "grandchild element",
-                modelId: elementsModel.id,
-                categoryId: categoryA.id,
-                parentId: childElement.id,
-              });
-              return { categoryA, categoryB, parentElement, childElement, grandchildElement };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-          using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
-
-          await validateHierarchy({
-            provider,
-            expect: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.categoryA],
-                children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.parentElement.className,
-                    children: [
-                      NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.parentElement],
-                        children: [
-                          NodeValidators.createForInstanceNode({
-                            instanceKeys: [keys.categoryB],
-                            children: [
-                              NodeValidators.createForClassGroupingNode({
-                                className: keys.childElement.className,
-                                children: [
-                                  NodeValidators.createForInstanceNode({
-                                    instanceKeys: [keys.childElement],
-                                    children: [
-                                      NodeValidators.createForInstanceNode({
-                                        instanceKeys: [keys.categoryA],
-                                        children: [
-                                          NodeValidators.createForClassGroupingNode({
-                                            className: keys.grandchildElement.className,
-                                            children: [
-                                              NodeValidators.createForInstanceNode({
-                                                instanceKeys: [keys.grandchildElement],
-                                                children: false,
-                                              }),
-                                            ],
-                                          }),
-                                        ],
-                                      }),
-                                    ],
-                                  }),
-                                ],
-                              }),
-                            ],
-                          }),
-                        ],
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.categoryB],
-                children: false,
-              }),
-            ],
-          });
-        });
-      });
-      describe(`elements.excludedClasses in '${viewType}' view`, () => {
-        const elementClassName: EC.FullClassNameDotNotation = viewType === "3d" ? "Generic.PhysicalObject" : "BisCore.DrawingGraphic";
-        const modeledElementClassName: EC.FullClassNameDotNotation = `${TestSchema.Name}.${viewType === "3d" ? TestSchema.ModeledElement3dClassName : TestSchema.ModeledElement2dClassName}`;
-        const unrelatedElementClassName: EC.FullClassNameDotNotation = viewType === "3d" ? "BisCore.GeometricElement2d" : "BisCore.GeometricElement3d";
-        const subModeledElementBaseClassName: EC.FullClassNameDotNotation = "BisCore.ISubModeledElement";
-        it("does not filter out elements when they don't belong to any of the excluded classes", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              const element = insertElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              return { category, element };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-          using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-            elements: { nodes: "include", excludedClasses: [unrelatedElementClassName] },
-          });
-
-          await validateHierarchy({
-            provider,
-            expect: [
-              NodeValidators.createForInstanceNode({
-                instanceKeys: [keys.category],
-                children: [
-                  NodeValidators.createForClassGroupingNode({
-                    className: keys.element.className,
-                    children: [
-                      NodeValidators.createForInstanceNode({
-                        instanceKeys: [keys.element],
-                        children: false,
-                      }),
-                    ],
-                  }),
-                ],
-              }),
-            ],
-          });
-        });
-
-        describe("root elements of excluded classes", () => {
-          it("filters out elements of excluded classes", async () => {
+        describe("Intermediate categories", () => {
+          it("does not show intermediate category when child element has same category as parent", async () => {
             await using buildIModelResult = await buildIModel(async (imodel) =>
               withEditTxn(imodel, (txn) => {
-                const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-                const category = insertCategory({ txn, codeValue: "category" });
-                const keptElement = insertElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-                insertModeledElement({
-                  txn,
-                  modelId: physicalModel.id,
-                  categoryId: category.id,
-                });
-                return { category, keptElement };
-              }),
-            );
-
-            const { imodelConnection, ...keys } = buildIModelResult;
-            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-              elements: { nodes: "include", excludedClasses: [modeledElementClassName] },
-            });
-
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.category],
-                  children: [
-                    NodeValidators.createForClassGroupingNode({
-                      className: keys.keptElement.className,
-                      children: [
-                        NodeValidators.createForInstanceNode({
-                          instanceKeys: [keys.keptElement],
-                          children: false,
-                        }),
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            });
-          });
-
-          it("filters out elements of classes derived from excluded classes", async () => {
-            await using buildIModelResult = await buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-                const category = insertCategory({ txn, codeValue: "category" });
-                insertModeledElement({
-                  txn,
-                  modelId: physicalModel.id,
-                  categoryId: category.id,
-                });
-                const keptElement = insertElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-                return { category, keptElement };
-              }),
-            );
-
-            const { imodelConnection, ...keys } = buildIModelResult;
-            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-              elements: { nodes: "include", excludedClasses: [subModeledElementBaseClassName] },
-            });
-
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.category],
-                  children: [
-                    NodeValidators.createForClassGroupingNode({
-                      className: keys.keptElement.className,
-                      children: [
-                        NodeValidators.createForInstanceNode({
-                          instanceKeys: [keys.keptElement],
-                          children: false,
-                        }),
-                      ],
-                    }),
-                  ],
-                }),
-              ],
-            });
-          });
-
-          it("shows category when it contains only excluded elements", async () => {
-            await using buildIModelResult = await buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-                const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-                const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-                const category = insertCategory({ txn, codeValue: "category", modelId: definitionModel.id });
-                insertElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-                return { category, definitionContainer };
-              }),
-            );
-
-            const { imodelConnection, ...keys } = buildIModelResult;
-            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-              elements: { nodes: "include", excludedClasses: [elementClassName] },
-            });
-
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.definitionContainer],
-                  children: [
-                    NodeValidators.createForInstanceNode({
-                      instanceKeys: [keys.category],
-                      children: false,
-                    }),
-                  ],
-                }),
-              ],
-            });
-          });
-        });
-
-        describe("child elements of excluded classes", () => {
-          it("sets hasChildren to false when parent contains only excluded child elements", async () => {
-            await using buildIModelResult = await buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-                const category = insertCategory({ txn, codeValue: "category" });
-                const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child category" });
-                const parentElement = insertElement({ txn, userLabel: "parent element", modelId: physicalModel.id, categoryId: category.id });
-                insertModeledElement({
-                  txn,
-                  userLabel: "excluded child element",
-                  modelId: physicalModel.id,
-                  categoryId: excludedChildCategory.id,
-                  parentId: parentElement.id,
-                });
-                return { category, parentElement, excludedChildCategory };
-              }),
-            );
-
-            const { imodelConnection, ...keys } = buildIModelResult;
-            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-              elements: { nodes: "include", excludedClasses: [modeledElementClassName] },
-            });
-
-            await validateHierarchy({
-              provider,
-              expect: [
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.category],
-                  children: [
-                    NodeValidators.createForClassGroupingNode({
-                      className: keys.parentElement.className,
-                      children: [
-                        NodeValidators.createForInstanceNode({
-                          instanceKeys: [keys.parentElement],
-                          children: false,
-                        }),
-                      ],
-                    }),
-                  ],
-                }),
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.excludedChildCategory],
-                  children: false,
-                }),
-              ],
-            });
-          });
-
-          it("filters out child of excluded classes and their categories", async () => {
-            await using buildIModelResult = await buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-                const category = insertCategory({ txn, codeValue: "category" });
-                const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child category" });
-                const childCategory = insertCategory({ txn, codeValue: "child category" });
-                const parentElement = insertElement({ txn, userLabel: "parent element", modelId: physicalModel.id, categoryId: category.id });
-                insertModeledElement({
-                  txn,
-                  userLabel: "excluded child element",
-                  modelId: physicalModel.id,
-                  categoryId: excludedChildCategory.id,
-                  parentId: parentElement.id,
-                });
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const parentElement = insertElement({ txn, userLabel: "parent el", modelId: elementsModel.id, categoryId: category.id });
                 const childElement = insertElement({
                   txn,
                   userLabel: "child element",
-                  modelId: physicalModel.id,
-                  categoryId: childCategory.id,
+                  modelId: elementsModel.id,
+                  categoryId: category.id,
                   parentId: parentElement.id,
                 });
-                return { category, parentElement, childCategory, childElement, excludedChildCategory };
+                return { category, parentElement, childElement };
               }),
             );
 
             const { imodelConnection, ...keys } = buildIModelResult;
-            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-              elements: { nodes: "include", excludedClasses: [modeledElementClassName] },
-            });
+            using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
 
             await validateHierarchy({
               provider,
@@ -1231,8 +617,60 @@ describe("Categories tree", () => {
                         NodeValidators.createForInstanceNode({
                           instanceKeys: [keys.parentElement],
                           children: [
+                            NodeValidators.createForClassGroupingNode({
+                              className: keys.childElement.className,
+                              children: [
+                                NodeValidators.createForInstanceNode({
+                                  instanceKeys: [keys.childElement],
+                                  children: false,
+                                }),
+                              ],
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            });
+          });
+
+          it("shows intermediate category when child element has different category than parent", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "cat A" });
+                const categoryB = insertCategory({ txn, codeValue: "cat B" });
+                const parentElement = insertElement({ txn, userLabel: "parent el", modelId: elementsModel.id, categoryId: categoryA.id });
+                const childElement = insertElement({
+                  txn,
+                  userLabel: "child element",
+                  modelId: elementsModel.id,
+                  categoryId: categoryB.id,
+                  parentId: parentElement.id,
+                });
+                return { categoryA, categoryB, parentElement, childElement };
+              }),
+            );
+
+            const { imodelConnection, ...keys } = buildIModelResult;
+            using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
+
+            await validateHierarchy({
+              provider,
+              expect: [
+                NodeValidators.createForInstanceNode({
+                  instanceKeys: [keys.categoryA],
+                  children: [
+                    NodeValidators.createForClassGroupingNode({
+                      className: keys.parentElement.className,
+                      children: [
+                        NodeValidators.createForInstanceNode({
+                          instanceKeys: [keys.parentElement],
+                          children: [
                             NodeValidators.createForInstanceNode({
-                              instanceKeys: [keys.childCategory],
+                              instanceKeys: [keys.categoryB],
                               children: [
                                 NodeValidators.createForClassGroupingNode({
                                   className: keys.childElement.className,
@@ -1252,111 +690,98 @@ describe("Categories tree", () => {
                   ],
                 }),
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.childCategory],
-                  children: false,
-                }),
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.excludedChildCategory],
+                  instanceKeys: [keys.categoryB],
                   children: false,
                 }),
               ],
             });
           });
 
-          it("sets hasChildren to false when parent modeled element contains only excluded elements", async () => {
+          it("does not show intermediate category when modeling element has the same category as modeled element", async () => {
             await using buildIModelResult = await buildIModel(async (imodel) =>
               withEditTxn(imodel, (txn) => {
-                const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-                const category = insertCategory({ txn, codeValue: "category" });
-                const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child category" });
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "cat A" });
                 const modeledElement = insertModeledElement({
                   txn,
-                  userLabel: "modeled element",
-                  modelId: physicalModel.id,
-                  categoryId: category.id,
+                  modelId: elementsModel.id,
+                  categoryId: categoryA.id,
                 });
                 const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-                insertElement({
+                const modelingElement = insertElement({
                   txn,
-                  userLabel: "excluded modeling element",
                   modelId: subModel.id,
-                  categoryId: excludedChildCategory.id,
+                  categoryId: categoryA.id,
                 });
-                return { category, modeledElement, excludedChildCategory };
+                return { categoryA, modeledElement, modelingElement };
               }),
             );
 
             const { imodelConnection, ...keys } = buildIModelResult;
-            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-              elements: { nodes: "include", excludedClasses: [elementClassName] },
-            });
+            using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
 
             await validateHierarchy({
               provider,
               expect: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.category],
+                  instanceKeys: [keys.categoryA],
                   children: [
                     NodeValidators.createForClassGroupingNode({
                       className: keys.modeledElement.className,
                       children: [
                         NodeValidators.createForInstanceNode({
                           instanceKeys: [keys.modeledElement],
-                          children: false,
+                          children: [
+                            NodeValidators.createForClassGroupingNode({
+                              className: keys.modelingElement.className,
+                              children: [
+                                NodeValidators.createForInstanceNode({
+                                  instanceKeys: [keys.modelingElement],
+                                  children: false,
+                                }),
+                              ],
+                            }),
+                          ],
                         }),
                       ],
                     }),
                   ],
                 }),
-                NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.excludedChildCategory],
-                  children: false,
-                }),
               ],
             });
           });
 
-          it("filters out sub-model child elements of excluded classes and their categories", async () => {
+          it("shows intermediate category when modeling element has different category than modeled element", async () => {
             await using buildIModelResult = await buildIModel(async (imodel) =>
               withEditTxn(imodel, (txn) => {
-                const physicalModel = insertElementsModel({ txn, codeValue: "model" });
-                const category = insertCategory({ txn, codeValue: "category" });
-                const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child category" });
-                const childCategory = insertCategory({ txn, codeValue: "child category" });
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "cat A" });
+                const categoryB = insertCategory({ txn, codeValue: "cat B" });
                 const modeledElement = insertModeledElement({
                   txn,
                   userLabel: "modeled element",
-                  modelId: physicalModel.id,
-                  categoryId: category.id,
+                  modelId: elementsModel.id,
+                  categoryId: categoryA.id,
                 });
                 const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-                insertElement({
+                const modelingElement = insertElement({
                   txn,
-                  userLabel: "excluded modeling element",
+                  userLabel: "modeling element",
                   modelId: subModel.id,
-                  categoryId: excludedChildCategory.id,
+                  categoryId: categoryB.id,
                 });
-                const childModeledElement = insertModeledElement({
-                  txn,
-                  userLabel: "child modeled element",
-                  modelId: subModel.id,
-                  categoryId: childCategory.id,
-                });
-                return { category, modeledElement, childCategory, childModeledElement, excludedChildCategory };
+                return { categoryA, categoryB, modeledElement, modelingElement };
               }),
             );
 
             const { imodelConnection, ...keys } = buildIModelResult;
-            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
-              elements: { nodes: "include", excludedClasses: [elementClassName] },
-            });
+            using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
 
             await validateHierarchy({
               provider,
               expect: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.category],
-                  label: "category",
+                  instanceKeys: [keys.categoryA],
                   children: [
                     NodeValidators.createForClassGroupingNode({
                       className: keys.modeledElement.className,
@@ -1365,13 +790,13 @@ describe("Categories tree", () => {
                           instanceKeys: [keys.modeledElement],
                           children: [
                             NodeValidators.createForInstanceNode({
-                              instanceKeys: [keys.childCategory],
+                              instanceKeys: [keys.categoryB],
                               children: [
                                 NodeValidators.createForClassGroupingNode({
-                                  className: keys.childModeledElement.className,
+                                  className: keys.modelingElement.className,
                                   children: [
                                     NodeValidators.createForInstanceNode({
-                                      instanceKeys: [keys.childModeledElement],
+                                      instanceKeys: [keys.modelingElement],
                                       children: false,
                                     }),
                                   ],
@@ -1385,78 +810,571 @@ describe("Categories tree", () => {
                   ],
                 }),
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.childCategory],
+                  instanceKeys: [keys.categoryB],
                   children: false,
                 }),
+              ],
+            });
+          });
+
+          it("shows intermediate category for deeply nested elements with different categories", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "cat A" });
+                const categoryB = insertCategory({ txn, codeValue: "cat B" });
+                const parentElement = insertElement({ txn, userLabel: "parent el", modelId: elementsModel.id, categoryId: categoryA.id });
+                const childElement = insertElement({
+                  txn,
+                  userLabel: "child element",
+                  modelId: elementsModel.id,
+                  categoryId: categoryB.id,
+                  parentId: parentElement.id,
+                });
+                const grandchildElement = insertElement({
+                  txn,
+                  userLabel: "grandchild element",
+                  modelId: elementsModel.id,
+                  categoryId: categoryA.id,
+                  parentId: childElement.id,
+                });
+                return { categoryA, categoryB, parentElement, childElement, grandchildElement };
+              }),
+            );
+
+            const { imodelConnection, ...keys } = buildIModelResult;
+            using provider = createCategoryTreeProvider(imodelConnection, viewType, { elements: { nodes: "include" } });
+
+            await validateHierarchy({
+              provider,
+              expect: [
                 NodeValidators.createForInstanceNode({
-                  instanceKeys: [keys.excludedChildCategory],
+                  instanceKeys: [keys.categoryA],
+                  children: [
+                    NodeValidators.createForClassGroupingNode({
+                      className: keys.parentElement.className,
+                      children: [
+                        NodeValidators.createForInstanceNode({
+                          instanceKeys: [keys.parentElement],
+                          children: [
+                            NodeValidators.createForInstanceNode({
+                              instanceKeys: [keys.categoryB],
+                              children: [
+                                NodeValidators.createForClassGroupingNode({
+                                  className: keys.childElement.className,
+                                  children: [
+                                    NodeValidators.createForInstanceNode({
+                                      instanceKeys: [keys.childElement],
+                                      children: [
+                                        NodeValidators.createForInstanceNode({
+                                          instanceKeys: [keys.categoryA],
+                                          children: [
+                                            NodeValidators.createForClassGroupingNode({
+                                              className: keys.grandchildElement.className,
+                                              children: [
+                                                NodeValidators.createForInstanceNode({
+                                                  instanceKeys: [keys.grandchildElement],
+                                                  children: false,
+                                                }),
+                                              ],
+                                            }),
+                                          ],
+                                        }),
+                                      ],
+                                    }),
+                                  ],
+                                }),
+                              ],
+                            }),
+                          ],
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+                NodeValidators.createForInstanceNode({
+                  instanceKeys: [keys.categoryB],
                   children: false,
                 }),
               ],
             });
           });
         });
-      });
-    });
 
-    describe("createInstanceKeyPaths", () => {
-      describe("query interrupts handling", () => {
-        const viewType = "3d";
-        let imodelConnection: IModelConnection;
-        let dispose: () => Promise<void>;
+        describe("elements.excludedClasses", () => {
+          const elementClassName: EC.FullClassNameDotNotation = viewType === "3d" ? "Generic.PhysicalObject" : "BisCore.DrawingGraphic";
+          const modeledElementClassName: EC.FullClassNameDotNotation = `${TestSchema.Name}.${viewType === "3d" ? TestSchema.ModeledElement3dClassName : TestSchema.ModeledElement2dClassName}`;
+          const unrelatedElementClassName: EC.FullClassNameDotNotation = viewType === "3d" ? "BisCore.GeometricElement2d" : "BisCore.GeometricElement3d";
+          const subModeledElementBaseClassName: EC.FullClassNameDotNotation = "BisCore.ISubModeledElement";
+          it("does not filter out elements when they don't belong to any of the excluded classes", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                return { category, element };
+              }),
+            );
 
-        beforeAll(async () => {
-          const buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertPhysicalModelWithPartition({ txn, codeValue: "xModel" });
-              const category1 = insertSpatialCategory({ txn, codeValue: "xCategory1", modelId: IModel.dictionaryId });
-              const subCategory1 = insertSubCategory({ txn, parentCategoryId: category1.id, codeValue: "xSubCategory", modelId: IModel.dictionaryId });
-              const category2 = insertSpatialCategory({ txn, codeValue: "xCategory2", modelId: IModel.dictionaryId });
-              const elementInCategory2 = insertPhysicalElement({ txn, modelId: model.id, categoryId: category2.id, userLabel: "xElement" });
-              return { model, category1, subCategory1, category2, elementInCategory2 };
-            }),
-          );
-          imodelConnection = buildIModelResult.imodelConnection;
-          dispose = async () => buildIModelResult[Symbol.asyncDispose]();
+            const { imodelConnection, ...keys } = buildIModelResult;
+            using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+              elements: { nodes: "include", excludedClasses: [unrelatedElementClassName] },
+            });
+
+            await validateHierarchy({
+              provider,
+              expect: [
+                NodeValidators.createForInstanceNode({
+                  instanceKeys: [keys.category],
+                  children: [
+                    NodeValidators.createForClassGroupingNode({
+                      className: keys.element.className,
+                      children: [
+                        NodeValidators.createForInstanceNode({
+                          instanceKeys: [keys.element],
+                          children: false,
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            });
+          });
+
+          describe("root elements of excluded classes", () => {
+            it("filters out elements of excluded classes", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                  const category = insertCategory({ txn, codeValue: "cat" });
+                  const keptElement = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                  insertModeledElement({
+                    txn,
+                    modelId: elementsModel.id,
+                    categoryId: category.id,
+                  });
+                  return { category, keptElement };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+                elements: { nodes: "include", excludedClasses: [modeledElementClassName] },
+              });
+
+              await validateHierarchy({
+                provider,
+                expect: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.keptElement.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.keptElement],
+                            children: false,
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              });
+            });
+
+            it("filters out elements of classes derived from excluded classes", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                  const category = insertCategory({ txn, codeValue: "cat" });
+                  insertModeledElement({
+                    txn,
+                    modelId: elementsModel.id,
+                    categoryId: category.id,
+                  });
+                  const keptElement = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                  return { category, keptElement };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+                elements: { nodes: "include", excludedClasses: [subModeledElementBaseClassName] },
+              });
+
+              await validateHierarchy({
+                provider,
+                expect: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.keptElement.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.keptElement],
+                            children: false,
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                ],
+              });
+            });
+
+            it("shows category when it contains only excluded elements", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+                  const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                  const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+                  insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                  return { category, definitionContainer };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+                elements: { nodes: "include", excludedClasses: [elementClassName] },
+              });
+
+              await validateHierarchy({
+                provider,
+                expect: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.definitionContainer],
+                    children: [
+                      NodeValidators.createForInstanceNode({
+                        instanceKeys: [keys.category],
+                        children: false,
+                      }),
+                    ],
+                  }),
+                ],
+              });
+            });
+          });
+
+          describe("child elements of excluded classes", () => {
+            it("sets hasChildren to false when parent contains only excluded child elements", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                  const category = insertCategory({ txn, codeValue: "cat" });
+                  const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child category" });
+                  const parentElement = insertElement({ txn, userLabel: "parent el", modelId: elementsModel.id, categoryId: category.id });
+                  insertModeledElement({
+                    txn,
+                    userLabel: "excluded child element",
+                    modelId: elementsModel.id,
+                    categoryId: excludedChildCategory.id,
+                    parentId: parentElement.id,
+                  });
+                  return { category, parentElement, excludedChildCategory };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+                elements: { nodes: "include", excludedClasses: [modeledElementClassName] },
+              });
+
+              await validateHierarchy({
+                provider,
+                expect: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.parentElement.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.parentElement],
+                            children: false,
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.excludedChildCategory],
+                    children: false,
+                  }),
+                ],
+              });
+            });
+
+            it("filters out child of excluded classes and their categories", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                  const category = insertCategory({ txn, codeValue: "cat" });
+                  const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child cat" });
+                  const childCategory = insertCategory({ txn, codeValue: "child cat" });
+                  const parentElement = insertElement({ txn, userLabel: "parent el", modelId: elementsModel.id, categoryId: category.id });
+                  insertModeledElement({
+                    txn,
+                    userLabel: "excluded child element",
+                    modelId: elementsModel.id,
+                    categoryId: excludedChildCategory.id,
+                    parentId: parentElement.id,
+                  });
+                  const childElement = insertElement({
+                    txn,
+                    userLabel: "child element",
+                    modelId: elementsModel.id,
+                    categoryId: childCategory.id,
+                    parentId: parentElement.id,
+                  });
+                  return { category, parentElement, childCategory, childElement, excludedChildCategory };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+                elements: { nodes: "include", excludedClasses: [modeledElementClassName] },
+              });
+
+              await validateHierarchy({
+                provider,
+                expect: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.parentElement.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.parentElement],
+                            children: [
+                              NodeValidators.createForInstanceNode({
+                                instanceKeys: [keys.childCategory],
+                                children: [
+                                  NodeValidators.createForClassGroupingNode({
+                                    className: keys.childElement.className,
+                                    children: [
+                                      NodeValidators.createForInstanceNode({
+                                        instanceKeys: [keys.childElement],
+                                        children: false,
+                                      }),
+                                    ],
+                                  }),
+                                ],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.childCategory],
+                    children: false,
+                  }),
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.excludedChildCategory],
+                    children: false,
+                  }),
+                ],
+              });
+            });
+
+            it("sets hasChildren to false when parent modeled element contains only excluded elements", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                  const category = insertCategory({ txn, codeValue: "cat" });
+                  const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child category" });
+                  const modeledElement = insertModeledElement({
+                    txn,
+                    userLabel: "modeled element",
+                    modelId: elementsModel.id,
+                    categoryId: category.id,
+                  });
+                  const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                  insertElement({
+                    txn,
+                    userLabel: "excluded modeling element",
+                    modelId: subModel.id,
+                    categoryId: excludedChildCategory.id,
+                  });
+                  return { category, modeledElement, excludedChildCategory };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+                elements: { nodes: "include", excludedClasses: [elementClassName] },
+              });
+
+              await validateHierarchy({
+                provider,
+                expect: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.modeledElement.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.modeledElement],
+                            children: false,
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.excludedChildCategory],
+                    children: false,
+                  }),
+                ],
+              });
+            });
+
+            it("filters out sub-model child elements of excluded classes and their categories", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                  const category = insertCategory({ txn, codeValue: "cat" });
+                  const excludedChildCategory = insertCategory({ txn, codeValue: "excluded child category" });
+                  const childCategory = insertCategory({ txn, codeValue: "child category" });
+                  const modeledElement = insertModeledElement({
+                    txn,
+                    userLabel: "modeled element",
+                    modelId: elementsModel.id,
+                    categoryId: category.id,
+                  });
+                  const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                  insertElement({
+                    txn,
+                    userLabel: "excluded modeling element",
+                    modelId: subModel.id,
+                    categoryId: excludedChildCategory.id,
+                  });
+                  const childModeledElement = insertModeledElement({
+                    txn,
+                    userLabel: "child modeled element",
+                    modelId: subModel.id,
+                    categoryId: childCategory.id,
+                  });
+                  return { category, modeledElement, childCategory, childModeledElement, excludedChildCategory };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              using provider = createCategoryTreeProvider(imodelConnection, viewType, {
+                elements: { nodes: "include", excludedClasses: [elementClassName] },
+              });
+
+              await validateHierarchy({
+                provider,
+                expect: [
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.category],
+                    label: "cat",
+                    children: [
+                      NodeValidators.createForClassGroupingNode({
+                        className: keys.modeledElement.className,
+                        children: [
+                          NodeValidators.createForInstanceNode({
+                            instanceKeys: [keys.modeledElement],
+                            children: [
+                              NodeValidators.createForInstanceNode({
+                                instanceKeys: [keys.childCategory],
+                                children: [
+                                  NodeValidators.createForClassGroupingNode({
+                                    className: keys.childModeledElement.className,
+                                    children: [
+                                      NodeValidators.createForInstanceNode({
+                                        instanceKeys: [keys.childModeledElement],
+                                        children: false,
+                                      }),
+                                    ],
+                                  }),
+                                ],
+                              }),
+                            ],
+                          }),
+                        ],
+                      }),
+                    ],
+                  }),
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.childCategory],
+                    children: false,
+                  }),
+                  NodeValidators.createForInstanceNode({
+                    instanceKeys: [keys.excludedChildCategory],
+                    children: false,
+                  }),
+                ],
+              });
+            });
+          });
         });
 
-        afterAll(async () => {
-          await dispose();
-        });
+        describe("createInstanceKeyPaths query interrupts handling", () => {
+          let imodelConnection: IModelConnection;
+          let dispose: () => Promise<void>;
 
-        [
-          { queryIdentifier: "LIKE '%' || ? || '%'", description: "label filtering query" },
-          { queryIdentifier: "FROM CategoriesElementsHierarchy mce", description: "elements' search paths query" },
-        ].forEach(({ queryIdentifier, description }) => {
-          it(`doesn't throw on ecsql query interrupt in ${description}`, async () => {
-            const imodelAccess = createIModelAccess(imodelConnection);
-            const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView(viewType).elementClass, type: viewType });
-            const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: viewType, baseIdsCache });
-            const iter = CategoriesTreeDefinition.createInstanceKeyPaths({
-              imodelAccess,
-              idsCache,
-              viewType,
-              hierarchyConfig: {
-                subCategories: { nodes: "include" },
-                categories: { withoutElements: "include" },
-                elements: { nodes: "include", excludedClasses: [] },
-              },
-              label: "x",
+          beforeAll(async () => {
+            const buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "xModel" });
+                const category1 = insertCategory({ txn, codeValue: "xCat1", modelId: IModel.dictionaryId });
+                const subCategory1 = insertSubCategory({ txn, parentCategoryId: category1.id, codeValue: "xSubCat", modelId: IModel.dictionaryId });
+                const category2 = insertCategory({ txn, codeValue: "xCat2", modelId: IModel.dictionaryId });
+                const elementInCategory2 = insertElement({ txn, modelId: model.id, categoryId: category2.id, userLabel: "xEl" });
+                return { model, category1, subCategory1, category2, elementInCategory2 };
+              }),
+            );
+            imodelConnection = buildIModelResult.imodelConnection;
+            dispose = async () => buildIModelResult[Symbol.asyncDispose]();
+          });
+
+          afterAll(async () => {
+            await dispose();
+          });
+
+          [
+            { queryIdentifier: "LIKE '%' || ? || '%'", description: "label filtering query" },
+            { queryIdentifier: "FROM CategoriesElementsHierarchy mce", description: "elements' search paths query" },
+          ].forEach(({ queryIdentifier, description }) => {
+            it(`doesn't throw on ecsql query interrupt in ${description}`, async () => {
+              const imodelAccess = createIModelAccess(imodelConnection);
+              const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView(viewType).elementClass, type: viewType });
+              const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: viewType, baseIdsCache });
+              const iter = CategoriesTreeDefinition.createInstanceKeyPaths({
+                imodelAccess,
+                idsCache,
+                viewType,
+                hierarchyConfig: {
+                  subCategories: { nodes: "include" },
+                  categories: { withoutElements: "include" },
+                  elements: { nodes: "include", excludedClasses: [] },
+                },
+                label: "x",
+              });
+              let didInterrupt = false;
+              const originalQueryReader = imodelConnection.createQueryReader.bind(imodelConnection);
+              vi.spyOn(imodelConnection, "createQueryReader").mockImplementation(async function* (...args): any {
+                const [ecsql] = args;
+                if (ecsql.includes(queryIdentifier)) {
+                  didInterrupt = true;
+                  const err = new Error(ecsql);
+                  err.name = "BE_SQLITE_INTERRUPT";
+                  throw err;
+                }
+                return yield* originalQueryReader(...args);
+              });
+              await expect(Array.fromAsync(iter)).resolves.toBeDefined();
+              expect(didInterrupt).toBe(true);
             });
-            let didInterrupt = false;
-            const originalQueryReader = imodelConnection.createQueryReader.bind(imodelConnection);
-            vi.spyOn(imodelConnection, "createQueryReader").mockImplementation(async function* (...args): any {
-              const [ecsql] = args;
-              if (ecsql.includes(queryIdentifier)) {
-                didInterrupt = true;
-                const err = new Error(ecsql);
-                err.name = "BE_SQLITE_INTERRUPT";
-                throw err;
-              }
-              return yield* originalQueryReader(...args);
-            });
-            await expect(Array.fromAsync(iter)).resolves.toBeDefined();
-            expect(didInterrupt).toBe(true);
           });
         });
       });

--- a/packages/tree-widget/src/test/trees/categories-tree/CategoriesTreeFiltering.test.tsx
+++ b/packages/tree-widget/src/test/trees/categories-tree/CategoriesTreeFiltering.test.tsx
@@ -3,20 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  HierarchyCacheMode,
-  initializeCore,
-  insertDefinitionContainer,
-  insertDrawingCategory,
-  insertDrawingGraphic,
-  insertDrawingModelWithPartition,
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertSpatialCategory,
-  insertSubCategory,
-  insertSubModel,
-  terminateCore,
-} from "test-utilities";
+import { HierarchyCacheMode, initializeCore, insertDefinitionContainer, insertSubCategory, insertSubModel, terminateCore } from "test-utilities";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { withEditTxn } from "@itwin/core-backend";
 import { Id64 } from "@itwin/core-bentley";
@@ -25,13 +12,12 @@ import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { act, renderHook } from "@testing-library/react";
-import { CLASS_NAME_GeometricElement2d, CLASS_NAME_GeometricElement3d } from "../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
+import { CLASS_NAME_DefinitionModel } from "../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
 import { getClassesByView } from "../../../tree-widget-react/shared/internal/Utils.js";
 import { SharedTreeContextProvider } from "../../../tree-widget-react/shared/SharedTreeContextProvider.js";
 import { useCategoriesTree } from "../../../tree-widget-react/trees/categories-tree/UseCategoriesTree.js";
 import { buildIModel } from "../../IModelUtils.js";
 import { createFakeViewport, createIModelAccess } from "../Common.js";
-import { CLASS_NAME_DefinitionModel } from "../TreeUtils.js";
 import { getInsertFunctionByViewType } from "./internal/Utils.js";
 
 import type { IModelConnection } from "@itwin/core-frontend";
@@ -63,648 +49,435 @@ describe("Categories tree", () => {
       await terminateCore();
     });
 
-    it("finds definition container by label", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer", userLabel: "Test" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.definitionContainer, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-    });
-
-    it("does not return definition container with only empty categories when `categories.withoutElements` is set to 'exclude'", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer", userLabel: "Test" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          return { definitionContainer };
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([]);
-    });
-
-    it("returns definition container with only empty categories when `categories.withoutElements` is set to 'include'", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer", userLabel: "Test" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          return { definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        hierarchyConfig: { categories: { withoutElements: "include" } },
-        searchText: "Test",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.definitionContainer, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-    });
-
-    it("aborts when abort signal fires", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer", userLabel: "Test" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...ids } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-
-      const abortController1 = new AbortController();
-      const pathsPromiseAborted = act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: abortController1.signal }));
-      abortController1.abort();
-      expect(await pathsPromiseAborted).toEqual([]);
-
-      const abortController2 = new AbortController();
-      const pathsPromise = act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: abortController2.signal }));
-      expect(await pathsPromise).toEqual([
-        {
-          identifier: { className: "BisCore.DefinitionContainer", id: ids.definitionContainer.id },
-          options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-        },
-      ]);
-    });
-
-    it("finds definition container by label when it is contained by another definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const definitionContainerChild = insertDefinitionContainer({
-            txn,
-            codeValue: "DefinitionContainerChild",
-            userLabel: "Test",
-            modelId: definitionModel.id,
-          });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { definitionContainer, definitionContainerChild };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.definitionContainer,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.definitionContainerChild, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-    });
-
-    it("does not find definition container by label when it doesn't contain categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer", userLabel: "Test" });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([]);
-    });
-
-    it("finds category by label when it is contained by definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", userLabel: "Test", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { definitionContainer, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.definitionContainer,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.category, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-    });
-
-    it("finds subCategory by label when its parent category is contained by definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          const subCategory1 = insertSubCategory({ txn, codeValue: "SubCategory1", parentCategoryId: category.id, modelId: definitionModel.id });
-
-          return { definitionContainer, category, subCategory1 };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "SubCategory1",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.definitionContainer,
-          options: { autoExpand: true },
-          children: [
-            {
-              identifier: keys.category,
-              options: { autoExpand: true },
-              children: [{ identifier: keys.subCategory1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-            },
-          ],
-        },
-      ]);
-    });
-
-    it("finds 3d categories by label containing special SQLite characters", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-          const category1 = insertSpatialCategory({ txn, codeValue: "Test SpatialCat_egory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category1.id });
-
-          const category2 = insertSpatialCategory({ txn, codeValue: "Test SpatialCat%egory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-
-          return { category1, category2 };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "_",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.category1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-
-      hook.rerender({
-        imodelConnection,
-        searchText: "%",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.category2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-    });
-
-    it("finds 3d subcategories by label containing special SQLite characters", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          const subCategory1 = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "SubCat_egory1" });
-          const subCategory2 = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "SubCat%egory2" });
-
-          return { category, subCategory1, subCategory2 };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "_",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.category,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.subCategory1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-
-      hook.rerender({
-        imodelConnection,
-        searchText: "%",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.category,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.subCategory2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-    });
-
-    it("finds 3d categories by label when subCategory count is 1 and labels of category and subCategory differ", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          // SubCategory gets inserted by default
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", userLabel: "Test" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { category };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.category, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-
-      hook.rerender({
-        imodelConnection,
-        searchText: "SpatialCategory",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([]);
-    });
-
-    it("finds 3d categories and subCategories by label when subCategory count is > 1", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", userLabel: "Test" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          const subCategory1 = insertSubCategory({ txn, codeValue: "SubCategory1", parentCategoryId: category.id });
-
-          const subCategory2 = insertSubCategory({ txn, codeValue: "SubCategory2", parentCategoryId: category.id });
-
-          return { category, subCategory1, subCategory2 };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "Test",
-        viewType: "3d",
-      });
-
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.category, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-
-      hook.rerender({
-        imodelConnection,
-        searchText: "SubCategory1",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.category,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.subCategory1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-
-      hook.rerender({
-        imodelConnection,
-        searchText: "SubCategory2",
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.category,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.subCategory2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-    });
-
-    it("finds 2d categories by label containing special SQLite characters", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const drawingModel = insertDrawingModelWithPartition({ txn, codeValue: "TestDrawingModel" });
-
-          const category1 = insertDrawingCategory({ txn, codeValue: "Test Drawing Cat_egory" });
-          insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: category1.id });
-
-          const category2 = insertDrawingCategory({ txn, codeValue: "Test Drawing Cat%egory" });
-          insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: category2.id });
-
-          return { category1, category2 };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "_",
-        viewType: "2d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.category1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-
-      hook.rerender({
-        imodelConnection,
-        searchText: "%",
-        viewType: "2d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        { identifier: keys.category2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-      ]);
-    });
-
-    it("finds 2d subcategories by label containing special SQLite characters", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const drawingModel = insertDrawingModelWithPartition({ txn, codeValue: "TestDrawingModel" });
-
-          const category = insertDrawingCategory({ txn, codeValue: "Test Drawing Category" });
-          insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: category.id });
-
-          const subCategory1 = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test Drawing SubCat_egory" });
-          const subCategory2 = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test Drawing SubCat%egory" });
-
-          return { category, subCategory1, subCategory2 };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        searchText: "_",
-        viewType: "2d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.category,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.subCategory1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-
-      hook.rerender({
-        imodelConnection,
-        searchText: "%",
-        viewType: "2d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.category,
-          options: { autoExpand: true },
-          children: [{ identifier: keys.subCategory2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-        },
-      ]);
-    });
-
-    it("finds 3d element by base36 ECInstanceId suffix", async function () {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "TestDefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          return { definitionContainer, element, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-
-      const briefcaseId = Id64.getBriefcaseId(keys.element.id).toString(36).toLocaleUpperCase();
-      const localId = Id64.getLocalId(keys.element.id).toString(36).toLocaleUpperCase();
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        hierarchyConfig: { elements: { nodes: "include" } },
-        searchText: `[${briefcaseId}-${localId}]`,
-        viewType: "3d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.definitionContainer,
-          options: { autoExpand: true },
-          children: [
-            {
-              identifier: keys.category,
-              options: { autoExpand: true },
-              children: [
-                {
-                  identifier: { ...keys.element, className: CLASS_NAME_GeometricElement3d },
-                  options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-                },
-              ],
-            },
-          ],
-        },
-      ]);
-    });
-
-    it("finds 2d element by base36 ECInstanceId suffix", async function () {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "TestDefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          const drawingModel = insertDrawingModelWithPartition({ txn, codeValue: "TestDrawingModel" });
-
-          const category = insertDrawingCategory({ txn, codeValue: "Test Drawing Category", modelId: definitionModel.id });
-          const element = insertDrawingGraphic({ txn, modelId: drawingModel.id, categoryId: category.id });
-
-          return { definitionContainer, element, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-
-      const briefcaseId = Id64.getBriefcaseId(keys.element.id).toString(36).toLocaleUpperCase();
-      const localId = Id64.getLocalId(keys.element.id).toString(36).toLocaleUpperCase();
-      const imodelAccess = createIModelAccess(imodelConnection);
-      using hook = renderUseCategoriesTreeHook({
-        imodelConnection,
-        hierarchyConfig: { elements: { nodes: "include" } },
-        searchText: `[${briefcaseId}-${localId}]`,
-        viewType: "2d",
-      });
-      expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-        {
-          identifier: keys.definitionContainer,
-          options: { autoExpand: true },
-          children: [
-            {
-              identifier: keys.category,
-              options: { autoExpand: true },
-              children: [
-                {
-                  identifier: { ...keys.element, className: CLASS_NAME_GeometricElement2d },
-                  options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-                },
-              ],
-            },
-          ],
-        },
-      ]);
-    });
     ["2d" as const, "3d" as const].forEach((viewType) => {
-      const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
-      describe(`intermediate ${viewType} categories`, () => {
-        const showElementsConfig = { elements: { nodes: "include" as const } };
-        const { elementClass, modelClass } = getClassesByView(viewType);
-        it("finds child element with different category than parent (intermediate category in path)", async () => {
+      describe(`${viewType} view`, () => {
+        const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
+
+        it("finds definition container by label", async () => {
           await using buildIModelResult = await buildIModel(async (imodel) =>
             withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "TestModel" });
-              const categoryA = insertCategory({ txn, codeValue: "category-a" });
-              const categoryB = insertCategory({ txn, codeValue: "category-b" });
-              const parentElement = insertElement({ txn, userLabel: "parent element", modelId: model.id, categoryId: categoryA.id });
-              const childElement = insertElement({
-                txn,
-                userLabel: "child",
-                modelId: model.id,
-                categoryId: categoryB.id,
-                parentId: parentElement.id,
-              });
-              return { categoryA, categoryB, parentElement, childElement };
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc", userLabel: "Test" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { definitionContainer };
             }),
           );
           const { imodelConnection, ...keys } = buildIModelResult;
           const imodelAccess = createIModelAccess(imodelConnection);
           using hook = renderUseCategoriesTreeHook({
             imodelConnection,
-            hierarchyConfig: showElementsConfig,
-            searchText: "child",
+            searchText: "Test",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            { identifier: keys.definitionContainer, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+          ]);
+        });
+
+        it("does not return definition container with only empty categories when `categories.withoutElements` is set to 'exclude'", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc", userLabel: "Test" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+              return { definitionContainer };
+            }),
+          );
+          const { imodelConnection } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "Test",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
+            [],
+          );
+        });
+
+        it("returns definition container with only empty categories when `categories.withoutElements` is set to 'include'", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc", userLabel: "Test" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+              return { definitionContainer };
+            }),
+          );
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            hierarchyConfig: { categories: { withoutElements: "include" } },
+            searchText: "Test",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            { identifier: keys.definitionContainer, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+          ]);
+        });
+
+        it("aborts when abort signal fires", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc", userLabel: "Test" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+              return { definitionContainer };
+            }),
+          );
+          const { imodelConnection, ...ids } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "Test",
+            viewType,
+          });
+
+          const abortController1 = new AbortController();
+          const pathsPromiseAborted = act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: abortController1.signal }));
+          abortController1.abort();
+          expect(await pathsPromiseAborted).toEqual([]);
+
+          const abortController2 = new AbortController();
+          const pathsPromise = act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: abortController2.signal }));
+          expect(await pathsPromise).toEqual([
+            {
+              identifier: { className: "BisCore.DefinitionContainer", id: ids.definitionContainer.id },
+              options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+            },
+          ]);
+        });
+
+        it("finds definition container by label when it is contained by another definition container", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const definitionContainerChild = insertDefinitionContainer({
+                txn,
+                codeValue: "DefinitionContainerChild",
+                userLabel: "Test",
+                modelId: definitionModel.id,
+              });
+              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModelChild.id });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { definitionContainer, definitionContainerChild };
+            }),
+          );
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "Test",
             viewType,
           });
           expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
             {
-              identifier: keys.categoryA,
+              identifier: keys.definitionContainer,
+              options: { autoExpand: true },
+              children: [{ identifier: keys.definitionContainerChild, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+            },
+          ]);
+        });
+
+        it("does not find definition container by label when it doesn't contain categories", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc", userLabel: "Test" });
+              insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const category = insertCategory({ txn, codeValue: "cat" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            }),
+          );
+          const { imodelConnection } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "Test",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
+            [],
+          );
+        });
+
+        it("finds category by label when it is contained by definition container", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const category = insertCategory({ txn, codeValue: "cat", userLabel: "Test", modelId: definitionModel.id });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { definitionContainer, category };
+            }),
+          );
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "Test",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            {
+              identifier: keys.definitionContainer,
+              options: { autoExpand: true },
+              children: [{ identifier: keys.category, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+            },
+          ]);
+        });
+
+        it("finds subCategory by label when its parent category is contained by definition container", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+              const subCategory1 = insertSubCategory({ txn, codeValue: "SubCategory1", parentCategoryId: category.id, modelId: definitionModel.id });
+
+              return { definitionContainer, category, subCategory1 };
+            }),
+          );
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "SubCategory1",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            {
+              identifier: keys.definitionContainer,
               options: { autoExpand: true },
               children: [
                 {
-                  identifier: { className: elementClass, id: keys.parentElement.id },
+                  identifier: keys.category,
                   options: { autoExpand: true },
-                  children: [
-                    {
-                      identifier: keys.categoryB,
-                      options: { autoExpand: true },
-                      children: [
-                        {
-                          identifier: { className: elementClass, id: keys.childElement.id },
-                          options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-                        },
-                      ],
-                    },
-                  ],
+                  children: [{ identifier: keys.subCategory1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
                 },
               ],
             },
           ]);
         });
 
-        it("finds child element with same category as parent (no intermediate category in path)", async () => {
+        it("finds categories by label containing special SQLite characters", async () => {
           await using buildIModelResult = await buildIModel(async (imodel) =>
             withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "TestModel" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              const parentElement = insertElement({ txn, userLabel: "parent element", modelId: model.id, categoryId: category.id });
-              const childElement = insertElement({
-                txn,
-                userLabel: "child",
-                modelId: model.id,
-                categoryId: category.id,
-                parentId: parentElement.id,
-              });
-              return { category, parentElement, childElement };
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+              const category1 = insertCategory({ txn, codeValue: "Test Cat_egory" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category1.id });
+
+              const category2 = insertCategory({ txn, codeValue: "Test Cat%egory" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category2.id });
+
+              return { category1, category2 };
             }),
           );
+
           const { imodelConnection, ...keys } = buildIModelResult;
           const imodelAccess = createIModelAccess(imodelConnection);
           using hook = renderUseCategoriesTreeHook({
             imodelConnection,
-            hierarchyConfig: showElementsConfig,
-            searchText: "child",
+            searchText: "_",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            { identifier: keys.category1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+          ]);
+
+          hook.rerender({
+            imodelConnection,
+            searchText: "%",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            { identifier: keys.category2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+          ]);
+        });
+
+        it("finds subcategories by label containing special SQLite characters", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+              const category = insertCategory({ txn, codeValue: "Test Category" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              const subCategory1 = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "SubCat_egory1" });
+              const subCategory2 = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "SubCat%egory2" });
+
+              return { category, subCategory1, subCategory2 };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "_",
             viewType,
           });
           expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
             {
               identifier: keys.category,
               options: { autoExpand: true },
+              children: [{ identifier: keys.subCategory1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+            },
+          ]);
+
+          hook.rerender({
+            imodelConnection,
+            searchText: "%",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            {
+              identifier: keys.category,
+              options: { autoExpand: true },
+              children: [{ identifier: keys.subCategory2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+            },
+          ]);
+        });
+
+        it("finds categories by label when subCategory count is 1 and labels of category and subCategory differ", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              // SubCategory gets inserted by default
+              const category = insertCategory({ txn, codeValue: "cat", userLabel: "Test" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { category };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "Test",
+            viewType,
+          });
+
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            { identifier: keys.category, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+          ]);
+
+          hook.rerender({
+            imodelConnection,
+            searchText: "cat",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
+            [],
+          );
+        });
+
+        it("finds categories and subCategories by label when subCategory count is > 1", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+              const category = insertCategory({ txn, codeValue: "cat", userLabel: "Test" });
+              insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              const subCategory1 = insertSubCategory({ txn, codeValue: "SubCategory1", parentCategoryId: category.id });
+
+              const subCategory2 = insertSubCategory({ txn, codeValue: "SubCategory2", parentCategoryId: category.id });
+
+              return { category, subCategory1, subCategory2 };
+            }),
+          );
+
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            searchText: "Test",
+            viewType,
+          });
+
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            { identifier: keys.category, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+          ]);
+
+          hook.rerender({
+            imodelConnection,
+            searchText: "SubCategory1",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            {
+              identifier: keys.category,
+              options: { autoExpand: true },
+              children: [{ identifier: keys.subCategory1, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+            },
+          ]);
+
+          hook.rerender({
+            imodelConnection,
+            searchText: "SubCategory2",
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            {
+              identifier: keys.category,
+              options: { autoExpand: true },
+              children: [{ identifier: keys.subCategory2, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+            },
+          ]);
+        });
+
+        it("finds element by base36 ECInstanceId suffix", async function () {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "TestDefinitionContainer" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+              const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+
+              return { definitionContainer, element, category };
+            }),
+          );
+          const { imodelConnection, ...keys } = buildIModelResult;
+
+          const briefcaseId = Id64.getBriefcaseId(keys.element.id).toString(36).toLocaleUpperCase();
+          const localId = Id64.getLocalId(keys.element.id).toString(36).toLocaleUpperCase();
+          const imodelAccess = createIModelAccess(imodelConnection);
+          using hook = renderUseCategoriesTreeHook({
+            imodelConnection,
+            hierarchyConfig: { elements: { nodes: "include" } },
+            searchText: `[${briefcaseId}-${localId}]`,
+            viewType,
+          });
+          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+            {
+              identifier: keys.definitionContainer,
+              options: { autoExpand: true },
               children: [
                 {
-                  identifier: { className: elementClass, id: keys.parentElement.id },
+                  identifier: keys.category,
                   options: { autoExpand: true },
                   children: [
                     {
-                      identifier: { className: elementClass, id: keys.childElement.id },
+                      identifier: { ...keys.element, className: getClassesByView(viewType).elementClass },
                       options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
                     },
                   ],
@@ -714,428 +487,527 @@ describe("Categories tree", () => {
           ]);
         });
 
-        it("finds category that appears as intermediate category", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "TestModel" });
-              const categoryA = insertCategory({ txn, codeValue: "category-a" });
-              const categoryB = insertCategory({ txn, codeValue: "category-b" });
-              const parentElement = insertElement({ txn, userLabel: "parent element", modelId: model.id, categoryId: categoryA.id });
-              insertElement({
-                txn,
-                userLabel: "child element",
-                modelId: model.id,
-                categoryId: categoryB.id,
-                parentId: parentElement.id,
-              });
-              return { categoryA, categoryB, parentElement };
-            }),
-          );
-          const { imodelConnection, ...keys } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: showElementsConfig,
-            searchText: "category-b",
-            viewType,
+        describe("intermediate categories", () => {
+          const showElementsConfig = { elements: { nodes: "include" as const } };
+          const { elementClass, modelClass } = getClassesByView(viewType);
+          it("finds child element with different category than parent (intermediate category in path)", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "catA" });
+                const categoryB = insertCategory({ txn, codeValue: "catB" });
+                const parentElement = insertElement({ txn, userLabel: "parent element", modelId: model.id, categoryId: categoryA.id });
+                const childElement = insertElement({
+                  txn,
+                  userLabel: "child",
+                  modelId: model.id,
+                  categoryId: categoryB.id,
+                  parentId: parentElement.id,
+                });
+                return { categoryA, categoryB, parentElement, childElement };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: showElementsConfig,
+              searchText: "child",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+              {
+                identifier: keys.categoryA,
+                options: { autoExpand: true },
+                children: [
+                  {
+                    identifier: { className: elementClass, id: keys.parentElement.id },
+                    options: { autoExpand: true },
+                    children: [
+                      {
+                        identifier: keys.categoryB,
+                        options: { autoExpand: true },
+                        children: [
+                          {
+                            identifier: { className: elementClass, id: keys.childElement.id },
+                            options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ]);
           });
-          const paths = await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
-          // Should find the category as an intermediate category path (under parentElement)
-          expect(paths).toEqual([
-            {
-              identifier: keys.categoryA,
-              options: { autoExpand: true },
-              children: [
-                {
-                  identifier: { className: elementClass, id: keys.parentElement.id },
-                  options: { autoExpand: true },
-                  children: [{ identifier: keys.categoryB, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-                },
-              ],
-            },
-            {
-              identifier: keys.categoryB,
-              options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-            },
-          ]);
+
+          it("finds child element with same category as parent (no intermediate category in path)", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "m" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const parentElement = insertElement({ txn, userLabel: "parent element", modelId: model.id, categoryId: category.id });
+                const childElement = insertElement({
+                  txn,
+                  userLabel: "child",
+                  modelId: model.id,
+                  categoryId: category.id,
+                  parentId: parentElement.id,
+                });
+                return { category, parentElement, childElement };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: showElementsConfig,
+              searchText: "child",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+              {
+                identifier: keys.category,
+                options: { autoExpand: true },
+                children: [
+                  {
+                    identifier: { className: elementClass, id: keys.parentElement.id },
+                    options: { autoExpand: true },
+                    children: [
+                      {
+                        identifier: { className: elementClass, id: keys.childElement.id },
+                        options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ]);
+          });
+
+          it("finds category that appears as intermediate category", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "catA" });
+                const categoryB = insertCategory({ txn, codeValue: "catB" });
+                const parentElement = insertElement({ txn, userLabel: "parent element", modelId: model.id, categoryId: categoryA.id });
+                insertElement({
+                  txn,
+                  userLabel: "child element",
+                  modelId: model.id,
+                  categoryId: categoryB.id,
+                  parentId: parentElement.id,
+                });
+                return { categoryA, categoryB, parentElement };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: showElementsConfig,
+              searchText: "catB",
+              viewType,
+            });
+            const paths = await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
+            // Should find the category as an intermediate category path (under parentElement)
+            expect(paths).toEqual([
+              {
+                identifier: keys.categoryA,
+                options: { autoExpand: true },
+                children: [
+                  {
+                    identifier: { className: elementClass, id: keys.parentElement.id },
+                    options: { autoExpand: true },
+                    children: [{ identifier: keys.categoryB, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+                  },
+                ],
+              },
+              {
+                identifier: keys.categoryB,
+                options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+              },
+            ]);
+          });
+
+          it("finds sub-model element with different category than modeled element (intermediate category in path)", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "catA" });
+                const categoryB = insertCategory({ txn, codeValue: "catB" });
+                const modeledElement = insertModeledElement({
+                  txn,
+                  userLabel: "modeled element",
+                  modelId: model.id,
+                  categoryId: categoryA.id,
+                });
+                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                const modelingElement = insertElement({
+                  txn,
+                  userLabel: "modeling element",
+                  modelId: subModel.id,
+                  categoryId: categoryB.id,
+                });
+                return { categoryA, categoryB, modeledElement, subModel, modelingElement };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: showElementsConfig,
+              searchText: "modeling element",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+              {
+                identifier: keys.categoryA,
+                options: { autoExpand: true },
+                children: [
+                  {
+                    identifier: { className: elementClass, id: keys.modeledElement.id },
+                    options: { autoExpand: true },
+                    children: [
+                      {
+                        identifier: { className: modelClass, id: keys.subModel.id },
+                        options: { autoExpand: true },
+                        children: [
+                          {
+                            identifier: keys.categoryB,
+                            options: { autoExpand: true },
+                            children: [
+                              {
+                                identifier: { className: elementClass, id: keys.modelingElement.id },
+                                options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ]);
+          });
+
+          it("finds sub-model element with same category as modeled element (no intermediate category in path)", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "m" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const modeledElement = insertModeledElement({
+                  txn,
+                  userLabel: "modeled element",
+                  modelId: model.id,
+                  categoryId: category.id,
+                });
+                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                const modelingElement = insertElement({
+                  txn,
+                  userLabel: "modeling element",
+                  modelId: subModel.id,
+                  categoryId: category.id,
+                });
+                return { category, modeledElement, subModel, modelingElement };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: showElementsConfig,
+              searchText: "modeling element",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+              {
+                identifier: keys.category,
+                options: { autoExpand: true },
+                children: [
+                  {
+                    identifier: { className: elementClass, id: keys.modeledElement.id },
+                    options: { autoExpand: true },
+                    children: [
+                      {
+                        identifier: { className: modelClass, id: keys.subModel.id },
+                        options: { autoExpand: true },
+                        children: [
+                          {
+                            identifier: { className: elementClass, id: keys.modelingElement.id },
+                            options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ]);
+          });
+
+          it("finds category that appears as intermediate category under sub-model", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "m" });
+                const categoryA = insertCategory({ txn, codeValue: "catA" });
+                const categoryB = insertCategory({ txn, codeValue: "catB" });
+                const modeledElement = insertModeledElement({
+                  txn,
+                  userLabel: "modeled element",
+                  modelId: model.id,
+                  categoryId: categoryA.id,
+                });
+                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                insertElement({
+                  txn,
+                  userLabel: "modeling element",
+                  modelId: subModel.id,
+                  categoryId: categoryB.id,
+                });
+                return { categoryA, categoryB, modeledElement, subModel };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: showElementsConfig,
+              searchText: "catB",
+              viewType,
+            });
+            const paths = await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
+            expect(paths).toEqual([
+              {
+                identifier: keys.categoryA,
+                options: { autoExpand: true },
+                children: [
+                  {
+                    identifier: { className: elementClass, id: keys.modeledElement.id },
+                    options: { autoExpand: true },
+                    children: [
+                      {
+                        identifier: { className: modelClass, id: keys.subModel.id },
+                        options: { autoExpand: true },
+                        children: [{ identifier: keys.categoryB, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                identifier: keys.categoryB,
+                options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
+              },
+            ]);
+          });
         });
 
-        it("finds sub-model element with different category than modeled element (intermediate category in path)", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "TestModel" });
-              const categoryA = insertCategory({ txn, codeValue: "category-a" });
-              const categoryB = insertCategory({ txn, codeValue: "category-b" });
-              const modeledElement = insertModeledElement({
-                txn,
-                userLabel: "modeled element",
-                modelId: model.id,
-                categoryId: categoryA.id,
-              });
-              const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-              const modelingElement = insertElement({
-                txn,
-                userLabel: "modeling element",
-                modelId: subModel.id,
-                categoryId: categoryB.id,
-              });
-              return { categoryA, categoryB, modeledElement, subModel, modelingElement };
-            }),
-          );
-          const { imodelConnection, ...keys } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: showElementsConfig,
-            searchText: "modeling element",
-            viewType,
+        describe("'onCategoriesFiltered' callback", () => {
+          it("is called with empty categories when `categories.withoutElements` is set to 'include'", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+                const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc", userLabel: "TestDC" });
+                const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+                const categoryWithElements = insertCategory({ txn, codeValue: "CategoryWithElements", modelId: definitionModel.id });
+                const categoryWithoutElements = insertCategory({ txn, codeValue: "CategoryWithoutElements", modelId: definitionModel.id });
+                insertElement({ txn, modelId: elementsModel.id, categoryId: categoryWithElements.id });
+
+                return { definitionContainer, categoryWithElements, categoryWithoutElements };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+
+            let filteredCategories: { categories: CategoryInfo[] | undefined } | undefined;
+            const onCategoriesFiltered = (props: { categories: CategoryInfo[] | undefined }) => {
+              filteredCategories = props;
+            };
+
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: { categories: { withoutElements: "include" } },
+              searchText: "TestDC",
+              viewType,
+              onCategoriesFiltered,
+            });
+            await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
+
+            // When categories.withoutElements is set to 'include', both categories should be reported (including the one without elements)
+            expect(filteredCategories?.categories).toEqual([
+              { categoryId: keys.categoryWithElements.id, subCategoryIds: undefined },
+              { categoryId: keys.categoryWithoutElements.id, subCategoryIds: undefined },
+            ]);
+            hook.rerender({
+              imodelConnection,
+              hierarchyConfig: { categories: { withoutElements: "exclude" } },
+              searchText: "TestDC",
+              viewType,
+              onCategoriesFiltered,
+            });
+            await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
+
+            // When categories.withoutElements is set to 'exclude', only the category with elements should be reported
+            expect(filteredCategories?.categories).toEqual([{ categoryId: keys.categoryWithElements.id, subCategoryIds: undefined }]);
           });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-            {
-              identifier: keys.categoryA,
-              options: { autoExpand: true },
-              children: [
-                {
-                  identifier: { className: elementClass, id: keys.modeledElement.id },
-                  options: { autoExpand: true },
-                  children: [
-                    {
-                      identifier: { className: modelClass, id: keys.subModel.id },
-                      options: { autoExpand: true },
-                      children: [
-                        {
-                          identifier: keys.categoryB,
-                          options: { autoExpand: true },
-                          children: [
-                            {
-                              identifier: { className: elementClass, id: keys.modelingElement.id },
-                              options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-                            },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ]);
         });
 
-        it("finds sub-model element with same category as modeled element (no intermediate category in path)", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "TestModel" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              const modeledElement = insertModeledElement({
-                txn,
-                userLabel: "modeled element",
-                modelId: model.id,
-                categoryId: category.id,
-              });
-              const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-              const modelingElement = insertElement({
-                txn,
-                userLabel: "modeling element",
-                modelId: subModel.id,
-                categoryId: category.id,
-              });
-              return { category, modeledElement, subModel, modelingElement };
-            }),
-          );
-          const { imodelConnection, ...keys } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: showElementsConfig,
-            searchText: "modeling element",
-            viewType,
+        describe("elements.excludedClasses", () => {
+          const showElementsConfig = { elements: { nodes: "include" as const } };
+          const elementClassName: EC.FullClassNameDotNotation = viewType === "3d" ? "Generic.PhysicalObject" : "BisCore.DrawingGraphic";
+          const subModeledElementBaseClassName: EC.FullClassNameDotNotation = "BisCore.ISubModeledElement";
+
+          it("excludes elements of excluded classes from search paths", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "model" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                insertElement({ txn, userLabel: "matching excluded element", modelId: model.id, categoryId: category.id });
+              }),
+            );
+            const { imodelConnection } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [elementClassName] } },
+              searchText: "matching",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
+              [],
+            );
           });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-            {
-              identifier: keys.category,
-              options: { autoExpand: true },
-              children: [
-                {
-                  identifier: { className: elementClass, id: keys.modeledElement.id },
-                  options: { autoExpand: true },
-                  children: [
-                    {
-                      identifier: { className: modelClass, id: keys.subModel.id },
-                      options: { autoExpand: true },
-                      children: [
-                        {
-                          identifier: { className: elementClass, id: keys.modelingElement.id },
-                          options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ]);
-        });
 
-        it("finds category that appears as intermediate category under sub-model", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "TestModel" });
-              const categoryA = insertCategory({ txn, codeValue: "category-a" });
-              const categoryB = insertCategory({ txn, codeValue: "category-b" });
-              const modeledElement = insertModeledElement({
-                txn,
-                userLabel: "modeled element",
-                modelId: model.id,
-                categoryId: categoryA.id,
-              });
-              const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-              insertElement({
-                txn,
-                userLabel: "modeling element",
-                modelId: subModel.id,
-                categoryId: categoryB.id,
-              });
-              return { categoryA, categoryB, modeledElement, subModel };
-            }),
-          );
-          const { imodelConnection, ...keys } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: showElementsConfig,
-            searchText: "category-b",
-            viewType,
+          it("excludes elements of classes derived from excluded classes from search paths", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "model" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                insertModeledElement({ txn, userLabel: "matching excluded element", modelId: model.id, categoryId: category.id });
+              }),
+            );
+            const { imodelConnection } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [subModeledElementBaseClassName] } },
+              searchText: "matching",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
+              [],
+            );
           });
-          const paths = await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
-          expect(paths).toEqual([
-            {
-              identifier: keys.categoryA,
-              options: { autoExpand: true },
-              children: [
-                {
-                  identifier: { className: elementClass, id: keys.modeledElement.id },
-                  options: { autoExpand: true },
-                  children: [
-                    {
-                      identifier: { className: modelClass, id: keys.subModel.id },
-                      options: { autoExpand: true },
-                      children: [{ identifier: keys.categoryB, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } }],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              identifier: keys.categoryB,
-              options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } },
-            },
-          ]);
-        });
-      });
 
-      describe(`'onCategoriesFiltered' callback with ${viewType} categories`, () => {
-        it("is called with empty categories when `categories.withoutElements` is set to 'include'", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertElementsModel({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer", userLabel: "TestDC" });
-              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-              const categoryWithElements = insertCategory({ txn, codeValue: "CategoryWithElements", modelId: definitionModel.id });
-              const categoryWithoutElements = insertCategory({ txn, codeValue: "CategoryWithoutElements", modelId: definitionModel.id });
-              insertElement({ txn, modelId: physicalModel.id, categoryId: categoryWithElements.id });
-
-              return { definitionContainer, categoryWithElements, categoryWithoutElements };
-            }),
-          );
-          const { imodelConnection, ...keys } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-
-          let filteredCategories: { categories: CategoryInfo[] | undefined } | undefined;
-          const onCategoriesFiltered = (props: { categories: CategoryInfo[] | undefined }) => {
-            filteredCategories = props;
-          };
-
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: { categories: { withoutElements: "include" } },
-            searchText: "TestDC",
-            viewType,
-            onCategoriesFiltered,
+          it("returns the category even when its only element is excluded", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "model" });
+                const excludedCategory = insertCategory({ txn, codeValue: "matching excluded category" });
+                insertElement({ txn, userLabel: "excluded element", modelId: model.id, categoryId: excludedCategory.id });
+                return { excludedCategory };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: { elements: { nodes: "exclude", excludedClasses: [elementClassName] } } as NonNullable<
+                Props<typeof useCategoriesTree>["hierarchyConfig"]
+              >,
+              searchText: "matching",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+              { identifier: keys.excludedCategory, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+            ]);
           });
-          await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
 
-          // When categories.withoutElements is set to 'include', both categories should be reported (including the one without elements)
-          expect(filteredCategories?.categories).toEqual([
-            { categoryId: keys.categoryWithElements.id, subCategoryIds: undefined },
-            { categoryId: keys.categoryWithoutElements.id, subCategoryIds: undefined },
-          ]);
-          hook.rerender({
-            imodelConnection,
-            hierarchyConfig: { categories: { withoutElements: "exclude" } },
-            searchText: "TestDC",
-            viewType,
-            onCategoriesFiltered,
+          it("does not return child elements of filtered out parent elements", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "model" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const excludedParent = insertElement({ txn, userLabel: "excluded parent", modelId: model.id, categoryId: category.id });
+                insertModeledElement({
+                  txn,
+                  userLabel: "matching child of excluded parent",
+                  modelId: model.id,
+                  categoryId: category.id,
+                  parentId: excludedParent.id,
+                });
+              }),
+            );
+            const { imodelConnection } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [elementClassName] } },
+              searchText: "matching",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
+              [],
+            );
           });
-          await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }));
 
-          // When categories.withoutElements is set to 'exclude', only the category with elements should be reported
-          expect(filteredCategories?.categories).toEqual([{ categoryId: keys.categoryWithElements.id, subCategoryIds: undefined }]);
-        });
-      });
-
-      describe(`elements.excludedClasses in '${viewType}' view`, () => {
-        const showElementsConfig = { elements: { nodes: "include" as const } };
-        const elementClassName: EC.FullClassNameDotNotation = viewType === "3d" ? "Generic.PhysicalObject" : "BisCore.DrawingGraphic";
-        const subModeledElementBaseClassName: EC.FullClassNameDotNotation = "BisCore.ISubModeledElement";
-
-        it("excludes elements of excluded classes from search paths", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "model" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              insertElement({ txn, userLabel: "matching excluded element", modelId: model.id, categoryId: category.id });
-            }),
-          );
-          const { imodelConnection } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [elementClassName] } },
-            searchText: "matching",
-            viewType,
+          it("does not return excluded child elements when their parent is not excluded", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "model" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const keptParent = insertElement({ txn, userLabel: "kept parent", modelId: model.id, categoryId: category.id });
+                insertModeledElement({
+                  txn,
+                  userLabel: "matching excluded child",
+                  modelId: model.id,
+                  categoryId: category.id,
+                  parentId: keptParent.id,
+                });
+              }),
+            );
+            const { imodelConnection } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [subModeledElementBaseClassName] } },
+              searchText: "matching",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
+              [],
+            );
           });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
-            [],
-          );
-        });
 
-        it("excludes elements of classes derived from excluded classes from search paths", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "model" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              insertModeledElement({ txn, userLabel: "matching excluded element", modelId: model.id, categoryId: category.id });
-            }),
-          );
-          const { imodelConnection } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [subModeledElementBaseClassName] } },
-            searchText: "matching",
-            viewType,
+          it("returns the category even when its only sub-model element is excluded", async () => {
+            await using buildIModelResult = await buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const model = insertElementsModel({ txn, codeValue: "model" });
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const excludedCategory = insertCategory({ txn, codeValue: "matching excluded category" });
+                const modeledElement = insertModeledElement({ txn, userLabel: "modeled element", modelId: model.id, categoryId: category.id });
+                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                insertElement({ txn, userLabel: "excluded element", modelId: subModel.id, categoryId: excludedCategory.id });
+                return { excludedCategory };
+              }),
+            );
+            const { imodelConnection, ...keys } = buildIModelResult;
+            const imodelAccess = createIModelAccess(imodelConnection);
+            using hook = renderUseCategoriesTreeHook({
+              imodelConnection,
+              hierarchyConfig: { elements: { nodes: "exclude", excludedClasses: [elementClassName] } } as NonNullable<
+                Props<typeof useCategoriesTree>["hierarchyConfig"]
+              >,
+              searchText: "matching",
+              viewType,
+            });
+            expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
+              { identifier: keys.excludedCategory, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
+            ]);
           });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
-            [],
-          );
-        });
-
-        it("returns the category even when its only element is excluded", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "model" });
-              const excludedCategory = insertCategory({ txn, codeValue: "matching excluded category" });
-              insertElement({ txn, userLabel: "excluded element", modelId: model.id, categoryId: excludedCategory.id });
-              return { excludedCategory };
-            }),
-          );
-          const { imodelConnection, ...keys } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: { elements: { nodes: "exclude", excludedClasses: [elementClassName] } } as NonNullable<
-              Props<typeof useCategoriesTree>["hierarchyConfig"]
-            >,
-            searchText: "matching",
-            viewType,
-          });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-            { identifier: keys.excludedCategory, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-          ]);
-        });
-
-        it("does not return child elements of filtered out parent elements", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "model" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              const excludedParent = insertElement({ txn, userLabel: "excluded parent", modelId: model.id, categoryId: category.id });
-              insertModeledElement({
-                txn,
-                userLabel: "matching child of excluded parent",
-                modelId: model.id,
-                categoryId: category.id,
-                parentId: excludedParent.id,
-              });
-            }),
-          );
-          const { imodelConnection } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [elementClassName] } },
-            searchText: "matching",
-            viewType,
-          });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
-            [],
-          );
-        });
-
-        it("does not return excluded child elements when their parent is not excluded", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "model" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              const keptParent = insertElement({ txn, userLabel: "kept parent", modelId: model.id, categoryId: category.id });
-              insertModeledElement({
-                txn,
-                userLabel: "matching excluded child",
-                modelId: model.id,
-                categoryId: category.id,
-                parentId: keptParent.id,
-              });
-            }),
-          );
-          const { imodelConnection } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: { elements: { ...showElementsConfig.elements, excludedClasses: [subModeledElementBaseClassName] } },
-            searchText: "matching",
-            viewType,
-          });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual(
-            [],
-          );
-        });
-
-        it("returns the category even when its only sub-model element is excluded", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const model = insertElementsModel({ txn, codeValue: "model" });
-              const category = insertCategory({ txn, codeValue: "category" });
-              const excludedCategory = insertCategory({ txn, codeValue: "matching excluded category" });
-              const modeledElement = insertModeledElement({ txn, userLabel: "modeled element", modelId: model.id, categoryId: category.id });
-              const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-              insertElement({ txn, userLabel: "excluded element", modelId: subModel.id, categoryId: excludedCategory.id });
-              return { excludedCategory };
-            }),
-          );
-          const { imodelConnection, ...keys } = buildIModelResult;
-          const imodelAccess = createIModelAccess(imodelConnection);
-          using hook = renderUseCategoriesTreeHook({
-            imodelConnection,
-            hierarchyConfig: { elements: { nodes: "exclude", excludedClasses: [elementClassName] } } as NonNullable<
-              Props<typeof useCategoriesTree>["hierarchyConfig"]
-            >,
-            searchText: "matching",
-            viewType,
-          });
-          expect(await act(async () => hook.result.current.treeProps.getSearchPaths?.({ imodelAccess, abortSignal: new AbortController().signal }))).toEqual([
-            { identifier: keys.excludedCategory, options: { autoExpand: { groupingLevel: Number.MAX_SAFE_INTEGER } } },
-          ]);
         });
       });
     });

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
@@ -17,7 +17,7 @@ import { buildIModel } from "../../../IModelUtils.js";
 import { getDefaultSubCategoryId } from "../../TreeUtils.js";
 import { createAccessAndCache, getInsertFunctionByViewType } from "./Utils.js";
 
-import type { CategoriesTreeIdsCache } from "../../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
+import type { IModelConnection } from "@itwin/core-frontend";
 
 describe("CategoriesTreeIdsCache", () => {
   beforeAll(async () => {
@@ -43,119 +43,18 @@ describe("CategoriesTreeIdsCache", () => {
   ["2d" as const, "3d" as const].forEach((viewType) => {
     const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
     describe(`${viewType} view`, () => {
-      let imodelWithoutElements: Awaited<ReturnType<typeof createIModelWithoutElements>>;
-      let imodelWithoutDefContainers: Awaited<ReturnType<typeof createIModelWithoutDefContainers>>;
-      let imodelWithDefContainersAndCategories: Awaited<ReturnType<typeof createIModelWithDefContainersAndCategories>>;
-      let cacheForIModelWithoutElements: CategoriesTreeIdsCache;
-      let cacheForIModelWithoutDefContainers: CategoriesTreeIdsCache;
-      let cacheForIModelWithDefContainersAndCategories: CategoriesTreeIdsCache;
-      async function createIModelWithoutElements() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const emptyDefContainer = insertDefinitionContainer({ txn, codeValue: "Empty dc" });
-            insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyDefContainer.id });
-            const emptyParentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc" });
-            const emptyParentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyParentDefContainer.id });
-            const childDefContainer = insertDefinitionContainer({ txn, codeValue: "Child dc", modelId: emptyParentDefModel.id });
-            insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefContainer.id });
-            const parentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc with cat" });
-            const parentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefContainer.id });
-            const defContainerOfCategories = insertDefinitionContainer({ txn, codeValue: "Categories dc", modelId: parentDefModel.id });
-            const defModelOfCategories = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: defContainerOfCategories.id });
-            const categoryOfDefContainer = insertCategory({ txn, codeValue: "cat of child", modelId: defModelOfCategories.id });
-            const emptyCategory = insertCategory({ txn, codeValue: "Empty cat" });
-
-            return {
-              emptyDefContainer,
-              emptyParentDefContainer,
-              childDefContainer,
-              defContainerOfCategories,
-              parentDefContainer,
-              categoryOfDefContainer,
-              emptyCategory,
-            };
-          }),
-        );
-      }
-
-      async function createIModelWithoutDefContainers() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const category = insertCategory({ txn, codeValue: "cat" });
-            const categoryWithSubCategories = insertCategory({ txn, codeValue: "cat with subCategories" });
-            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
-            const element1 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
-            const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryWithSubCategories.id });
-            const subCategory = insertSubCategory({ txn, parentCategoryId: categoryWithSubCategories.id, codeValue: "subCat" });
-
-            return {
-              category,
-              categoryWithSubCategories,
-              subCategory,
-              element1,
-              element2,
-            };
-          }),
-        );
-      }
-
-      async function createIModelWithDefContainersAndCategories() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const parentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc" });
-            const parentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefContainer.id });
-            const childDefContainer = insertDefinitionContainer({ txn, codeValue: "Child dc", modelId: parentDefModel.id });
-            const childDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefContainer.id });
-            const emptyChildDefContainer = insertDefinitionContainer({ txn, codeValue: "empty dc", modelId: parentDefModel.id });
-            insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyChildDefContainer.id });
-            const categoryUnderChild = insertCategory({ txn, codeValue: "cat", modelId: childDefModel.id });
-            const categoryUnderParentWithSubCategories = insertCategory({ txn, codeValue: "cat with subCategories", modelId: parentDefModel.id });
-            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
-            const element1 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryUnderChild.id });
-            const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryUnderParentWithSubCategories.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: categoryUnderParentWithSubCategories.id,
-              codeValue: "subCat",
-              modelId: parentDefModel.id,
-            });
-
-            return {
-              parentDefContainer,
-              childDefContainer,
-              emptyChildDefContainer,
-              categoryUnderChild,
-              categoryUnderParentWithSubCategories,
-              subCategory,
-              element1,
-              element2,
-            };
-          }),
-        );
-      }
-
+      let datasets: Awaited<ReturnType<typeof createDatasets>>;
       beforeAll(async () => {
-        imodelWithoutElements = await createIModelWithoutElements();
-        cacheForIModelWithoutElements = createAccessAndCache({ imodelConnection: imodelWithoutElements.imodelConnection, viewType }).idsCache;
-        imodelWithoutDefContainers = await createIModelWithoutDefContainers();
-        cacheForIModelWithoutDefContainers = createAccessAndCache({ imodelConnection: imodelWithoutDefContainers.imodelConnection, viewType }).idsCache;
-        imodelWithDefContainersAndCategories = await createIModelWithDefContainersAndCategories();
-        cacheForIModelWithDefContainersAndCategories = createAccessAndCache({
-          imodelConnection: imodelWithDefContainersAndCategories.imodelConnection,
-          viewType,
-        }).idsCache;
+        datasets = await createDatasets(viewType);
       });
 
       afterAll(async () => {
-        await imodelWithoutElements.imodelConnection.close();
-        await imodelWithoutDefContainers.imodelConnection.close();
-        await imodelWithDefContainersAndCategories.imodelConnection.close();
+        await datasets[Symbol.asyncDispose]();
       });
 
       describe("getDirectChildDefinitionContainersAndCategories", () => {
         it("returns empty list for empty definition containers", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(
             await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.emptyDefContainer.id] })),
           ).toEqual({
@@ -165,8 +64,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns empty list when child definition container is empty", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(
             await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.emptyParentDefContainer.id] })),
           ).toEqual({
@@ -176,8 +74,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns child non empty definition container", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(
             await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.parentDefContainer.id] })),
           ).toEqual({
@@ -195,8 +92,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns child definition container when it has empty category and includeEmpty is true", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(
             await firstValueFrom(
               idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.parentDefContainer.id], includeEmpty: true }),
@@ -208,8 +104,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns empty when child definition container has empty category and includeEmpty is false", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(
             await firstValueFrom(
               idsCache.getDirectChildDefinitionContainersAndCategories({
@@ -224,8 +119,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns child categories when definition container contains categories", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(
             await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.childDefContainer.id] })),
           ).toEqual({
@@ -243,8 +137,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns children without elements when includeEmpty is true", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(
             await firstValueFrom(
               idsCache.getDirectChildDefinitionContainersAndCategories({
@@ -267,8 +160,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns empty when no elements exist", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(
             await firstValueFrom(
               idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.defContainerOfCategories.id] }),
@@ -280,8 +172,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns only children which contain elements", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(
             await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.parentDefContainer.id] })),
           ).toEqual({
@@ -299,8 +190,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns children when definition container has parent", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(
             await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.childDefContainer.id] })),
           ).toEqual({
@@ -320,14 +210,12 @@ describe("CategoriesTreeIdsCache", () => {
 
       describe("getAllContainedCategories", () => {
         it("returns empty list when definition container is empty", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.emptyDefContainer.id] }))).toEqual([]);
         });
 
         it("returns empty child categories", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.defContainerOfCategories.id] }))).toEqual([
             {
               hasElements: false,
@@ -340,8 +228,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns direct and indirect child categories", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.parentDefContainer.id] }))).toEqual([
             {
               hasElements: true,
@@ -361,8 +248,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns direct child categories", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.childDefContainer.id] }))).toEqual([
             {
               hasElements: true,
@@ -377,13 +263,12 @@ describe("CategoriesTreeIdsCache", () => {
 
       describe("getSubCategoriesSearchPaths", () => {
         it("returns empty list when subcategory doesn't exist", async () => {
-          const idsCache = cacheForIModelWithoutElements;
+          const { idsCache } = datasets.withoutElements;
           expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: "0x123" }))).toEqual([]);
         });
 
         it("returns path to existing subCategory", async () => {
-          const keys = imodelWithoutDefContainers;
-          const idsCache = cacheForIModelWithoutDefContainers;
+          const { keys, idsCache } = datasets.withoutDefContainers;
           expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: keys.subCategory.id }))).toEqual([
             keys.categoryWithSubCategories,
             keys.subCategory,
@@ -391,8 +276,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns path to subCategory under definition container", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: keys.subCategory.id }))).toEqual([
             keys.parentDefContainer,
             keys.categoryUnderParentWithSubCategories,
@@ -401,8 +285,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns empty list when subCategory does not have siblings", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           const defaultSubCategory = getDefaultSubCategoryId(keys.categoryUnderChild.id);
           expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: defaultSubCategory }))).toEqual([]);
         });
@@ -410,13 +293,12 @@ describe("CategoriesTreeIdsCache", () => {
 
       describe("getSearchPathsUpToRootCategory", () => {
         it("returns empty list when category doesn't exist", async () => {
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { idsCache } = datasets.withDefContainersAndCategories;
           expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: "0x123" }))).toEqual([]);
         });
 
         it("returns empty list when category does not have definition container", async () => {
-          const keys = imodelWithoutDefContainers;
-          const idsCache = cacheForIModelWithoutDefContainers;
+          const { keys, idsCache } = datasets.withoutDefContainers;
           expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[]]);
         });
 
@@ -450,16 +332,14 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns path up to category it has definition container", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.categoryUnderParentWithSubCategories.id }))).toEqual([
             [keys.parentDefContainer],
           ]);
         });
 
         it("returns path up to nested category", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.categoryUnderChild.id }))).toEqual([
             [keys.parentDefContainer, keys.childDefContainer],
           ]);
@@ -468,21 +348,19 @@ describe("CategoriesTreeIdsCache", () => {
 
       describe("getDefinitionContainersSearchPaths", () => {
         it("returns empty list when definition container doesn't exist", async () => {
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { idsCache } = datasets.withDefContainersAndCategories;
           expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: "0x123" }))).toEqual([]);
         });
 
         it("returns definition container it has elements", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: keys.parentDefContainer.id }))).toEqual([
             keys.parentDefContainer,
           ]);
         });
 
         it("returns path to definition container when it has parent", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: keys.childDefContainer.id }))).toEqual([
             keys.parentDefContainer,
             keys.childDefContainer,
@@ -503,13 +381,12 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns empty list when no elements exist", async () => {
-          const idsCache = cacheForIModelWithoutElements;
+          const { idsCache } = datasets.withoutElements;
           expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({ categories: [], definitionContainers: [] });
         });
 
         it("returns categories and definition containers when no elements exist and includeEmpty is set to true", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories({ includeEmpty: true }));
           expect(result.categories).toHaveLength(2);
           expect(result.categories).toEqual(expect.arrayContaining([keys.categoryOfDefContainer.id, keys.emptyCategory.id]));
@@ -518,8 +395,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns categories and definition containers which have elements", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories());
           expect(result.categories).toHaveLength(2);
           expect(result.categories).toEqual(expect.arrayContaining([keys.categoryUnderChild.id, keys.categoryUnderParentWithSubCategories.id]));
@@ -528,8 +404,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns categories when no definition containers exist", async () => {
-          const keys = imodelWithoutDefContainers;
-          const idsCache = cacheForIModelWithoutDefContainers;
+          const { keys, idsCache } = datasets.withoutDefContainers;
           const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories());
           expect(result.categories).toHaveLength(2);
           expect(result.categories).toEqual(expect.arrayContaining([keys.category.id, keys.categoryWithSubCategories.id]));
@@ -553,7 +428,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns empty list when no elements exist", async () => {
-          const idsCache = cacheForIModelWithoutElements;
+          const { idsCache } = datasets.withoutElements;
           expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
             categories: [],
             definitionContainers: [],
@@ -561,8 +436,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns root categories and definition containers when no elements exist and includeEmpty is set to true", async () => {
-          const keys = imodelWithoutElements;
-          const idsCache = cacheForIModelWithoutElements;
+          const { keys, idsCache } = datasets.withoutElements;
           expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories({ includeEmpty: true }))).toEqual({
             categories: [
               {
@@ -578,8 +452,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns root categories", async () => {
-          const keys = imodelWithoutDefContainers;
-          const idsCache = cacheForIModelWithoutDefContainers;
+          const { keys, idsCache } = datasets.withoutDefContainers;
 
           const result = await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories());
           expect(result.categories).toHaveLength(2);
@@ -599,8 +472,7 @@ describe("CategoriesTreeIdsCache", () => {
         });
 
         it("returns root definition containers", async () => {
-          const keys = imodelWithDefContainersAndCategories;
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { keys, idsCache } = datasets.withDefContainersAndCategories;
           expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
             categories: [],
             definitionContainers: [keys.parentDefContainer.id],
@@ -610,19 +482,17 @@ describe("CategoriesTreeIdsCache", () => {
 
       describe("getSubCategories", () => {
         it("returns empty list when category doesn't exist", async () => {
-          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const { idsCache } = datasets.withDefContainersAndCategories;
           expect(await firstValueFrom(idsCache.getSubCategories({ categoryId: "0x123" }))).toEqual([]);
         });
 
         it("returns sub-category when category has one sub-category", async () => {
-          const keys = imodelWithoutDefContainers;
-          const idsCache = cacheForIModelWithoutDefContainers;
+          const { keys, idsCache } = datasets.withoutDefContainers;
           expect(await firstValueFrom(idsCache.getSubCategories({ categoryId: keys.category.id }))).toEqual([getDefaultSubCategoryId(keys.category.id)]);
         });
 
         it("returns sub-categories when category has multiple sub-categories", async () => {
-          const keys = imodelWithoutDefContainers;
-          const idsCache = cacheForIModelWithoutDefContainers;
+          const { keys, idsCache } = datasets.withoutDefContainers;
           const result = await firstValueFrom(idsCache.getSubCategories({ categoryId: keys.categoryWithSubCategories.id }));
           expect(result.includes(keys.subCategory.id)).toBe(true);
           expect(result.length).toBe(2);
@@ -631,3 +501,100 @@ describe("CategoriesTreeIdsCache", () => {
     });
   });
 });
+
+async function createDatasets(viewType: "2d" | "3d") {
+  const imodels: IModelConnection[] = [];
+  const { insertElementsModel, insertCategory, insertElement } = getInsertFunctionByViewType(viewType);
+
+  return {
+    [Symbol.asyncDispose]: async () => Promise.all(imodels.map(async (imodel) => imodel.close())),
+    ["withoutElements"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          const emptyDefContainer = insertDefinitionContainer({ txn, codeValue: "Empty dc" });
+          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyDefContainer.id });
+          const emptyParentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc" });
+          const emptyParentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyParentDefContainer.id });
+          const childDefContainer = insertDefinitionContainer({ txn, codeValue: "Child dc", modelId: emptyParentDefModel.id });
+          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefContainer.id });
+          const parentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc with cat" });
+          const parentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefContainer.id });
+          const defContainerOfCategories = insertDefinitionContainer({ txn, codeValue: "Categories dc", modelId: parentDefModel.id });
+          const defModelOfCategories = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: defContainerOfCategories.id });
+          const categoryOfDefContainer = insertCategory({ txn, codeValue: "cat of child", modelId: defModelOfCategories.id });
+          const emptyCategory = insertCategory({ txn, codeValue: "Empty cat" });
+
+          return {
+            emptyDefContainer,
+            emptyParentDefContainer,
+            childDefContainer,
+            defContainerOfCategories,
+            parentDefContainer,
+            categoryOfDefContainer,
+            emptyCategory,
+          };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+    ["withoutDefContainers"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          const category = insertCategory({ txn, codeValue: "cat" });
+          const categoryWithSubCategories = insertCategory({ txn, codeValue: "cat with subCategories" });
+          const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+          const element1 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+          const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryWithSubCategories.id });
+          const subCategory = insertSubCategory({ txn, parentCategoryId: categoryWithSubCategories.id, codeValue: "subCat" });
+
+          return {
+            category,
+            categoryWithSubCategories,
+            subCategory,
+            element1,
+            element2,
+          };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+    ["withDefContainersAndCategories"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          const parentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc" });
+          const parentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefContainer.id });
+          const childDefContainer = insertDefinitionContainer({ txn, codeValue: "Child dc", modelId: parentDefModel.id });
+          const childDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefContainer.id });
+          const emptyChildDefContainer = insertDefinitionContainer({ txn, codeValue: "empty dc", modelId: parentDefModel.id });
+          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyChildDefContainer.id });
+          const categoryUnderChild = insertCategory({ txn, codeValue: "cat", modelId: childDefModel.id });
+          const categoryUnderParentWithSubCategories = insertCategory({ txn, codeValue: "cat with subCategories", modelId: parentDefModel.id });
+          const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+          const element1 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryUnderChild.id });
+          const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryUnderParentWithSubCategories.id });
+          const subCategory = insertSubCategory({
+            txn,
+            parentCategoryId: categoryUnderParentWithSubCategories.id,
+            codeValue: "subCat",
+            modelId: parentDefModel.id,
+          });
+
+          return {
+            parentDefContainer,
+            childDefContainer,
+            emptyChildDefContainer,
+            categoryUnderChild,
+            categoryUnderParentWithSubCategories,
+            subCategory,
+            element1,
+            element2,
+          };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+  };
+}

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
@@ -4,31 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { firstValueFrom } from "rxjs";
-import {
-  HierarchyCacheMode,
-  initializeCore,
-  insertDefinitionContainer,
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertPhysicalSubModel,
-  insertSpatialCategory,
-  insertSubCategory,
-  insertSubModel,
-  terminateCore,
-} from "test-utilities";
+import { HierarchyCacheMode, initializeCore, insertDefinitionContainer, insertSubCategory, insertSubModel, terminateCore } from "test-utilities";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { withEditTxn } from "@itwin/core-backend";
 import { IModelReadRpcInterface } from "@itwin/core-common";
 import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
-import { BaseIdsCache } from "../../../../tree-widget-react/shared/internal/caches/BaseIdsCache.js";
+import { CLASS_NAME_DefinitionModel } from "../../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
 import { collect } from "../../../../tree-widget-react/shared/internal/Rxjs.js";
-import { getClassesByView } from "../../../../tree-widget-react/shared/internal/Utils.js";
-import { CategoriesTreeIdsCache } from "../../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 import { buildIModel } from "../../../IModelUtils.js";
-import { createIModelAccess } from "../../Common.js";
-import { CLASS_NAME_DefinitionModel, getDefaultSubCategoryId } from "../../TreeUtils.js";
+import { getDefaultSubCategoryId } from "../../TreeUtils.js";
+import { createAccessAndCache, getInsertFunctionByViewType } from "./Utils.js";
+
+import type { CategoriesTreeIdsCache } from "../../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 
 describe("CategoriesTreeIdsCache", () => {
   beforeAll(async () => {
@@ -51,1162 +40,589 @@ describe("CategoriesTreeIdsCache", () => {
     await terminateCore();
   });
 
-  describe("getDirectChildDefinitionContainersAndCategories", () => {
-    it("returns empty list when definition container contains nothing", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainer.id] })),
-      ).toEqual({
-        categories: [],
-        definitionContainers: [],
-      });
-    });
+  ["2d" as const, "3d" as const].forEach((viewType) => {
+    const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
+    describe(`${viewType} view`, () => {
+      let imodelWithoutElements: Awaited<ReturnType<typeof createIModelWithoutElements>>;
+      let imodelWithoutDefContainers: Awaited<ReturnType<typeof createIModelWithoutDefContainers>>;
+      let imodelWithDefContainersAndCategories: Awaited<ReturnType<typeof createIModelWithDefContainersAndCategories>>;
+      let cacheForIModelWithoutElements: CategoriesTreeIdsCache;
+      let cacheForIModelWithoutDefContainers: CategoriesTreeIdsCache;
+      let cacheForIModelWithDefContainersAndCategories: CategoriesTreeIdsCache;
+      async function createIModelWithoutElements() {
+        return buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const emptyDefContainer = insertDefinitionContainer({ txn, codeValue: "Empty dc" });
+            insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyDefContainer.id });
+            const emptyParentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc" });
+            const emptyParentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyParentDefContainer.id });
+            const childDefContainer = insertDefinitionContainer({ txn, codeValue: "Child dc", modelId: emptyParentDefModel.id });
+            insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefContainer.id });
+            const parentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc with cat" });
+            const parentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefContainer.id });
+            const defContainerOfCategories = insertDefinitionContainer({ txn, codeValue: "Categories dc", modelId: parentDefModel.id });
+            const defModelOfCategories = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: defContainerOfCategories.id });
+            const categoryOfDefContainer = insertCategory({ txn, codeValue: "cat of child", modelId: defModelOfCategories.id });
+            const emptyCategory = insertCategory({ txn, codeValue: "Empty cat" });
 
-    it("returns empty lists when definition container contains empty definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          return { definitionContainerRoot };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
-      ).toEqual({
-        categories: [],
-        definitionContainers: [],
-      });
-    });
-
-    it("returns child definition container when definition container contains definition container, that has categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot, definitionContainerChild };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
-      ).toEqual({
-        categories: [],
-        definitionContainers: [keys.definitionContainerChild.id],
-      });
-    });
-
-    it("returns child definition container when definition container contains definition container, that has empty categories and includeEmpty is true", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainerChild.id });
-          insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          return { definitionContainerRoot, definitionContainerChild };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(
-          idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id], includeEmpty: true }),
-        ),
-      ).toEqual({
-        categories: [],
-        definitionContainers: [keys.definitionContainerChild.id],
-      });
-    });
-
-    it("returns empty when definition container contains definition container, that has empty categories and includeEmpty is false", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainerChild.id });
-          insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          return { definitionContainerRoot, definitionContainerChild };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(
-          idsCache.getDirectChildDefinitionContainersAndCategories({
-            parentDefinitionContainerIds: [keys.definitionContainerRoot.id],
-            includeEmpty: false,
+            return {
+              emptyDefContainer,
+              emptyParentDefContainer,
+              childDefContainer,
+              defContainerOfCategories,
+              parentDefContainer,
+              categoryOfDefContainer,
+              emptyCategory,
+            };
           }),
-        ),
-      ).toEqual({
-        categories: [],
-        definitionContainers: [],
+        );
+      }
+
+      async function createIModelWithoutDefContainers() {
+        return buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const category = insertCategory({ txn, codeValue: "cat" });
+            const categoryWithSubCategories = insertCategory({ txn, codeValue: "cat with subCategories" });
+            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+            const element1 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryWithSubCategories.id });
+            const subCategory = insertSubCategory({ txn, parentCategoryId: categoryWithSubCategories.id, codeValue: "subCat" });
+
+            return {
+              category,
+              categoryWithSubCategories,
+              subCategory,
+              element1,
+              element2,
+            };
+          }),
+        );
+      }
+
+      async function createIModelWithDefContainersAndCategories() {
+        return buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const parentDefContainer = insertDefinitionContainer({ txn, codeValue: "Parent dc" });
+            const parentDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefContainer.id });
+            const childDefContainer = insertDefinitionContainer({ txn, codeValue: "Child dc", modelId: parentDefModel.id });
+            const childDefModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefContainer.id });
+            const emptyChildDefContainer = insertDefinitionContainer({ txn, codeValue: "empty dc", modelId: parentDefModel.id });
+            insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: emptyChildDefContainer.id });
+            const categoryUnderChild = insertCategory({ txn, codeValue: "cat", modelId: childDefModel.id });
+            const categoryUnderParentWithSubCategories = insertCategory({ txn, codeValue: "cat with subCategories", modelId: parentDefModel.id });
+            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+            const element1 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryUnderChild.id });
+            const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryUnderParentWithSubCategories.id });
+            const subCategory = insertSubCategory({
+              txn,
+              parentCategoryId: categoryUnderParentWithSubCategories.id,
+              codeValue: "subCat",
+              modelId: parentDefModel.id,
+            });
+
+            return {
+              parentDefContainer,
+              childDefContainer,
+              emptyChildDefContainer,
+              categoryUnderChild,
+              categoryUnderParentWithSubCategories,
+              subCategory,
+              element1,
+              element2,
+            };
+          }),
+        );
+      }
+
+      beforeAll(async () => {
+        imodelWithoutElements = await createIModelWithoutElements();
+        cacheForIModelWithoutElements = createAccessAndCache({ imodelConnection: imodelWithoutElements.imodelConnection, viewType }).idsCache;
+        imodelWithoutDefContainers = await createIModelWithoutDefContainers();
+        cacheForIModelWithoutDefContainers = createAccessAndCache({ imodelConnection: imodelWithoutDefContainers.imodelConnection, viewType }).idsCache;
+        imodelWithDefContainersAndCategories = await createIModelWithDefContainersAndCategories();
+        cacheForIModelWithDefContainersAndCategories = createAccessAndCache({
+          imodelConnection: imodelWithDefContainersAndCategories.imodelConnection,
+          viewType,
+        }).idsCache;
       });
-    });
 
-    it("returns child categories when definition container contains categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
-      ).toEqual({
-        categories: [
-          { id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true, hasElementsFromNonExcludedClasses: true },
-        ],
-        definitionContainers: [],
+      afterAll(async () => {
+        await imodelWithoutElements.imodelConnection.close();
+        await imodelWithoutDefContainers.imodelConnection.close();
+        await imodelWithDefContainersAndCategories.imodelConnection.close();
       });
-    });
 
-    it("returns child categories when definition container contains empty categories and includeEmpty is true", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainerRoot.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          return { definitionContainerRoot, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(
-          idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id], includeEmpty: true }),
-        ),
-      ).toEqual({
-        categories: [
-          {
-            id: keys.category.id,
-            subCategoryChildCount: 1,
-            isTopMostElementCategory: false,
-            hasElements: false,
-            hasElementsFromNonExcludedClasses: false,
-          },
-        ],
-        definitionContainers: [],
-      });
-    });
-
-    it("returns empty when definition container contains empty categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainerRoot.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          return { definitionContainerRoot, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
-      ).toEqual({
-        categories: [],
-        definitionContainers: [],
-      });
-    });
-
-    it("returns only categories when definition container contains categories and definition containers that contain nothing", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
-      ).toEqual({
-        categories: [
-          { id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true, hasElementsFromNonExcludedClasses: true },
-        ],
-        definitionContainers: [],
-      });
-    });
-
-    it("returns child definition container and category when definition container contains categories and definition containers that contain categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const directCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const indirectCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-          return { definitionContainerRoot, directCategory, definitionModelChild };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionContainerRoot.id] })),
-      ).toEqual({
-        categories: [
-          {
-            id: keys.directCategory.id,
-            subCategoryChildCount: 1,
-            isTopMostElementCategory: true,
-            hasElements: true,
-            hasElementsFromNonExcludedClasses: true,
-          },
-        ],
-        definitionContainers: [keys.definitionModelChild.id],
-      });
-    });
-
-    it("returns child categories when definition container with categories is contained by definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const indirectCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-          return { definitionModelChild, indirectCategory };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(
-        await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.definitionModelChild.id] })),
-      ).toEqual({
-        categories: [
-          {
-            id: keys.indirectCategory.id,
-            subCategoryChildCount: 1,
-            isTopMostElementCategory: true,
-            hasElements: true,
-            hasElementsFromNonExcludedClasses: true,
-          },
-        ],
-        definitionContainers: [],
-      });
-    });
-  });
-
-  describe("getAllContainedCategories", () => {
-    it("returns empty list when definition container contains nothing", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          return { definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual([]);
-    });
-
-    it("returns empty categories when definition container contains them", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          return { definitionContainer, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual([
-        {
-          hasElements: false,
-          id: keys.category.id,
-          isTopMostElementCategory: false,
-          subCategoryChildCount: 1,
-          hasElementsFromNonExcludedClasses: false,
-        },
-      ]);
-    });
-
-    it("returns indirectly contained categories when definition container contains definition container that has categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainerRoot.id] }))).toEqual([
-        {
-          hasElements: true,
-          id: keys.category.id,
-          isTopMostElementCategory: true,
-          subCategoryChildCount: 1,
-          hasElementsFromNonExcludedClasses: true,
-        },
-      ]);
-    });
-
-    it("returns child categories when definition container contains categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainer, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainer.id] }))).toEqual([
-        {
-          hasElements: true,
-          id: keys.category.id,
-          isTopMostElementCategory: true,
-          subCategoryChildCount: 1,
-          hasElementsFromNonExcludedClasses: true,
-        },
-      ]);
-    });
-
-    it("returns direct and indirect categories when definition container contains categories and definition containers that contain categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const directCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const indirectCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-          return { definitionContainerRoot, directCategory, indirectCategory };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const result = await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.definitionContainerRoot.id] }));
-      const expectedResult = [keys.indirectCategory.id, keys.directCategory.id];
-      expect(expectedResult.every((id) => result.some(({ id: categoryId }) => categoryId === id))).toBe(true);
-    });
-  });
-
-  describe("getSubCategoriesSearchPaths", () => {
-    it("returns empty list when subcategory doesn't exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: "0x123" }))).toEqual([]);
-    });
-
-    it("returns path to subCategory when category has subCategory", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test SpatialSubCategory" });
-          return { subCategory, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: keys.subCategory.id }))).toEqual([keys.category, keys.subCategory]);
-    });
-
-    it("returns path to subCategory when definition container contains category that has subCategory", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "Test SpatialSubCategory", modelId: definitionModel.id });
-          return { subCategory, category, definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: keys.subCategory.id }))).toEqual([
-        keys.definitionContainer,
-        keys.category,
-        keys.subCategory,
-      ]);
-    });
-
-    it("returns path to subCategory when definition container contains definition container that contains category that has subCategory", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-
-          const subCategory = insertSubCategory({
-            txn,
-            parentCategoryId: category.id,
-            codeValue: "Test SpatialSubCategory",
-            modelId: definitionModelChild.id,
+      describe("getDirectChildDefinitionContainersAndCategories", () => {
+        it("returns empty list for empty definition containers", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(
+            await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.emptyDefContainer.id] })),
+          ).toEqual({
+            categories: [],
+            definitionContainers: [],
           });
-          return { subCategory, category, definitionContainerChild, definitionContainerRoot };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: keys.subCategory.id }))).toEqual([
-        keys.definitionContainerRoot,
-        keys.definitionContainerChild,
-        keys.category,
-        keys.subCategory,
-      ]);
-    });
-  });
+        });
 
-  describe("getSearchPathsUpToRootCategory", () => {
-    it("returns no paths when category doesn't exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: "0x123" }))).toEqual([]);
-    });
-
-    it("returns empty list when category does not have definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[]]);
-    });
-
-    it("returns up to category path when it exist under sub-model", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel, testSchema) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          const modeledElement = insertPhysicalElement({
-            txn,
-            categoryId: category.id,
-            classFullName: testSchema.items.SubModelablePhysicalObject.fullName,
-            modelId: physicalModel.id,
+        it("returns empty list when child definition container is empty", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(
+            await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.emptyParentDefContainer.id] })),
+          ).toEqual({
+            categories: [],
+            definitionContainers: [],
           });
-          const subModel = insertPhysicalSubModel({
-            txn,
-            modeledElementId: modeledElement.id,
+        });
+
+        it("returns child non empty definition container", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(
+            await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.parentDefContainer.id] })),
+          ).toEqual({
+            categories: [
+              {
+                id: keys.categoryUnderParentWithSubCategories.id,
+                subCategoryChildCount: 2,
+                isTopMostElementCategory: true,
+                hasElements: true,
+                hasElementsFromNonExcludedClasses: true,
+              },
+            ],
+            definitionContainers: [keys.childDefContainer.id],
           });
-          const elementOfSubModel = insertPhysicalElement({
-            txn,
-            categoryId: category.id,
-            modelId: subModel.id,
+        });
+
+        it("returns child definition container when it has empty category and includeEmpty is true", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(
+            await firstValueFrom(
+              idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.parentDefContainer.id], includeEmpty: true }),
+            ),
+          ).toEqual({
+            categories: [],
+            definitionContainers: [keys.defContainerOfCategories.id],
           });
-          return { category, definitionContainer, modeledElement, elementOfSubModel, subModel };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[keys.definitionContainer]]);
-    });
+        });
 
-    it("returns path up to category when definition container contains category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category, definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[keys.definitionContainer]]);
-    });
+        it("returns empty when child definition container has empty category and includeEmpty is false", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(
+            await firstValueFrom(
+              idsCache.getDirectChildDefinitionContainersAndCategories({
+                parentDefinitionContainerIds: [keys.parentDefContainer.id],
+                includeEmpty: false,
+              }),
+            ),
+          ).toEqual({
+            categories: [],
+            definitionContainers: [],
+          });
+        });
 
-    it("returns path up to category when definition container contains definition container that contains category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category, definitionContainerChild, definitionContainerRoot };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([
-        [keys.definitionContainerRoot, keys.definitionContainerChild],
-      ]);
-    });
-  });
+        it("returns child categories when definition container contains categories", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(
+            await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.childDefContainer.id] })),
+          ).toEqual({
+            categories: [
+              {
+                id: keys.categoryUnderChild.id,
+                subCategoryChildCount: 1,
+                isTopMostElementCategory: true,
+                hasElements: true,
+                hasElementsFromNonExcludedClasses: true,
+              },
+            ],
+            definitionContainers: [],
+          });
+        });
 
-  describe("getDefinitionContainersSearchPaths", () => {
-    it("returns empty list when definition container doesn't exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: "0x123" }))).toEqual([]);
-    });
+        it("returns children without elements when includeEmpty is true", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(
+            await firstValueFrom(
+              idsCache.getDirectChildDefinitionContainersAndCategories({
+                parentDefinitionContainerIds: [keys.defContainerOfCategories.id],
+                includeEmpty: true,
+              }),
+            ),
+          ).toEqual({
+            categories: [
+              {
+                id: keys.categoryOfDefContainer.id,
+                subCategoryChildCount: 1,
+                isTopMostElementCategory: false,
+                hasElements: false,
+                hasElementsFromNonExcludedClasses: false,
+              },
+            ],
+            definitionContainers: [],
+          });
+        });
 
-    it("returns definition container when definition container contains category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category, definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: keys.definitionContainer.id }))).toEqual([
-        keys.definitionContainer,
-      ]);
-    });
+        it("returns empty when no elements exist", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(
+            await firstValueFrom(
+              idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.defContainerOfCategories.id] }),
+            ),
+          ).toEqual({
+            categories: [],
+            definitionContainers: [],
+          });
+        });
 
-    it("returns path to definition container when definition container is contained by definition container", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category, definitionContainerChild, definitionContainerRoot };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: keys.definitionContainerChild.id }))).toEqual([
-        keys.definitionContainerRoot,
-        keys.definitionContainerChild,
-      ]);
-    });
-  });
+        it("returns only children which contain elements", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(
+            await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.parentDefContainer.id] })),
+          ).toEqual({
+            categories: [
+              {
+                id: keys.categoryUnderParentWithSubCategories.id,
+                subCategoryChildCount: 2,
+                isTopMostElementCategory: true,
+                hasElements: true,
+                hasElementsFromNonExcludedClasses: true,
+              },
+            ],
+            definitionContainers: [keys.childDefContainer.id],
+          });
+        });
 
-  describe("getAllDefinitionContainersAndCategories", () => {
-    it("returns empty list when no categories or definition containers exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({ categories: [], definitionContainers: [] });
-    });
-
-    it("returns empty list when only empty categories exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({ categories: [], definitionContainers: [] });
-    });
-
-    it("returns empty categories and their definitionContainers when includeEmpty is set to true", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          return { category, definitionContainer };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories({ includeEmpty: true }))).toEqual({
-        categories: [keys.category.id],
-        definitionContainers: [keys.definitionContainer.id],
+        it("returns children when definition container has parent", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(
+            await firstValueFrom(idsCache.getDirectChildDefinitionContainersAndCategories({ parentDefinitionContainerIds: [keys.childDefContainer.id] })),
+          ).toEqual({
+            categories: [
+              {
+                id: keys.categoryUnderChild.id,
+                subCategoryChildCount: 1,
+                isTopMostElementCategory: true,
+                hasElements: true,
+                hasElementsFromNonExcludedClasses: true,
+              },
+            ],
+            definitionContainers: [],
+          });
+        });
       });
-    });
 
-    it("returns category when only category and empty definition container exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
-        categories: [keys.category.id],
-        definitionContainers: [],
+      describe("getAllContainedCategories", () => {
+        it("returns empty list when definition container is empty", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.emptyDefContainer.id] }))).toEqual([]);
+        });
+
+        it("returns empty child categories", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.defContainerOfCategories.id] }))).toEqual([
+            {
+              hasElements: false,
+              id: keys.categoryOfDefContainer.id,
+              isTopMostElementCategory: false,
+              subCategoryChildCount: 1,
+              hasElementsFromNonExcludedClasses: false,
+            },
+          ]);
+        });
+
+        it("returns direct and indirect child categories", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.parentDefContainer.id] }))).toEqual([
+            {
+              hasElements: true,
+              id: keys.categoryUnderChild.id,
+              isTopMostElementCategory: true,
+              subCategoryChildCount: 1,
+              hasElementsFromNonExcludedClasses: true,
+            },
+            {
+              hasElements: true,
+              id: keys.categoryUnderParentWithSubCategories.id,
+              isTopMostElementCategory: true,
+              subCategoryChildCount: 2,
+              hasElementsFromNonExcludedClasses: true,
+            },
+          ]);
+        });
+
+        it("returns direct child categories", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await collect(idsCache.getAllContainedCategories({ definitionContainerIds: [keys.childDefContainer.id] }))).toEqual([
+            {
+              hasElements: true,
+              id: keys.categoryUnderChild.id,
+              isTopMostElementCategory: true,
+              subCategoryChildCount: 1,
+              hasElementsFromNonExcludedClasses: true,
+            },
+          ]);
+        });
       });
-    });
 
-    it("returns category when category and definition containers (that don't contain categories) exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
-        categories: [keys.category.id],
-        definitionContainers: [],
+      describe("getSubCategoriesSearchPaths", () => {
+        it("returns empty list when subcategory doesn't exist", async () => {
+          const idsCache = cacheForIModelWithoutElements;
+          expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: "0x123" }))).toEqual([]);
+        });
+
+        it("returns path to existing subCategory", async () => {
+          const keys = imodelWithoutDefContainers;
+          const idsCache = cacheForIModelWithoutDefContainers;
+          expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: keys.subCategory.id }))).toEqual([
+            keys.categoryWithSubCategories,
+            keys.subCategory,
+          ]);
+        });
+
+        it("returns path to subCategory under definition container", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: keys.subCategory.id }))).toEqual([
+            keys.parentDefContainer,
+            keys.categoryUnderParentWithSubCategories,
+            keys.subCategory,
+          ]);
+        });
+
+        it("returns empty list when subCategory does not have siblings", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          const defaultSubCategory = getDefaultSubCategoryId(keys.categoryUnderChild.id);
+          expect(await firstValueFrom(idsCache.getSubCategoriesSearchPaths({ subCategoryIds: defaultSubCategory }))).toEqual([]);
+        });
       });
-    });
 
-    it("returns both definition containers and their contained category when definition container contains definition container that contains categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot, definitionContainerChild, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories());
-      const expectedResult = {
-        categories: [keys.category.id],
-        definitionContainers: [keys.definitionContainerRoot.id, keys.definitionContainerChild.id],
-      };
-      expect(result.categories).toEqual(expectedResult.categories);
-      expect(expectedResult.definitionContainers.every((dc) => result.definitionContainers.includes(dc))).toBe(true);
-    });
+      describe("getSearchPathsUpToRootCategory", () => {
+        it("returns empty list when category doesn't exist", async () => {
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: "0x123" }))).toEqual([]);
+        });
 
-    it("returns definition container and category when definition container contains category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
-        categories: [keys.category.id],
-        definitionContainers: [keys.definitionContainerRoot.id],
+        it("returns empty list when category does not have definition container", async () => {
+          const keys = imodelWithoutDefContainers;
+          const idsCache = cacheForIModelWithoutDefContainers;
+          expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[]]);
+        });
+
+        it("returns up to category path when it exist under sub-model", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+              const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+              const modeledElement = insertModeledElement({
+                txn,
+                categoryId: category.id,
+                modelId: elementsModel.id,
+              });
+              const subModel = insertElementsSubModel({
+                txn,
+                modeledElementId: modeledElement.id,
+              });
+              const elementOfSubModel = insertElement({
+                txn,
+                categoryId: category.id,
+                modelId: subModel.id,
+              });
+              return { category, definitionContainer, modeledElement, elementOfSubModel, subModel };
+            }),
+          );
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const accessAndCache = createAccessAndCache({ imodelConnection, viewType });
+          expect(await collect(accessAndCache.idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.category.id }))).toEqual([[keys.definitionContainer]]);
+        });
+
+        it("returns path up to category it has definition container", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.categoryUnderParentWithSubCategories.id }))).toEqual([
+            [keys.parentDefContainer],
+          ]);
+        });
+
+        it("returns path up to nested category", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await collect(idsCache.getSearchPathsUpToRootCategory({ categoryId: keys.categoryUnderChild.id }))).toEqual([
+            [keys.parentDefContainer, keys.childDefContainer],
+          ]);
+        });
       });
-    });
 
-    it("returns definition container and category when definition container contains category and definition container that doesn't contain category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
-        categories: [keys.category.id],
-        definitionContainers: [keys.definitionContainerRoot.id],
+      describe("getDefinitionContainersSearchPaths", () => {
+        it("returns empty list when definition container doesn't exist", async () => {
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: "0x123" }))).toEqual([]);
+        });
+
+        it("returns definition container it has elements", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: keys.parentDefContainer.id }))).toEqual([
+            keys.parentDefContainer,
+          ]);
+        });
+
+        it("returns path to definition container when it has parent", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await firstValueFrom(idsCache.getDefinitionContainersSearchPaths({ definitionContainerIds: keys.childDefContainer.id }))).toEqual([
+            keys.parentDefContainer,
+            keys.childDefContainer,
+          ]);
+        });
       });
-    });
 
-    it("returns both definition containers and categories when definition container contains categories and definition container that contain categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const directCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
+      describe("getAllDefinitionContainersAndCategories", () => {
+        it("returns empty list when no categories or definition containers exist", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              insertElementsModel({ txn, codeValue: "m" });
+            }),
+          );
+          const { imodelConnection } = buildIModelResult;
+          const accessAndCache = createAccessAndCache({ imodelConnection, viewType });
+          expect(await firstValueFrom(accessAndCache.idsCache.getAllDefinitionContainersAndCategories())).toEqual({ categories: [], definitionContainers: [] });
+        });
 
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const indirectCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
+        it("returns empty list when no elements exist", async () => {
+          const idsCache = cacheForIModelWithoutElements;
+          expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({ categories: [], definitionContainers: [] });
+        });
 
-          return { definitionContainerRoot, directCategory, definitionModelChild, indirectCategory };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories());
-      const expectedResult = {
-        categories: [keys.directCategory.id, keys.indirectCategory.id],
-        definitionContainers: [keys.definitionModelChild.id, keys.definitionContainerRoot.id],
-      };
-      expect(expectedResult.categories.every((c) => result.categories.includes(c))).toBe(true);
-      expect(expectedResult.definitionContainers.every((dc) => result.definitionContainers.includes(dc))).toBe(true);
-    });
-  });
+        it("returns categories and definition containers when no elements exist and includeEmpty is set to true", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories({ includeEmpty: true }))).toEqual({
+            categories: [keys.categoryOfDefContainer.id, keys.emptyCategory.id],
+            definitionContainers: [keys.defContainerOfCategories.id, keys.parentDefContainer.id],
+          });
+        });
 
-  describe("getRootDefinitionContainersAndCategories", () => {
-    it("returns empty list when no categories or definition containers exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({ categories: [], definitionContainers: [] });
-    });
+        it("returns categories and definition containers which have elements", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
+            categories: [keys.categoryUnderChild.id, keys.categoryUnderParentWithSubCategories.id],
+            definitionContainers: [keys.childDefContainer.id, keys.parentDefContainer.id],
+          });
+        });
 
-    it("returns empty list when only empty categories exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          insertSpatialCategory({ txn, codeValue: "Root SpatialCategory" });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-        categories: [],
-        definitionContainers: [],
+        it("returns categories when no definition containers exist", async () => {
+          const keys = imodelWithoutDefContainers;
+          const idsCache = cacheForIModelWithoutDefContainers;
+          expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
+            categories: [keys.category.id, keys.categoryWithSubCategories.id],
+            definitionContainers: [],
+          });
+        });
       });
-    });
 
-    it("returns empty categories and definition containers when only `includeEmpty` is set to true", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: "BisCore.DefinitionModel", modeledElementId: definitionContainer.id });
-          insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModel.id });
-          const rootCategory = insertSpatialCategory({ txn, codeValue: "Root SpatialCategory" });
-          return { definitionContainer, rootCategory };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories({ includeEmpty: true }))).toEqual({
-        categories: [
-          {
-            id: keys.rootCategory.id,
-            subCategoryChildCount: 1,
-            isTopMostElementCategory: false,
-            hasElements: false,
-            hasElementsFromNonExcludedClasses: false,
-          },
-        ],
-        definitionContainers: [keys.definitionContainer.id],
+      describe("getRootDefinitionContainersAndCategories", () => {
+        it("returns empty list when no categories or definition containers exist", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              insertElementsModel({ txn, codeValue: "m" });
+            }),
+          );
+          const { imodelConnection } = buildIModelResult;
+          const accessAndCache = createAccessAndCache({ imodelConnection, viewType });
+          expect(await firstValueFrom(accessAndCache.idsCache.getRootDefinitionContainersAndCategories())).toEqual({
+            categories: [],
+            definitionContainers: [],
+          });
+        });
+
+        it("returns empty list when no elements exist", async () => {
+          const idsCache = cacheForIModelWithoutElements;
+          expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
+            categories: [],
+            definitionContainers: [],
+          });
+        });
+
+        it("returns root categories and definition containers when no elements exist and includeEmpty is set to true", async () => {
+          const keys = imodelWithoutElements;
+          const idsCache = cacheForIModelWithoutElements;
+          expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories({ includeEmpty: true }))).toEqual({
+            categories: [
+              {
+                id: keys.emptyCategory.id,
+                subCategoryChildCount: 1,
+                isTopMostElementCategory: false,
+                hasElements: false,
+                hasElementsFromNonExcludedClasses: false,
+              },
+            ],
+            definitionContainers: [keys.parentDefContainer.id],
+          });
+        });
+
+        it("returns root categories", async () => {
+          const keys = imodelWithoutDefContainers;
+          const idsCache = cacheForIModelWithoutDefContainers;
+          expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
+            categories: [
+              { id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true, hasElementsFromNonExcludedClasses: true },
+              {
+                id: keys.categoryWithSubCategories.id,
+                subCategoryChildCount: 2,
+                isTopMostElementCategory: true,
+                hasElements: true,
+                hasElementsFromNonExcludedClasses: true,
+              },
+            ],
+            definitionContainers: [],
+          });
+        });
+
+        it("returns root definition containers", async () => {
+          const keys = imodelWithDefContainersAndCategories;
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
+            categories: [],
+            definitionContainers: [keys.parentDefContainer.id],
+          });
+        });
       });
-    });
 
-    it("returns category when category and definition container that doesn't contain anything exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-        categories: [
-          { id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true, hasElementsFromNonExcludedClasses: true },
-        ],
-        definitionContainers: [],
+      describe("getSubCategories", () => {
+        it("returns empty list when category doesn't exist", async () => {
+          const idsCache = cacheForIModelWithDefContainersAndCategories;
+          expect(await firstValueFrom(idsCache.getSubCategories({ categoryId: "0x123" }))).toEqual([]);
+        });
+
+        it("returns sub-category when category has one sub-category", async () => {
+          const keys = imodelWithoutDefContainers;
+          const idsCache = cacheForIModelWithoutDefContainers;
+          expect(await firstValueFrom(idsCache.getSubCategories({ categoryId: keys.category.id }))).toEqual([getDefaultSubCategoryId(keys.category.id)]);
+        });
+
+        it("returns sub-categories when category has multiple sub-categories", async () => {
+          const keys = imodelWithoutDefContainers;
+          const idsCache = cacheForIModelWithoutDefContainers;
+          const result = await firstValueFrom(idsCache.getSubCategories({ categoryId: keys.categoryWithSubCategories.id }));
+          expect(result.includes(keys.subCategory.id)).toBe(true);
+          expect(result.length).toBe(2);
+        });
       });
-    });
-
-    it("returns category when category and definition container that contains empty definition container exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-        categories: [
-          { id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true, hasElementsFromNonExcludedClasses: true },
-        ],
-        definitionContainers: [],
-      });
-    });
-
-    it("returns only the root definition container when definition container contains definition container that contains categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer", modelId: definitionModelRoot.id });
-          const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelChild.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-        categories: [],
-        definitionContainers: [keys.definitionContainerRoot.id],
-      });
-    });
-
-    it("returns definition container when definition container contains category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { definitionContainerRoot };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-        categories: [],
-        definitionContainers: [keys.definitionContainerRoot.id],
-      });
-    });
-
-    it("returns root categories and definition containers when root categories and definition containers exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer" });
-          const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-          const definitionContainerRootNoChildren = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainerNoChild" });
-          insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRootNoChildren.id });
-
-          const definitionContainerRoot2 = insertDefinitionContainer({ txn, codeValue: "Test DefinitionContainer2" });
-          const definitionModelRoot2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot2.id });
-
-          const rootCategory1 = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: rootCategory1.id });
-          const rootCategory2 = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory2" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: rootCategory2.id });
-
-          const childCategory = insertSpatialCategory({ txn, codeValue: "Test SpatialCategoryChild", modelId: definitionModelRoot.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: childCategory.id });
-          const childCategory2 = insertSpatialCategory({ txn, codeValue: "Test SpatialCategoryChild2", modelId: definitionModelRoot2.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: childCategory2.id });
-
-          return { definitionContainerRoot, rootCategory1, definitionContainerRoot2, rootCategory2 };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const result = await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories());
-      const expectedResult = {
-        categories: [
-          {
-            id: keys.rootCategory1.id,
-            subCategoryChildCount: 1,
-            isTopMostElementCategory: true,
-            hasElements: true,
-            hasElementsFromNonExcludedClasses: true,
-          },
-          {
-            id: keys.rootCategory2.id,
-            subCategoryChildCount: 1,
-            isTopMostElementCategory: true,
-            hasElements: true,
-            hasElementsFromNonExcludedClasses: true,
-          },
-        ],
-        definitionContainers: [keys.definitionContainerRoot.id, keys.definitionContainerRoot2.id],
-      };
-      expect(
-        expectedResult.categories.every((expectedCategory) =>
-          result.categories.find(
-            (category) => category.id === expectedCategory.id && category.subCategoryChildCount === expectedCategory.subCategoryChildCount,
-          ),
-        ),
-      ).toBe(true);
-      expect(expectedResult.definitionContainers.every((dc) => result.definitionContainers.includes(dc))).toBe(true);
-    });
-  });
-
-  describe("getSubCategories", () => {
-    it("returns empty list when category doesn't exist", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-        }),
-      );
-      const { imodelConnection } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getSubCategories({ categoryId: "0x123" }))).toEqual([]);
-    });
-
-    it("returns sub-category when category has one sub-category", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      expect(await firstValueFrom(idsCache.getSubCategories({ categoryId: keys.category.id }))).toEqual([getDefaultSubCategoryId(keys.category.id)]);
-    });
-
-    it("returns sub-categories when category has multiple sub-categories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subC 1" });
-          return { subCategory, category };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const result = await firstValueFrom(idsCache.getSubCategories({ categoryId: keys.category.id }));
-      expect(result.includes(keys.subCategory.id)).toBe(true);
-      expect(result.length).toBe(2);
-    });
-
-    it("returns only child subCategories when multiple categories have multiple subCategories", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const category = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subC 1" });
-
-          const category2 = insertSpatialCategory({ txn, codeValue: "Test SpatialCategory2" });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-          const subCategory2 = insertSubCategory({ txn, parentCategoryId: category2.id, codeValue: "subC 2" });
-          return { subCategory2, category2 };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, type: "3d", elementClassName: getClassesByView("3d").elementClass });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const result = await firstValueFrom(idsCache.getSubCategories({ categoryId: keys.category2.id }));
-      expect(result).toBeDefined();
-      expect(result.includes(keys.subCategory2.id)).toBe(true);
-      expect(result.length).toBe(2);
     });
   });
 });

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeIdsCache.test.ts
@@ -510,28 +510,30 @@ describe("CategoriesTreeIdsCache", () => {
         it("returns categories and definition containers when no elements exist and includeEmpty is set to true", async () => {
           const keys = imodelWithoutElements;
           const idsCache = cacheForIModelWithoutElements;
-          expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories({ includeEmpty: true }))).toEqual({
-            categories: [keys.categoryOfDefContainer.id, keys.emptyCategory.id],
-            definitionContainers: [keys.defContainerOfCategories.id, keys.parentDefContainer.id],
-          });
+          const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories({ includeEmpty: true }));
+          expect(result.categories).toHaveLength(2);
+          expect(result.categories).toEqual(expect.arrayContaining([keys.categoryOfDefContainer.id, keys.emptyCategory.id]));
+          expect(result.definitionContainers).toHaveLength(2);
+          expect(result.definitionContainers).toEqual(expect.arrayContaining([keys.defContainerOfCategories.id, keys.parentDefContainer.id]));
         });
 
         it("returns categories and definition containers which have elements", async () => {
           const keys = imodelWithDefContainersAndCategories;
           const idsCache = cacheForIModelWithDefContainersAndCategories;
-          expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
-            categories: [keys.categoryUnderChild.id, keys.categoryUnderParentWithSubCategories.id],
-            definitionContainers: [keys.childDefContainer.id, keys.parentDefContainer.id],
-          });
+          const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories());
+          expect(result.categories).toHaveLength(2);
+          expect(result.categories).toEqual(expect.arrayContaining([keys.categoryUnderChild.id, keys.categoryUnderParentWithSubCategories.id]));
+          expect(result.definitionContainers).toHaveLength(2);
+          expect(result.definitionContainers).toEqual(expect.arrayContaining([keys.childDefContainer.id, keys.parentDefContainer.id]));
         });
 
         it("returns categories when no definition containers exist", async () => {
           const keys = imodelWithoutDefContainers;
           const idsCache = cacheForIModelWithoutDefContainers;
-          expect(await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories())).toEqual({
-            categories: [keys.category.id, keys.categoryWithSubCategories.id],
-            definitionContainers: [],
-          });
+          const result = await firstValueFrom(idsCache.getAllDefinitionContainersAndCategories());
+          expect(result.categories).toHaveLength(2);
+          expect(result.categories).toEqual(expect.arrayContaining([keys.category.id, keys.categoryWithSubCategories.id]));
+          expect(result.definitionContainers).toHaveLength(0);
         });
       });
 
@@ -578,8 +580,11 @@ describe("CategoriesTreeIdsCache", () => {
         it("returns root categories", async () => {
           const keys = imodelWithoutDefContainers;
           const idsCache = cacheForIModelWithoutDefContainers;
-          expect(await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories())).toEqual({
-            categories: [
+
+          const result = await firstValueFrom(idsCache.getRootDefinitionContainersAndCategories());
+          expect(result.categories).toHaveLength(2);
+          expect(result.categories).toEqual(
+            expect.arrayContaining([
               { id: keys.category.id, subCategoryChildCount: 1, isTopMostElementCategory: true, hasElements: true, hasElementsFromNonExcludedClasses: true },
               {
                 id: keys.categoryWithSubCategories.id,
@@ -588,9 +593,9 @@ describe("CategoriesTreeIdsCache", () => {
                 hasElements: true,
                 hasElementsFromNonExcludedClasses: true,
               },
-            ],
-            definitionContainers: [],
-          });
+            ]),
+          );
+          expect(result.definitionContainers).toHaveLength(0);
         });
 
         it("returns root definition containers", async () => {

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.Search.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.Search.test.ts
@@ -1,0 +1,2070 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { HierarchyCacheMode, initializeCore, insertDefinitionContainer, insertSubCategory, insertSubModel, terminateCore } from "test-utilities";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from "vitest";
+import { withEditTxn } from "@itwin/core-backend";
+import { IModelReadRpcInterface } from "@itwin/core-common";
+import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
+import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
+import { PresentationRpcInterface } from "@itwin/presentation-common";
+import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
+import { CLASS_NAME_DefinitionModel, CLASS_NAME_SubCategory } from "../../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
+import { getClassesByView, mergeWithDefaults } from "../../../../tree-widget-react/shared/internal/Utils.js";
+import { CategoriesTreeDefinition, defaultHierarchyConfiguration } from "../../../../tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.js";
+import { createCategoriesTreeVisibilityHandler } from "../../../../tree-widget-react/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.js";
+import { buildIModel } from "../../../IModelUtils.js";
+import { TestUtils } from "../../../TestUtils.js";
+import { createTreeWidgetTestingViewport, getDefaultSubCategoryId } from "../../TreeUtils.js";
+import {
+  createAccessAndCache,
+  createCategoryHierarchyNode,
+  createDefinitionContainerHierarchyNode,
+  createElementHierarchyNode,
+  createSubCategoryHierarchyNode,
+  getInsertFunctionByViewType,
+  validateCategoriesTreeHierarchyVisibility,
+} from "./Utils.js";
+
+import type { Id64Arg } from "@itwin/core-bentley";
+import type { IModelConnection } from "@itwin/core-frontend";
+import type { HierarchySearchTree } from "@itwin/presentation-hierarchies";
+import type {
+  CategoriesTreeHierarchyConfiguration,
+  RequiredCategoriesTreeHierarchyConfiguration,
+} from "../../../../tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.js";
+import type { CategoriesTreeIdsCache } from "../../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
+import type { createIModelAccess, IModelAccess } from "../../Common.js";
+
+describe("CategoriesTreeVisibilityHandler", () => {
+  beforeAll(async () => {
+    await initializeCore({
+      backendProps: {
+        caching: {
+          hierarchies: {
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            mode: HierarchyCacheMode.Memory,
+          },
+        },
+      },
+      rpcs: [IModelReadRpcInterface, PresentationRpcInterface, ECSchemaRpcInterface],
+    });
+    await TestUtils.initialize();
+    // eslint-disable-next-line @itwin/no-internal
+    ECSchemaRpcImpl.register();
+  });
+
+  afterAll(async () => {
+    await terminateCore();
+    TestUtils.terminate();
+  });
+
+  ["2d" as const, "3d" as const].forEach((viewType) => {
+    const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
+
+    function createProvider(props: {
+      idsCache: CategoriesTreeIdsCache;
+      imodelAccess: ReturnType<typeof createIModelAccess>;
+      searchPaths?: HierarchySearchTree[];
+      hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration;
+    }) {
+      return createIModelHierarchyProvider({
+        hierarchyDefinition: new CategoriesTreeDefinition({ ...props, viewType }),
+        imodelAccess: props.imodelAccess,
+        ...(props.searchPaths ? { search: { paths: props.searchPaths } } : undefined),
+      });
+    }
+
+    describe(`${viewType} view`, () => {
+      describe("search nodes", () => {
+        async function createFilteredVisibilityTestData({
+          imodelConnection,
+          searchPaths,
+          visibleByDefault,
+          subCategoriesOfCategories,
+          idsCache,
+          imodelAccess,
+        }: {
+          searchPaths: HierarchySearchTree[];
+          visibleByDefault?: boolean;
+          subCategoriesOfCategories: Array<{ categoryId: string; subCategories: Id64Arg }>;
+          imodelConnection: IModelConnection;
+          hierarchyConfig?: CategoriesTreeHierarchyConfiguration;
+          imodelAccess: IModelAccess;
+          idsCache: CategoriesTreeIdsCache;
+        }) {
+          const hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration = mergeWithDefaults({
+            defaults: defaultHierarchyConfiguration,
+            overrides: {
+              elements: { nodes: "include" },
+              categories: { withoutElements: "include" },
+            },
+          });
+          const viewport = createTreeWidgetTestingViewport({
+            iModel: imodelConnection,
+            viewType,
+            visibleByDefault,
+            subCategoriesOfCategories,
+          });
+          const visibilityHandlerWithSearchPaths = createCategoriesTreeVisibilityHandler({
+            idsCache,
+            searchPaths,
+            imodelAccess,
+            viewport,
+            hierarchyConfig,
+          });
+          const defaultVisibilityHandler = createCategoriesTreeVisibilityHandler({
+            idsCache,
+            imodelAccess,
+            viewport,
+            hierarchyConfig,
+          });
+          const defaultProvider = createProvider({ idsCache, imodelAccess, hierarchyConfig });
+          const providerWithSearchPaths = createProvider({
+            idsCache,
+            imodelAccess,
+            searchPaths,
+            hierarchyConfig,
+          });
+          return {
+            defaultVisibilityHandler,
+            visibilityHandlerWithSearchPaths,
+            defaultProvider,
+            providerWithSearchPaths,
+            imodelConnection,
+            imodelAccess,
+            viewport,
+            [Symbol.dispose]() {
+              defaultVisibilityHandler[Symbol.dispose]();
+              visibilityHandlerWithSearchPaths[Symbol.dispose]();
+              defaultProvider[Symbol.dispose]();
+              providerWithSearchPaths[Symbol.dispose]();
+            },
+          };
+        }
+
+        it("returns 'disabled' when node has search paths but visibility handler doesn't", async () => {
+          await using buildIModelResult = await buildIModel(async (imodel) =>
+            withEditTxn(imodel, (txn) => {
+              const category = insertCategory({ txn, codeValue: "cat" });
+              const subCategory = insertSubCategory({
+                txn,
+                parentCategoryId: category.id,
+                codeValue: "subCat",
+              });
+              return { category, subCategory };
+            }),
+          );
+          const { imodelConnection, ...keys } = buildIModelResult;
+          const hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration = mergeWithDefaults({
+            defaults: defaultHierarchyConfiguration,
+            overrides: {
+              elements: { nodes: "include" },
+              categories: { withoutElements: "include" },
+            },
+          });
+          const accessAndCache = createAccessAndCache({ imodelConnection, viewType });
+          const viewport = createTreeWidgetTestingViewport({
+            iModel: imodelConnection,
+            viewType,
+            visibleByDefault: true,
+            subCategoriesOfCategories: [
+              {
+                categoryId: keys.category.id,
+                subCategories: [keys.subCategory.id, getDefaultSubCategoryId(keys.category.id)],
+              },
+            ],
+          });
+          using visibilityHandlerWithoutSearchPaths = createCategoriesTreeVisibilityHandler({
+            idsCache: accessAndCache.idsCache,
+            searchPaths: undefined,
+            imodelAccess: accessAndCache.imodelAccess,
+            viewport,
+            hierarchyConfig,
+          });
+
+          using providerWithSearchPaths = createProvider({
+            idsCache: accessAndCache.idsCache,
+            imodelAccess: accessAndCache.imodelAccess,
+            searchPaths: [{ identifier: keys.category, children: [{ identifier: keys.subCategory }] }],
+            hierarchyConfig,
+          });
+          await validateCategoriesTreeHierarchyVisibility({
+            provider: providerWithSearchPaths,
+            handler: visibilityHandlerWithoutSearchPaths,
+            viewport,
+            // prettier-ignore
+            expectations: {
+                [keys.category.id]: "disabled",
+                  [keys.subCategory.id]: "visible",
+              },
+          });
+        });
+
+        describe("category with sub-categories hierarchy", () => {
+          let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
+          let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
+          let accessAndCache: ReturnType<typeof createAccessAndCache>;
+          async function createIModel() {
+            return buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
+                const subCategory = insertSubCategory({
+                  txn,
+                  parentCategoryId: category.id,
+                  codeValue: "subCat",
+                });
+
+                const siblingCategory = insertCategory({ txn, codeValue: "sibling cat" });
+                const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
+                const siblingSubCategory = insertSubCategory({
+                  txn,
+                  parentCategoryId: siblingCategory.id,
+                  codeValue: "sibling SubCategory",
+                });
+
+                return {
+                  category,
+                  subCategory,
+                  siblingCategory,
+                  siblingSubCategory,
+                  defaultSubCategory,
+                  defaultSiblingSubCategory,
+                  searchPaths: [{ identifier: category, children: [{ identifier: defaultSubCategory }] }],
+                };
+              }),
+            );
+          }
+
+          beforeAll(async () => {
+            createIModelResult = await createIModel();
+            accessAndCache = createAccessAndCache({ imodelConnection: createIModelResult.imodelConnection, viewType });
+          });
+
+          beforeEach(async function () {
+            visibilityTestData = await createFilteredVisibilityTestData({
+              imodelConnection: createIModelResult.imodelConnection,
+              searchPaths: createIModelResult.searchPaths,
+              visibleByDefault: false,
+              subCategoriesOfCategories: [
+                { categoryId: createIModelResult.category.id, subCategories: [createIModelResult.subCategory.id, createIModelResult.defaultSubCategory.id] },
+                {
+                  categoryId: createIModelResult.siblingCategory.id,
+                  subCategories: [createIModelResult.siblingSubCategory.id, createIModelResult.defaultSiblingSubCategory.id],
+                },
+              ],
+              imodelAccess: accessAndCache.imodelAccess,
+              idsCache: accessAndCache.idsCache,
+            });
+          });
+
+          afterEach(() => {
+            visibilityTestData[Symbol.dispose]();
+          });
+
+          afterAll(async () => {
+            await createIModelResult.imodelConnection.close();
+          });
+
+          it("showing category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { category, subCategory, defaultSubCategory, siblingCategory, siblingSubCategory, defaultSiblingSubCategory } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: category.id,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: defaultSubCategory }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "visible",
+                  [defaultSubCategory.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [defaultSubCategory.id]: "visible",
+                  [subCategory.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingSubCategory.id]: "hidden",
+                  [defaultSiblingSubCategory.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing search target sub-category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { category, subCategory, defaultSubCategory, siblingCategory, siblingSubCategory, defaultSiblingSubCategory } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createSubCategoryHierarchyNode({
+                id: defaultSubCategory.id,
+                categoryId: category.id,
+                parentKeys: [category],
+                search: { isSearchTarget: true },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "visible",
+                  [defaultSubCategory.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [defaultSubCategory.id]: "visible",
+                  [subCategory.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingSubCategory.id]: "hidden",
+                  [defaultSiblingSubCategory.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("category with child elements hierarchy", () => {
+          let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
+          let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
+          let accessAndCache: ReturnType<typeof createAccessAndCache>;
+          async function createIModel() {
+            return buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
+                const parentElement1 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                const parentElement2 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                const childElement11 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id, parentId: parentElement1.id });
+                const childElement12 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id, parentId: parentElement1.id });
+                const childElement21 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id, parentId: parentElement2.id });
+
+                const siblingCategory = insertCategory({ txn, codeValue: "sibling cat" });
+                const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
+                const siblingElement = insertElement({ txn, modelId: elementsModel.id, categoryId: siblingCategory.id });
+
+                return {
+                  category,
+                  defaultSubCategory,
+                  parentElement1,
+                  parentElement2,
+                  element,
+                  childElement11,
+                  childElement12,
+                  childElement21,
+                  defaultSiblingSubCategory,
+                  siblingElement,
+                  siblingCategory,
+                  elementsModel,
+                  searchPaths: [
+                    { identifier: category, children: [{ identifier: parentElement1, children: [{ identifier: childElement11 }] }] },
+                    { identifier: category, children: [{ identifier: parentElement2, isTarget: true, children: [{ identifier: childElement21 }] }] },
+                  ],
+                };
+              }),
+            );
+          }
+
+          beforeAll(async () => {
+            createIModelResult = await createIModel();
+            accessAndCache = createAccessAndCache({ imodelConnection: createIModelResult.imodelConnection, viewType });
+          });
+
+          beforeEach(async function () {
+            visibilityTestData = await createFilteredVisibilityTestData({
+              imodelConnection: createIModelResult.imodelConnection,
+              searchPaths: createIModelResult.searchPaths,
+              visibleByDefault: false,
+              subCategoriesOfCategories: [
+                { categoryId: createIModelResult.category.id, subCategories: createIModelResult.defaultSubCategory.id },
+                { categoryId: createIModelResult.siblingCategory.id, subCategories: createIModelResult.defaultSiblingSubCategory.id },
+              ],
+              idsCache: accessAndCache.idsCache,
+              imodelAccess: accessAndCache.imodelAccess,
+            });
+            visibilityTestData.viewport.setNeverDrawn({
+              elementIds: new Set([
+                createIModelResult.element.id,
+                createIModelResult.childElement11.id,
+                createIModelResult.childElement12.id,
+                createIModelResult.siblingElement.id,
+                createIModelResult.childElement21.id,
+                createIModelResult.parentElement1.id,
+                createIModelResult.parentElement2.id,
+              ]),
+            });
+          });
+
+          afterEach(() => {
+            visibilityTestData[Symbol.dispose]();
+          });
+
+          afterAll(async () => {
+            await createIModelResult.imodelConnection.close();
+          });
+
+          it("showing category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { category, element, siblingElement, parentElement1, childElement11, childElement12, parentElement2, childElement21, siblingCategory } =
+              createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: category.id,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: parentElement1, children: [{ identifier: childElement11 }] }, { identifier: parentElement2 }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "visible",
+                  [parentElement1.id]: "visible",
+                    [childElement11.id]: "visible",
+
+                  [parentElement2.id]: "visible",
+                    [childElement21.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement1.id]: "partial",
+                    [childElement11.id]: "visible",
+                    [childElement12.id]: "hidden",
+
+                  [parentElement2.id]: "visible",
+                    [childElement21.id]: "visible",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing parent element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              element,
+              siblingElement,
+              parentElement1,
+              childElement11,
+              childElement12,
+              parentElement2,
+              childElement21,
+              siblingCategory,
+              elementsModel,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: parentElement1.id,
+                parentKeys: [category],
+                modelId: elementsModel.id,
+                categoryId: category.id,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: childElement11 }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [parentElement1.id]: "visible",
+                    [childElement11.id]: "visible",
+
+                  [parentElement2.id]: "hidden",
+                    [childElement21.id]: "hidden",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement1.id]: "partial",
+                    [childElement11.id]: "visible",
+                    [childElement12.id]: "hidden",
+
+                  [parentElement2.id]: "hidden",
+                    [childElement21.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing search target child element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              element,
+              siblingElement,
+              parentElement1,
+              childElement11,
+              childElement12,
+              parentElement2,
+              childElement21,
+              siblingCategory,
+              elementsModel,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: childElement11.id,
+                parentKeys: [category, parentElement1],
+                modelId: elementsModel.id,
+                categoryId: category.id,
+                search: { isSearchTarget: true },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [parentElement1.id]: "partial",
+                    [childElement11.id]: "visible",
+
+                  [parentElement2.id]: "hidden",
+                    [childElement21.id]: "hidden",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement1.id]: "partial",
+                    [childElement11.id]: "visible",
+                    [childElement12.id]: "hidden",
+
+                  [parentElement2.id]: "hidden",
+                    [childElement21.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing search target parent element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              element,
+              siblingElement,
+              parentElement1,
+              childElement11,
+              childElement12,
+              parentElement2,
+              childElement21,
+              siblingCategory,
+              elementsModel,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: parentElement2.id,
+                parentKeys: [category],
+                modelId: elementsModel.id,
+                categoryId: category.id,
+                search: { isSearchTarget: true, childrenTargetPaths: [{ identifier: childElement21 }] },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [parentElement1.id]: "hidden",
+                    [childElement11.id]: "hidden",
+
+                  [parentElement2.id]: "visible",
+                    [childElement21.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement1.id]: "hidden",
+                    [childElement11.id]: "hidden",
+                    [childElement12.id]: "hidden",
+
+                  [parentElement2.id]: "visible",
+                    [childElement21.id]: "visible",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing search target child element of search target parent element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              element,
+              siblingElement,
+              parentElement1,
+              childElement11,
+              childElement12,
+              parentElement2,
+              childElement21,
+              siblingCategory,
+              elementsModel,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: childElement21.id,
+                parentKeys: [category, parentElement2],
+                modelId: elementsModel.id,
+                categoryId: category.id,
+                search: { isSearchTarget: true, hasSearchTargetAncestor: true },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [parentElement1.id]: "hidden",
+                    [childElement11.id]: "hidden",
+
+                  [parentElement2.id]: "partial",
+                    [childElement21.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement1.id]: "hidden",
+                    [childElement11.id]: "hidden",
+                    [childElement12.id]: "hidden",
+
+                  [parentElement2.id]: "partial",
+                    [childElement21.id]: "visible",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("category with elements which are search targets and have search target ancestor", () => {
+          let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
+          let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
+          let accessAndCache: ReturnType<typeof createAccessAndCache>;
+          async function createIModel() {
+            return buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
+                const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id, parentId: parentElement.id });
+                const childOfChild1 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id, parentId: childElement.id });
+                const childOfChild2 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id, parentId: childElement.id });
+
+                return {
+                  category,
+                  defaultSubCategory,
+                  parentElement,
+                  element,
+                  childElement,
+                  elementsModel,
+                  childOfChild1,
+                  childOfChild2,
+                  searchPaths: [
+                    {
+                      identifier: category,
+                      children: [
+                        { identifier: parentElement, isTarget: true, children: [{ identifier: childElement, children: [{ identifier: childOfChild1 }] }] },
+                      ],
+                    },
+                  ],
+                };
+              }),
+            );
+          }
+
+          beforeAll(async () => {
+            createIModelResult = await createIModel();
+            accessAndCache = createAccessAndCache({ imodelConnection: createIModelResult.imodelConnection, viewType });
+          });
+
+          beforeEach(async function () {
+            visibilityTestData = await createFilteredVisibilityTestData({
+              imodelConnection: createIModelResult.imodelConnection,
+              searchPaths: createIModelResult.searchPaths,
+              visibleByDefault: false,
+              subCategoriesOfCategories: [{ categoryId: createIModelResult.category.id, subCategories: createIModelResult.defaultSubCategory.id }],
+              imodelAccess: accessAndCache.imodelAccess,
+              idsCache: accessAndCache.idsCache,
+            });
+            visibilityTestData.viewport.setNeverDrawn({
+              elementIds: new Set([
+                createIModelResult.element.id,
+                createIModelResult.parentElement.id,
+                createIModelResult.childElement.id,
+                createIModelResult.childOfChild1.id,
+                createIModelResult.childOfChild2.id,
+              ]),
+            });
+          });
+
+          afterEach(() => {
+            visibilityTestData[Symbol.dispose]();
+          });
+
+          afterAll(async () => {
+            await createIModelResult.imodelConnection.close();
+          });
+
+          it("showing category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { category, element, parentElement, childElement, childOfChild1, childOfChild2 } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: category.id,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [
+                    { identifier: parentElement, isTarget: true, children: [{ identifier: childElement, children: [{ identifier: childOfChild1 }] }] },
+                  ],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "visible",
+                  [parentElement.id]: "visible",
+                    [childElement.id]: "visible",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement.id]: "visible",
+                    [childElement.id]: "visible",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "visible",
+              },
+            });
+          });
+
+          it("showing search target parent element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { category, element, parentElement, childElement, childOfChild1, childOfChild2, elementsModel } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: parentElement.id,
+                parentKeys: [category, { type: "class-grouping", className: getClassesByView(viewType).elementClass }],
+                modelId: elementsModel.id,
+                categoryId: category.id,
+                search: { isSearchTarget: true, childrenTargetPaths: [{ identifier: childElement, children: [{ identifier: childOfChild1 }] }] },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "visible",
+                  [parentElement.id]: "visible",
+                    [childElement.id]: "visible",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement.id]: "visible",
+                    [childElement.id]: "visible",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "visible",
+              },
+            });
+          });
+
+          it("showing child element of search target parent element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { category, element, parentElement, childElement, childOfChild1, childOfChild2, elementsModel } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: childElement.id,
+                parentKeys: [
+                  category,
+                  { type: "class-grouping", className: getClassesByView(viewType).elementClass },
+                  parentElement,
+                  { type: "class-grouping", className: getClassesByView(viewType).elementClass },
+                ],
+                modelId: elementsModel.id,
+                categoryId: category.id,
+                search: { isSearchTarget: false, hasSearchTargetAncestor: true, childrenTargetPaths: [{ identifier: childOfChild1 }] },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [childElement.id]: "visible",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement.id]: "partial",
+                    [childElement.id]: "visible",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "visible",
+              },
+            });
+          });
+
+          it("showing nested child search target element with search target ancestor element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { category, element, parentElement, childElement, childOfChild1, childOfChild2, elementsModel } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: childOfChild1.id,
+                parentKeys: [
+                  category,
+                  { type: "class-grouping", className: getClassesByView(viewType).elementClass },
+                  parentElement,
+                  { type: "class-grouping", className: getClassesByView(viewType).elementClass },
+                  childElement,
+                  { type: "class-grouping", className: getClassesByView(viewType).elementClass },
+                ],
+                modelId: elementsModel.id,
+                categoryId: category.id,
+                search: { isSearchTarget: true, hasSearchTargetAncestor: true },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [childElement.id]: "partial",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "hidden",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [parentElement.id]: "partial",
+                    [childElement.id]: "partial",
+                      [childOfChild1.id]: "visible",
+                      [childOfChild2.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("category with intermediate categories hierarchy", () => {
+          let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
+          let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
+          let accessAndCache: ReturnType<typeof createAccessAndCache>;
+          async function createIModel() {
+            return buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+                const categoryA = insertCategory({ txn, codeValue: "catA" });
+                const defaultSubCategoryA = { id: getDefaultSubCategoryId(categoryA.id), className: CLASS_NAME_SubCategory };
+                const categoryB = insertCategory({ txn, codeValue: "catB" });
+                const defaultSubCategoryB = { id: getDefaultSubCategoryId(categoryB.id), className: CLASS_NAME_SubCategory };
+                const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
+                const childElement1 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
+                const childElement2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
+                const siblingElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
+
+                return {
+                  categoryA,
+                  categoryB,
+                  defaultSubCategoryA,
+                  defaultSubCategoryB,
+                  parentElement,
+                  childElement1,
+                  childElement2,
+                  siblingElement,
+                  elementsModel,
+                  searchPaths: [
+                    {
+                      identifier: categoryA,
+                      children: [
+                        {
+                          identifier: parentElement,
+                          children: [{ identifier: categoryB, children: [{ identifier: childElement1 }] }],
+                        },
+                      ],
+                    },
+                  ],
+                };
+              }),
+            );
+          }
+
+          beforeAll(async () => {
+            createIModelResult = await createIModel();
+            accessAndCache = createAccessAndCache({ imodelConnection: createIModelResult.imodelConnection, viewType });
+          });
+
+          beforeEach(async function () {
+            visibilityTestData = await createFilteredVisibilityTestData({
+              imodelConnection: createIModelResult.imodelConnection,
+              searchPaths: createIModelResult.searchPaths,
+              visibleByDefault: false,
+              subCategoriesOfCategories: [
+                { categoryId: createIModelResult.categoryA.id, subCategories: createIModelResult.defaultSubCategoryA.id },
+                { categoryId: createIModelResult.categoryB.id, subCategories: createIModelResult.defaultSubCategoryB.id },
+              ],
+              imodelAccess: accessAndCache.imodelAccess,
+              idsCache: accessAndCache.idsCache,
+            });
+            visibilityTestData.viewport.setNeverDrawn({
+              elementIds: new Set([
+                createIModelResult.parentElement.id,
+                createIModelResult.childElement1.id,
+                createIModelResult.childElement2.id,
+                createIModelResult.siblingElement.id,
+              ]),
+            });
+          });
+
+          afterEach(() => {
+            visibilityTestData[Symbol.dispose]();
+          });
+
+          afterAll(async () => {
+            await createIModelResult.imodelConnection.close();
+          });
+
+          it("showing intermediate category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: categoryB.id,
+                modelIds: [elementsModel.id],
+                hasChildren: true,
+                parentKeys: [categoryA, parentElement],
+                parentElementsPath: [{ elementIds: [parentElement.id], categoryIds: categoryA.id }],
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: childElement1 }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [`${parentElement.id}-${categoryB.id}`]: "visible",
+                      [childElement1.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [`${parentElement.id}-${categoryB.id}`]: "partial",
+                      [childElement1.id]: "visible",
+                      [childElement2.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [categoryB.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing child element under intermediate category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: childElement1.id,
+                modelId: elementsModel.id,
+                categoryId: categoryB.id,
+                parentKeys: [categoryA, parentElement, categoryB],
+                parentElementsPath: [{ elementIds: [parentElement.id], categoryIds: categoryA.id }],
+                search: { isSearchTarget: true },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [`${parentElement.id}-${categoryB.id}`]: "visible",
+                      [childElement1.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [`${parentElement.id}-${categoryB.id}`]: "partial",
+                      [childElement1.id]: "visible",
+                      [childElement2.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [categoryB.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing parent element changes visibility for intermediate category children in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: parentElement.id,
+                modelId: elementsModel.id,
+                categoryId: categoryA.id,
+                parentKeys: [categoryA],
+                hasChildren: true,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: categoryB, children: [{ identifier: childElement1 }] }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "visible",
+                  [parentElement.id]: "visible",
+                    [`${parentElement.id}-${categoryB.id}`]: "visible",
+                      [childElement1.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [`${parentElement.id}-${categoryB.id}`]: "partial",
+                      [childElement1.id]: "visible",
+                      [childElement2.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [categoryB.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing root category changes visibility for intermediate category children in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: categoryA.id,
+                hasChildren: true,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: parentElement, children: [{ identifier: categoryB, children: [{ identifier: childElement1 }] }] }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "visible",
+                  [parentElement.id]: "visible",
+                    [`${parentElement.id}-${categoryB.id}`]: "visible",
+                      [childElement1.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [parentElement.id]: "partial",
+                    [`${parentElement.id}-${categoryB.id}`]: "partial",
+                      [childElement1.id]: "visible",
+                      [childElement2.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [categoryB.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("category with intermediate categories under sub-model hierarchy", () => {
+          let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
+          let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
+          let accessAndCache: ReturnType<typeof createAccessAndCache>;
+          async function createIModel() {
+            return buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+                const categoryA = insertCategory({ txn, codeValue: "catA" });
+                const defaultSubCategoryA = { id: getDefaultSubCategoryId(categoryA.id), className: CLASS_NAME_SubCategory };
+                const categoryB = insertCategory({ txn, codeValue: "catB" });
+                const defaultSubCategoryB = { id: getDefaultSubCategoryId(categoryB.id), className: CLASS_NAME_SubCategory };
+                const modeledElement = insertModeledElement({
+                  txn,
+                  modelId: elementsModel.id,
+                  categoryId: categoryA.id,
+                });
+                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                const subModelElement1 = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
+                const subModelElement2 = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
+
+                return {
+                  categoryA,
+                  categoryB,
+                  defaultSubCategoryA,
+                  defaultSubCategoryB,
+                  modeledElement,
+                  subModel,
+                  subModelElement1,
+                  subModelElement2,
+                  elementsModel,
+                  searchPaths: [
+                    {
+                      identifier: categoryA,
+                      children: [
+                        {
+                          identifier: modeledElement,
+                          children: [{ identifier: subModel, children: [{ identifier: categoryB, children: [{ identifier: subModelElement1 }] }] }],
+                        },
+                      ],
+                    },
+                  ],
+                };
+              }),
+            );
+          }
+
+          beforeAll(async () => {
+            createIModelResult = await createIModel();
+            accessAndCache = createAccessAndCache({ imodelConnection: createIModelResult.imodelConnection, viewType });
+          });
+
+          beforeEach(async function () {
+            visibilityTestData = await createFilteredVisibilityTestData({
+              imodelConnection: createIModelResult.imodelConnection,
+              searchPaths: createIModelResult.searchPaths,
+              visibleByDefault: false,
+              subCategoriesOfCategories: [
+                { categoryId: createIModelResult.categoryA.id, subCategories: createIModelResult.defaultSubCategoryA.id },
+                { categoryId: createIModelResult.categoryB.id, subCategories: createIModelResult.defaultSubCategoryB.id },
+              ],
+              imodelAccess: accessAndCache.imodelAccess,
+              idsCache: accessAndCache.idsCache,
+            });
+            visibilityTestData.viewport.setNeverDrawn({
+              elementIds: new Set([createIModelResult.modeledElement.id, createIModelResult.subModelElement1.id, createIModelResult.subModelElement2.id]),
+            });
+          });
+
+          afterEach(() => {
+            visibilityTestData[Symbol.dispose]();
+          });
+
+          afterAll(async () => {
+            await createIModelResult.imodelConnection.close();
+          });
+
+          it("showing intermediate category under sub-model changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2 } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: categoryB.id,
+                modelIds: [modeledElement.id],
+                hasChildren: true,
+                parentKeys: [categoryA, modeledElement, subModel],
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: subModelElement1 }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [modeledElement.id]: "partial",
+                    [subModel.id]: "partial",
+                      [`${modeledElement.id}-${categoryB.id}`]: "visible",
+                        [subModelElement1.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [modeledElement.id]: "partial",
+                    [`${modeledElement.id}-${categoryB.id}`]: "partial",
+                      [subModelElement1.id]: "visible",
+                      [subModelElement2.id]: "hidden",
+
+                [categoryB.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing element under intermediate category in sub-model changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2 } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: subModelElement1.id,
+                modelId: modeledElement.id,
+                categoryId: categoryB.id,
+                parentKeys: [categoryA, modeledElement, subModel, categoryB],
+                search: { isSearchTarget: true },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [modeledElement.id]: "partial",
+                    [subModel.id]: "partial",
+                      [`${modeledElement.id}-${categoryB.id}`]: "visible",
+                        [subModelElement1.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [modeledElement.id]: "partial",
+                    [`${modeledElement.id}-${categoryB.id}`]: "partial",
+                      [subModelElement1.id]: "visible",
+                      [subModelElement2.id]: "hidden",
+
+                [categoryB.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing modeled element changes visibility for intermediate category children in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2, elementsModel } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: modeledElement.id,
+                modelId: elementsModel.id,
+                categoryId: categoryA.id,
+                parentKeys: [categoryA],
+                hasChildren: true,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: subModel, children: [{ identifier: categoryB, children: [{ identifier: subModelElement1 }] }] }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "visible",
+                  [modeledElement.id]: "visible",
+                    [subModel.id]: "visible",
+                      [`${modeledElement.id}-${categoryB.id}`]: "visible",
+                        [subModelElement1.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [categoryA.id]: "partial",
+                  [modeledElement.id]: "partial",
+                    [`${modeledElement.id}-${categoryB.id}`]: "partial",
+                      [subModelElement1.id]: "visible",
+                      [subModelElement2.id]: "hidden",
+
+                [categoryB.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("category with modeled elements hierarchy", () => {
+          let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
+          let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
+          let accessAndCache: ReturnType<typeof createAccessAndCache>;
+          async function createIModel() {
+            return buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+                const category = insertCategory({ txn, codeValue: "cat" });
+                const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
+                const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                const modeledElement = insertModeledElement({
+                  txn,
+                  userLabel: "modeled el",
+                  modelId: elementsModel.id,
+                  categoryId: category.id,
+                });
+                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                const subModelCategory = insertCategory({ txn, codeValue: "subModel cat" });
+                const subModelElement = insertElement({ txn, userLabel: "subModel el", modelId: subModel.id, categoryId: subModelCategory.id });
+                const subModelElement2 = insertElement({ txn, userLabel: "subModel el 2", modelId: subModel.id, categoryId: subModelCategory.id });
+                const defaultSubCategoryOfSubModelCategory = { id: getDefaultSubCategoryId(subModelCategory.id), className: CLASS_NAME_SubCategory };
+
+                const otherSubModelCategory = insertCategory({ txn, codeValue: "other subModel cat" });
+                const otherSubModelElement = insertElement({
+                  txn,
+                  userLabel: "other subModel el",
+                  modelId: subModel.id,
+                  categoryId: otherSubModelCategory.id,
+                });
+                const defaultSubCategoryOfOtherSubModelCategory = { id: getDefaultSubCategoryId(otherSubModelCategory.id), className: CLASS_NAME_SubCategory };
+
+                const siblingCategory = insertCategory({ txn, codeValue: "sibling cat" });
+                const siblingElement = insertElement({ txn, modelId: elementsModel.id, categoryId: siblingCategory.id });
+                const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
+
+                return {
+                  category,
+                  elementsModel,
+                  defaultSubCategory,
+                  element,
+                  modeledElement,
+                  subModel,
+                  subModelCategory,
+                  subModelElement,
+                  subModelElement2,
+                  defaultSubCategoryOfSubModelCategory,
+                  otherSubModelCategory,
+                  otherSubModelElement,
+                  defaultSubCategoryOfOtherSubModelCategory,
+                  siblingCategory,
+                  siblingElement,
+                  defaultSiblingSubCategory,
+                  searchPaths: [
+                    {
+                      identifier: category,
+                      children: [
+                        {
+                          identifier: modeledElement,
+                          children: [{ identifier: subModel, children: [{ identifier: subModelCategory, children: [{ identifier: subModelElement }] }] }],
+                        },
+                      ],
+                    },
+                  ],
+                };
+              }),
+            );
+          }
+
+          beforeAll(async () => {
+            createIModelResult = await createIModel();
+            accessAndCache = createAccessAndCache({ imodelConnection: createIModelResult.imodelConnection, viewType });
+          });
+
+          beforeEach(async function () {
+            visibilityTestData = await createFilteredVisibilityTestData({
+              imodelConnection: createIModelResult.imodelConnection,
+              searchPaths: createIModelResult.searchPaths,
+              visibleByDefault: false,
+              subCategoriesOfCategories: [
+                { categoryId: createIModelResult.category.id, subCategories: createIModelResult.defaultSubCategory.id },
+                { categoryId: createIModelResult.subModelCategory.id, subCategories: createIModelResult.defaultSubCategoryOfSubModelCategory.id },
+                {
+                  categoryId: createIModelResult.otherSubModelCategory.id,
+                  subCategories: createIModelResult.defaultSubCategoryOfOtherSubModelCategory.id,
+                },
+                { categoryId: createIModelResult.siblingCategory.id, subCategories: createIModelResult.defaultSiblingSubCategory.id },
+              ],
+              imodelAccess: accessAndCache.imodelAccess,
+              idsCache: accessAndCache.idsCache,
+            });
+          });
+
+          afterEach(() => {
+            visibilityTestData[Symbol.dispose]();
+          });
+
+          afterAll(async () => {
+            await createIModelResult.imodelConnection.close();
+          });
+
+          it("showing category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              modeledElement,
+              subModel,
+              subModelCategory,
+              subModelElement,
+              siblingCategory,
+              siblingElement,
+              element,
+              subModelElement2,
+              otherSubModelCategory,
+              otherSubModelElement,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: category.id,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [
+                    {
+                      identifier: modeledElement,
+                      children: [{ identifier: subModel, children: [{ identifier: subModelCategory, children: [{ identifier: subModelElement }] }] }],
+                    },
+                  ],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "visible",
+                  [modeledElement.id]: "visible",
+                    [`${subModel.id}-${subModelCategory.id}`]: "visible",
+                      [subModelElement.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [modeledElement.id]: "partial",
+                    [`${subModel.id}-${subModelCategory.id}`]: "partial",
+                      [subModelElement.id]: "visible",
+                      [subModelElement2.id]: "hidden",
+                    [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                      [otherSubModelElement.id]: "hidden",
+
+                [otherSubModelCategory.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [subModelCategory.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing modeled element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              modeledElement,
+              subModel,
+              subModelCategory,
+              subModelElement,
+              siblingCategory,
+              siblingElement,
+              element,
+              subModelElement2,
+              otherSubModelCategory,
+              otherSubModelElement,
+              elementsModel,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: modeledElement.id,
+                categoryId: category.id,
+                parentKeys: [category],
+                modelId: elementsModel.id,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: subModel, children: [{ identifier: subModelCategory, children: [{ identifier: subModelElement }] }] }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "visible",
+                  [modeledElement.id]: "visible",
+                    [`${subModel.id}-${subModelCategory.id}`]: "visible",
+                      [subModelElement.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [modeledElement.id]: "partial",
+                    [`${subModel.id}-${subModelCategory.id}`]: "partial",
+                      [subModelElement.id]: "visible",
+                      [subModelElement2.id]: "hidden",
+                    [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                      [otherSubModelElement.id]: "hidden",
+
+                [otherSubModelCategory.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [subModelCategory.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing category of subModel changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              modeledElement,
+              subModel,
+              subModelCategory,
+              subModelElement,
+              siblingCategory,
+              siblingElement,
+              element,
+              subModelElement2,
+              otherSubModelCategory,
+              otherSubModelElement,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: subModelCategory.id,
+                parentKeys: [category, modeledElement, subModel],
+                modelIds: [subModel.id],
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: subModelElement }],
+                },
+              }),
+              true,
+            );
+            // In this case when turning on subModelCategory, only subModelElement is put into always drawn list (due to search paths).
+            // Because subModelElement and subModelCategory visibility is not affected by visibility of nodes above them (in hierarchy),
+            // visibility handler does not change the visibility of modeledElement or category (They get partial visibility because their subModels are visible, but they themselves are not).
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [modeledElement.id]: "partial",
+                    [`${subModel.id}-${subModelCategory.id}`]: "visible",
+                      [subModelElement.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [modeledElement.id]: "partial",
+                    [`${subModel.id}-${subModelCategory.id}`]: "partial",
+                      [subModelElement.id]: "visible",
+                      [subModelElement2.id]: "hidden",
+                    [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                      [otherSubModelElement.id]: "hidden",
+
+                [otherSubModelCategory.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [subModelCategory.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing search target subModel element changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const {
+              category,
+              modeledElement,
+              subModel,
+              subModelCategory,
+              subModelElement,
+              siblingCategory,
+              siblingElement,
+              element,
+              subModelElement2,
+              otherSubModelCategory,
+              otherSubModelElement,
+            } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createElementHierarchyNode({
+                elementId: subModelElement.id,
+                parentKeys: [category, modeledElement, subModelCategory],
+                categoryId: subModelCategory.id,
+                modelId: subModel.id,
+                search: { isSearchTarget: true },
+              }),
+              true,
+            );
+
+            // In this case when turning on subModelElement visibility, it is put into always drawn list.
+            // Because subModelElement and subModelCategory visibility is not affected by visibility of nodes above them (in hierarchy),
+            // visibility handler does not change the visibility of modeledElement or category (They get partial visibility because their subModels are visible, but they themselves are not).
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [modeledElement.id]: "partial",
+                    [`${subModel.id}-${subModelCategory.id}`]: "visible",
+                      [subModelElement.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [category.id]: "partial",
+                  [element.id]: "hidden",
+
+                  [modeledElement.id]: "partial",
+                    [`${subModel.id}-${subModelCategory.id}`]: "partial",
+                      [subModelElement.id]: "visible",
+                      [subModelElement2.id]: "hidden",
+                    [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
+                      [otherSubModelElement.id]: "hidden",
+
+                [otherSubModelCategory.id]: "hidden",
+
+                [siblingCategory.id]: "hidden",
+                  [siblingElement.id]: "hidden",
+
+                [subModelCategory.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("category under definition container hierarchy", () => {
+          let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
+          let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
+          let accessAndCache: ReturnType<typeof createAccessAndCache>;
+          async function createIModel() {
+            return buildIModel(async (imodel) =>
+              withEditTxn(imodel, (txn) => {
+                const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+                const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+                const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+                const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
+                const subCategory = insertSubCategory({
+                  txn,
+                  parentCategoryId: category.id,
+                  codeValue: "subCat",
+                  modelId: definitionModel.id,
+                });
+
+                const siblingCategory = insertCategory({ txn, codeValue: "sibling cat", modelId: definitionModel.id });
+                const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
+
+                return {
+                  definitionContainer,
+                  category,
+                  defaultSubCategory,
+                  subCategory,
+                  siblingCategory,
+                  defaultSiblingSubCategory,
+                  searchPaths: [{ identifier: definitionContainer, children: [{ identifier: category, children: [{ identifier: defaultSubCategory }] }] }],
+                };
+              }),
+            );
+          }
+
+          beforeAll(async () => {
+            createIModelResult = await createIModel();
+            accessAndCache = createAccessAndCache({ imodelConnection: createIModelResult.imodelConnection, viewType });
+          });
+
+          beforeEach(async function () {
+            visibilityTestData = await createFilteredVisibilityTestData({
+              imodelConnection: createIModelResult.imodelConnection,
+              searchPaths: createIModelResult.searchPaths,
+              visibleByDefault: false,
+              subCategoriesOfCategories: [
+                { categoryId: createIModelResult.category.id, subCategories: [createIModelResult.subCategory.id, createIModelResult.defaultSubCategory.id] },
+                { categoryId: createIModelResult.siblingCategory.id, subCategories: createIModelResult.defaultSiblingSubCategory.id },
+              ],
+              imodelAccess: accessAndCache.imodelAccess,
+              idsCache: accessAndCache.idsCache,
+            });
+          });
+
+          afterEach(() => {
+            visibilityTestData[Symbol.dispose]();
+          });
+
+          afterAll(async () => {
+            await createIModelResult.imodelConnection.close();
+          });
+
+          it("showing definition container changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createDefinitionContainerHierarchyNode({
+                id: definitionContainer.id,
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: category, children: [{ identifier: defaultSubCategory }] }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [definitionContainer.id]: "visible",
+                  [category.id]: "visible",
+                    [defaultSubCategory.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [definitionContainer.id]: "partial",
+                  [category.id]: "partial",
+                    [defaultSubCategory.id]: "visible",
+                    [subCategory.id]: "hidden",
+
+                  [siblingCategory.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createCategoryHierarchyNode({
+                id: category.id,
+                parentKeys: [definitionContainer],
+                search: {
+                  isSearchTarget: false,
+                  childrenTargetPaths: [{ identifier: defaultSubCategory }],
+                },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [definitionContainer.id]: "visible",
+                  [category.id]: "visible",
+                    [defaultSubCategory.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [definitionContainer.id]: "partial",
+                  [category.id]: "partial",
+                    [defaultSubCategory.id]: "visible",
+                    [subCategory.id]: "hidden",
+
+                  [siblingCategory.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing search target sub-category changes visibility for related nodes in search paths", async () => {
+            const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
+            const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
+            await visibilityHandlerWithSearchPaths.changeVisibility(
+              createSubCategoryHierarchyNode({
+                id: defaultSubCategory.id,
+                parentKeys: [definitionContainer, category],
+                categoryId: category.id,
+                search: { isSearchTarget: true },
+              }),
+              true,
+            );
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: providerWithSearchPaths,
+              handler: visibilityHandlerWithSearchPaths,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [definitionContainer.id]: "visible",
+                  [category.id]: "visible",
+                    [defaultSubCategory.id]: "visible",
+              },
+            });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider: defaultProvider,
+              handler: defaultVisibilityHandler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [definitionContainer.id]: "partial",
+                  [category.id]: "partial",
+                    [defaultSubCategory.id]: "visible",
+                    [subCategory.id]: "hidden",
+
+                  [siblingCategory.id]: "hidden",
+              },
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -3,42 +3,23 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-import {
-  HierarchyCacheMode,
-  initializeCore,
-  insertDefinitionContainer,
-  insertPhysicalElement,
-  insertPhysicalModelWithPartition,
-  insertPhysicalPartition,
-  insertPhysicalSubModel,
-  insertSpatialCategory,
-  insertSubCategory,
-  insertSubModel,
-  terminateCore,
-} from "test-utilities";
+import { HierarchyCacheMode, initializeCore, insertDefinitionContainer, insertSubCategory, insertSubModel, terminateCore } from "test-utilities";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, it } from "vitest";
 import { withEditTxn } from "@itwin/core-backend";
-import { IModel, IModelReadRpcInterface } from "@itwin/core-common";
+import { IModelReadRpcInterface } from "@itwin/core-common";
 import { ECSchemaRpcInterface } from "@itwin/ecschema-rpcinterface-common";
 import { ECSchemaRpcImpl } from "@itwin/ecschema-rpcinterface-impl";
 import { PresentationRpcInterface } from "@itwin/presentation-common";
 import { createIModelHierarchyProvider } from "@itwin/presentation-hierarchies";
-import { BaseIdsCache } from "../../../../tree-widget-react/shared/internal/caches/BaseIdsCache.js";
-import {
-  CLASS_NAME_GeometricElement3d,
-  CLASS_NAME_SubCategory,
-  CLASS_NAME_Subject,
-} from "../../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
+import { CLASS_NAME_DefinitionModel } from "../../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
 import { getClassesByView, mergeWithDefaults } from "../../../../tree-widget-react/shared/internal/Utils.js";
 import { CategoriesTreeDefinition, defaultHierarchyConfiguration } from "../../../../tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.js";
-import { CategoriesTreeIdsCache } from "../../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 import { createCategoriesTreeVisibilityHandler } from "../../../../tree-widget-react/trees/categories-tree/internal/visibility/CategoriesTreeVisibilityHandler.js";
 import { buildIModel } from "../../../IModelUtils.js";
-import { validateHierarchyVisibility } from "../../../shared/VisibilityValidation.js";
 import { TestUtils } from "../../../TestUtils.js";
-import { createIModelAccess } from "../../Common.js";
-import { CLASS_NAME_DefinitionModel, createTreeWidgetTestingViewport, getDefaultSubCategoryId } from "../../TreeUtils.js";
+import { createTreeWidgetTestingViewport, getDefaultSubCategoryId } from "../../TreeUtils.js";
 import {
+  createAccessAndCache,
   createCategoryHierarchyNode,
   createClassGroupingHierarchyNode,
   createDefinitionContainerHierarchyNode,
@@ -46,19 +27,21 @@ import {
   createModelHierarchyNode,
   createSubCategoryHierarchyNode,
   getInsertFunctionByViewType,
+  setupInitialDisplayState,
+  validateCategoriesTreeHierarchyVisibility,
 } from "./Utils.js";
-import { validateNodeVisibility } from "./VisibilityValidation.js";
 
 import type { Id64Arg, Id64String } from "@itwin/core-bentley";
 import type { IModelConnection } from "@itwin/core-frontend";
 import type { GroupingHierarchyNode, HierarchySearchTree, NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
-import type { InstanceKey, Props } from "@itwin/presentation-shared";
+import type { InstanceKey } from "@itwin/presentation-shared";
 import type {
   CategoriesTreeHierarchyConfiguration,
   RequiredCategoriesTreeHierarchyConfiguration,
 } from "../../../../tree-widget-react/trees/categories-tree/CategoriesTreeDefinition.js";
+import type { CategoriesTreeIdsCache } from "../../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 import type { VisibilityExpectations } from "../../../shared/VisibilityValidation.js";
-import type { TreeWidgetTestingViewport } from "../../TreeUtils.js";
+import type { createIModelAccess, IModelAccess } from "../../Common.js";
 
 describe("CategoriesTreeVisibilityHandler", () => {
   beforeAll(async () => {
@@ -83,5652 +66,2237 @@ describe("CategoriesTreeVisibilityHandler", () => {
     TestUtils.terminate();
   });
 
-  async function createCommonProps({
-    imodelConnection,
-    hierarchyConfig,
-    subCategoriesOfCategories,
-    visibleByDefault,
-    viewType,
-  }: {
-    imodelConnection: IModelConnection;
-    hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration;
-    subCategoriesOfCategories?: Array<{ categoryId: Id64String; subCategories: Id64Arg }>;
-    visibleByDefault?: boolean;
-    viewType: "2d" | "3d";
-  }) {
-    const imodelAccess = createIModelAccess(imodelConnection);
-    const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView(viewType).elementClass, type: viewType });
-    const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: viewType, baseIdsCache });
-    const viewport = createTreeWidgetTestingViewport({ iModel: imodelConnection, subCategoriesOfCategories, viewType, visibleByDefault });
+  ["2d" as const, "3d" as const].forEach((viewType) => {
+    const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
+    function createProvider(props: {
+      idsCache: CategoriesTreeIdsCache;
+      imodelAccess: ReturnType<typeof createIModelAccess>;
+      searchPaths?: HierarchySearchTree[];
+      hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration;
+    }) {
+      return createIModelHierarchyProvider({
+        hierarchyDefinition: new CategoriesTreeDefinition({ ...props, viewType }),
+        imodelAccess: props.imodelAccess,
+        ...(props.searchPaths ? { search: { paths: props.searchPaths } } : undefined),
+      });
+    }
 
-    return {
-      imodelAccess,
-      viewport,
+    async function createVisibilityTestData({
+      imodelConnection,
+      subCategoriesOfCategories,
+      visibleByDefault,
       idsCache,
-      hierarchyConfig,
-      baseIdsCache,
-    };
-  }
-
-  function createProvider(props: {
-    idsCache: CategoriesTreeIdsCache;
-    imodelAccess: ReturnType<typeof createIModelAccess>;
-    searchPaths?: HierarchySearchTree[];
-    hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration;
-    viewType?: "2d" | "3d";
-  }) {
-    return createIModelHierarchyProvider({
-      hierarchyDefinition: new CategoriesTreeDefinition({ ...props, viewType: props.viewType ?? "3d" }),
-      imodelAccess: props.imodelAccess,
-      ...(props.searchPaths ? { search: { paths: props.searchPaths } } : undefined),
-    });
-  }
-
-  async function createVisibilityTestData({
-    imodelConnection,
-    subCategoriesOfCategories,
-    visibleByDefault,
-    viewType,
-    ...restProps
-  }: {
-    imodelConnection: IModelConnection;
-    hierarchyConfig?: CategoriesTreeHierarchyConfiguration;
-    subCategoriesOfCategories?: Array<{ categoryId: Id64String; subCategories: Id64Arg }>;
-    visibleByDefault?: boolean;
-    viewType?: "2d" | "3d";
-  }) {
-    const hierarchyConfig = mergeWithDefaults({
-      defaults: defaultHierarchyConfiguration,
-      overrides: restProps.hierarchyConfig,
-    });
-    const commonProps = await createCommonProps({ imodelConnection, hierarchyConfig, subCategoriesOfCategories, visibleByDefault, viewType: viewType ?? "3d" });
-    const handler = createCategoriesTreeVisibilityHandler({
-      viewport: commonProps.viewport,
-      idsCache: commonProps.idsCache,
-      imodelAccess: commonProps.imodelAccess,
-      searchPaths: undefined,
-      hierarchyConfig,
-    });
-    const provider = createProvider({ ...commonProps, hierarchyConfig, viewType });
-
-    return {
-      handler,
-      provider,
-      ...commonProps,
-      [Symbol.dispose]() {
-        handler[Symbol.dispose]();
-        provider[Symbol.dispose]();
-      },
-    };
-  }
-
-  describe("enabling visibility", () => {
-    it("by default everything is hidden", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCategory", modelId: definitionModel.id });
-          return { category, subCategory, physicalModel };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-
-      using visibilityTestData = await createVisibilityTestData({
-        imodelConnection,
-        subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+      imodelAccess,
+      ...restProps
+    }: {
+      imodelConnection: IModelConnection;
+      hierarchyConfig?: CategoriesTreeHierarchyConfiguration;
+      subCategoriesOfCategories?: Array<{ categoryId: Id64String; subCategories: Id64Arg }>;
+      visibleByDefault?: boolean;
+      idsCache: CategoriesTreeIdsCache;
+      imodelAccess: IModelAccess;
+    }) {
+      const hierarchyConfig = mergeWithDefaults({
+        defaults: defaultHierarchyConfiguration,
+        overrides: restProps.hierarchyConfig,
       });
-      const { handler, provider, viewport } = visibilityTestData;
-
-      await validateCategoriesTreeHierarchyVisibility({
-        provider,
-        handler,
+      const viewport = createTreeWidgetTestingViewport({ iModel: imodelConnection, subCategoriesOfCategories, viewType, visibleByDefault });
+      const handler = createCategoriesTreeVisibilityHandler({
         viewport,
-        expectations: "all-hidden",
+        idsCache,
+        imodelAccess,
+        searchPaths: undefined,
+        hierarchyConfig,
       });
-    });
+      const provider = createProvider({ idsCache, imodelAccess, hierarchyConfig });
 
-    describe("definitionContainers", () => {
-      it("showing definition container makes it and all of its contained elements visible", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
+      return {
+        handler,
+        provider,
+        viewport,
+        [Symbol.dispose]() {
+          handler[Symbol.dispose]();
+          provider[Symbol.dispose]();
+        },
+      };
+    }
+    describe(`${viewType} view`, () => {
+      let simpleIModel: Awaited<ReturnType<typeof createSimpleIModel>>;
+      let accessAndCacheSimpleIModel: ReturnType<typeof createAccessAndCache>;
+
+      let unrelatedDefContainersIModel: Awaited<ReturnType<typeof createUnrelatedDefContainersIModel>>;
+      let accessAndCacheUnrelatedDefContainersIModel: ReturnType<typeof createAccessAndCache>;
+
+      let siblingCategoriesIModel: Awaited<ReturnType<typeof createSiblingCategoriesIModel>>;
+      let accessAndCacheSiblingCategoriesIModel: ReturnType<typeof createAccessAndCache>;
+
+      let elementsModelsIModel: Awaited<ReturnType<typeof createElementsModelsIModel>>;
+      let accessAndCacheElementsModelsIModel: ReturnType<typeof createAccessAndCache>;
+
+      let intermediateCategoriesIModel: Awaited<ReturnType<typeof createIntermediateCategoriesIModel>>;
+      let accessAndCacheIntermediateCategoriesIModel: ReturnType<typeof createAccessAndCache>;
+
+      let subModelIntermediateCategoriesIModel: Awaited<ReturnType<typeof createSubModelIntermediateCategoriesIModel>>;
+      let accessAndCacheSubModelIntermediateCategoriesIModel: ReturnType<typeof createAccessAndCache>;
+
+      async function createSimpleIModel() {
+        return buildIModel(async (imodel) =>
           withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
+            // Structure of the iModel:
+            // - DefinitionContainer
+            //   - Category
+            //     - Default SubCategory
+            //     - SubCategory
+            //     - Element
+            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+            const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+            const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
 
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-
-            const directCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            const indirectSubCategory = insertSubCategory({
-              txn,
-              parentCategoryId: indirectCategory.id,
-              codeValue: "subCategory",
-              modelId: definitionModelChild.id,
-            });
-            return { definitionContainerRoot, definitionContainerChild, directCategory, indirectCategory, indirectSubCategory, physicalModel };
+            const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+            const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
+            return { definitionContainer, category, subCategory, elementsModel, element, defaultSubCategoryId: getDefaultSubCategoryId(category.id) };
           }),
         );
+      }
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerRoot.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: "all-visible",
-        });
-      });
-
-      it("showing definition container makes it and all of its contained elements visible and doesn't affect non contained definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
+      async function createUnrelatedDefContainersIModel() {
+        return buildIModel(async (imodel) =>
           withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            const indirectSubCategory = insertSubCategory({
-              txn,
-              parentCategoryId: indirectCategory.id,
-              codeValue: "subCategory",
-              modelId: definitionModelChild.id,
-            });
+            // Structure of the iModel:
+            // - DefinitionContainer
+            //   - Category
+            //     - Default SubCategory
+            //     - SubCategory
+            //     - Element
+            //
+            // - DefinitionContainer2
+            //   - Category2
+            //     - Default SubCategory2
+            //     - SubCategory2
+            //     - Element2
+            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+            const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+            const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+            const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+            const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
 
-            const definitionContainerRoot2 = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot2" });
-            const definitionModelRoot2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot2.id });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot2.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({ txn, parentCategoryId: category2.id, codeValue: "subCategory2", modelId: definitionModelRoot2.id });
-
+            const definitionContainer2 = insertDefinitionContainer({ txn, codeValue: "dc2" });
+            const definitionModel2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer2.id });
+            const category2 = insertCategory({ txn, codeValue: "cat2", modelId: definitionModel2.id });
+            const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: category2.id });
+            const subCategory2 = insertSubCategory({ txn, parentCategoryId: category2.id, codeValue: "subCat2", modelId: definitionModel2.id });
             return {
-              definitionContainerRoot,
-              definitionContainerChild,
-              indirectCategory,
-              indirectSubCategory,
-              definitionContainerRoot2,
+              definitionContainer,
+              category,
+              subCategory,
+              elementsModel,
+              element,
+              defaultSubCategoryId: getDefaultSubCategoryId(category.id),
+              definitionContainer2,
               category2,
               subCategory2,
-              physicalModel,
+              element2,
+              defaultSubCategoryId2: getDefaultSubCategoryId(category2.id),
             };
           }),
         );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerRoot.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "visible",
-              [keys.definitionContainerChild.id]: "visible",
-                [keys.indirectCategory.id]: "visible",
-                  [keys.indirectSubCategory.id]: "visible",
-                  [getDefaultSubCategoryId(keys.indirectCategory.id)]: "visible",
-
-            [keys.definitionContainerRoot2.id]: "hidden",
-              [keys.category2.id]: "hidden",
-                [keys.subCategory2.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-          },
-        });
-      });
-
-      it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more direct child categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-
-            const directCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            return { definitionContainerRoot, definitionContainerChild, directCategory, indirectCategory, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.directCategory.id]: "hidden",
-
-              [keys.definitionContainerChild.id]: "visible",
-                [keys.indirectCategory.id]: "visible",
-          },
-        });
-      });
-
-      it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-            const definitionContainerChild2 = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild2", modelId: definitionModelRoot.id });
-            const definitionModelChild2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild2.id });
-            const indirectCategory2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild2.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory2.id });
-            return { definitionContainerRoot, definitionContainerChild, indirectCategory2, indirectCategory, definitionContainerChild2, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "visible",
-                [keys.indirectCategory.id]: "visible",
-
-              [keys.definitionContainerChild2.id]: "hidden",
-                [keys.indirectCategory2.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing child definition container makes it, all of its contained elements and its parent definition container visible", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            const indirectSubCategory = insertSubCategory({
-              txn,
-              parentCategoryId: indirectCategory.id,
-              codeValue: "subCategory",
-              modelId: definitionModelChild.id,
-            });
-
-            return { definitionContainerRoot, definitionContainerChild, indirectCategory, indirectSubCategory, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: "all-visible",
-        });
-      });
-    });
-
-    describe("categories", () => {
-      it("showing category of hidden model does not enable other categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            const otherCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-            const categoryWithHideOverride = insertSpatialCategory({ txn, codeValue: "SpatialCategory3" });
-            const categoryWithShowOverride = insertSpatialCategory({ txn, codeValue: "SpatialCategory4" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: otherCategory.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryWithHideOverride.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryWithShowOverride.id });
-            return { category, otherCategory, categoryWithHideOverride, categoryWithShowOverride, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: getDefaultSubCategoryId(keys.category.id) }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: false });
-        viewport.changeCategoryDisplay({ categoryIds: keys.otherCategory.id, display: true });
-        viewport.changeSubCategoryDisplay({ subCategoryId: getDefaultSubCategoryId(keys.category.id), display: true });
-        viewport.setPerModelCategoryOverride({ modelIds: keys.physicalModel.id, categoryIds: keys.categoryWithHideOverride.id, override: "hide" });
-        viewport.setPerModelCategoryOverride({ modelIds: keys.physicalModel.id, categoryIds: keys.categoryWithShowOverride.id, override: "show" });
-        viewport.renderFrame();
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: {
-            [keys.category.id]: "visible",
-            [keys.otherCategory.id]: "partial",
-            [keys.categoryWithHideOverride.id]: "hidden",
-            [keys.categoryWithShowOverride.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing category makes it and all of its subCategories visible", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            return { category, subCategory, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: "all-visible",
-        });
-      });
-
-      it("showing category makes it, all of its contained subCategories visible and doesn't affect other categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category2.id,
-              codeValue: "subCategory2",
-            });
-
-            return { category, category2, subCategory, subCategory2, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "visible",
-              [getDefaultSubCategoryId(keys.category.id)]: "visible",
-              [keys.subCategory.id]: "visible",
-
-            [keys.category2.id]: "hidden",
-              [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-              [keys.subCategory2.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing category makes it, all of its contained subCategories visible and doesn't affect non related definition container", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-
-            const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModel.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category2.id,
-              codeValue: "subCategory2",
-              modelId: definitionContainer.id,
-            });
-
-            return { definitionContainer, category, category2, subCategory, subCategory2, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "visible",
-              [getDefaultSubCategoryId(keys.category.id)]: "visible",
-              [keys.subCategory.id]: "visible",
-
-            [keys.definitionContainer.id]: "hidden",
-              [keys.category2.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-                [keys.subCategory2.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing category makes it and all of its subcategories visible, and parent container partially visible if it has more direct child categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-              modelId: definitionModelRoot.id,
-            });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category2.id,
-              codeValue: "subCategory2",
-              modelId: definitionModelRoot.id,
-            });
-            return { definitionContainerRoot, category, category2, subCategory, subCategory2, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "visible",
-                [getDefaultSubCategoryId(keys.category.id)]: "visible",
-                [keys.subCategory.id]: "visible",
-
-              [keys.category2.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-                [keys.subCategory2.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing category makes it and all of its subCategories visible, and parent container partially visible if it has more definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-              modelId: definitionModelRoot.id,
-            });
-            return { definitionContainerRoot, definitionContainerChild, category, indirectCategory, subCategory, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "visible",
-                [keys.subCategory.id]: "visible",
-                [getDefaultSubCategoryId(keys.category.id)]: "visible",
-
-              [keys.definitionContainerChild.id]: "hidden",
-                [keys.indirectCategory.id]: "hidden",
-          },
-        });
-      });
-    });
-
-    describe("subCategories", () => {
-      it("showing subCategory of hidden model does not enable other categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            const otherCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-            const categoryWithHideOverride = insertSpatialCategory({ txn, codeValue: "SpatialCategory3" });
-            const categoryWithShowOverride = insertSpatialCategory({ txn, codeValue: "SpatialCategory4" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: otherCategory.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryWithHideOverride.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryWithShowOverride.id });
-            return { category, otherCategory, categoryWithHideOverride, categoryWithShowOverride, physicalModel, subCategory };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: [keys.subCategory.id, getDefaultSubCategoryId(keys.category.id)] }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: false });
-        viewport.changeCategoryDisplay({ categoryIds: keys.otherCategory.id, display: true });
-        viewport.setPerModelCategoryOverride({ modelIds: keys.physicalModel.id, categoryIds: keys.categoryWithHideOverride.id, override: "hide" });
-        viewport.setPerModelCategoryOverride({ modelIds: keys.physicalModel.id, categoryIds: keys.categoryWithShowOverride.id, override: "show" });
-        viewport.renderFrame();
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-
-            [keys.otherCategory.id]: "partial",
-            [keys.categoryWithHideOverride.id]: "hidden",
-            [keys.categoryWithShowOverride.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing subCategory makes it visible and its parent category partially visible, and doesn't affect other subCategories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory2",
-            });
-            return { category, subCategory, subCategory2, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: [keys.subCategory.id, keys.subCategory2.id] }],
-        });
-
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "partial",
-              [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-              [keys.subCategory.id]: "visible",
-              [keys.subCategory2.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing subCategory makes it visible and its parent category partially visible, and doesn't affect other categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            return { category, subCategory, category2, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "partial",
-              [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-              [keys.subCategory.id]: "visible",
-
-            [keys.category2.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing subCategory makes it visible and parents partially visible", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-              modelId: definitionModelRoot.id,
-            });
-            return { category, subCategory, definitionContainerRoot, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "partial",
-                [keys.subCategory.id]: "visible",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-          },
-        });
-      });
-
-      it("showing subCategory makes it visible and doesn't affect non related definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            const categoryOfDefinitionContainer = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryOfDefinitionContainer.id });
-            const subCategoryOfDefinitionContainer = insertSubCategory({
-              txn,
-              parentCategoryId: categoryOfDefinitionContainer.id,
-              codeValue: "subCategory2",
-              modelId: definitionModelRoot.id,
-            });
-            return { category, subCategory, definitionContainerRoot, categoryOfDefinitionContainer, subCategoryOfDefinitionContainer, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.categoryOfDefinitionContainer.id, subCategories: keys.subCategoryOfDefinitionContainer.id },
-          ],
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "hidden",
-              [keys.categoryOfDefinitionContainer.id]: "hidden",
-                [keys.subCategoryOfDefinitionContainer.id]: "hidden",
-                [getDefaultSubCategoryId(keys.categoryOfDefinitionContainer.id)]: "hidden",
-
-            [keys.category.id]: "partial",
-              [keys.subCategory.id]: "visible",
-              [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-          },
-        });
-      });
-    });
-
-    describe("elements set to 'include'", () => {
-      describe("definitionContainers", () => {
-        it("showing definition container makes it and all of its contained elements visible", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-
-              const directCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModelRoot.id });
-              const element1 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-              const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild.id });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: indirectCategory.id,
-                codeValue: "subCategory",
-                modelId: definitionModelChild.id,
-              });
-              return { definitionContainerRoot, physicalModel, directCategory, element1, element2, subCategory, definitionModelChild, indirectCategory };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.indirectCategory.id, subCategories: keys.subCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerRoot.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-visible",
-          });
-        });
-
-        it("showing definition container makes it and all of its contained elements visible and doesn't affect non contained definition containers", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-              const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-              const indirectElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-              const indirectSubCategory = insertSubCategory({
-                txn,
-                parentCategoryId: indirectCategory.id,
-                codeValue: "subCategory",
-                modelId: definitionModelChild.id,
-              });
-
-              const definitionContainerRoot2 = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot2" });
-              const definitionModelRoot2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot2.id });
-              const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot2.id });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-              const subCategory2 = insertSubCategory({ txn, parentCategoryId: category2.id, codeValue: "subCategory2", modelId: definitionModelRoot2.id });
-
-              return {
-                definitionContainerRoot,
-                definitionContainerChild,
-                indirectCategory,
-                indirectSubCategory,
-                definitionContainerRoot2,
-                category2,
-                subCategory2,
-                indirectElement,
-                element2,
-                physicalModel,
-              };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [
-              { categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id },
-              { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-            ],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerRoot.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "visible",
-                [keys.definitionContainerChild.id]: "visible",
-                  [keys.indirectCategory.id]: "visible",
-                    [getDefaultSubCategoryId(keys.indirectCategory.id)]: "visible",
-                    [keys.indirectElement.id]: "visible",
-                    [keys.indirectSubCategory.id]: "visible",
-
-              [keys.definitionContainerRoot2.id]: "hidden",
-                [keys.category2.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-                  [keys.element2.id]: "hidden",
-                  [keys.subCategory2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more direct child categories", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-
-              const directCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModelRoot.id });
-              const directElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-              const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild.id });
-              const indirectElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-              return { definitionContainerRoot, definitionContainerChild, directCategory, indirectCategory, directElement, indirectElement, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-                [keys.directCategory.id]: "hidden",
-                  [keys.directElement.id]: "hidden",
-
-                [keys.definitionContainerChild.id]: "visible",
-                  [keys.indirectCategory.id]: "visible",
-                    [keys.indirectElement.id]: "visible",
-            },
-          });
-        });
-
-        it("showing definition container makes it and all of its contained elements visible, and parent container partially visible if it has more definition containers", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-              const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-              const indirectElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-              const definitionContainerChild2 = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild2", modelId: definitionModelRoot.id });
-              const definitionModelChild2 = insertSubModel({
-                txn,
-                classFullName: CLASS_NAME_DefinitionModel,
-                modeledElementId: definitionContainerChild2.id,
-              });
-              const indirectCategory2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild2.id });
-              const indirectElement2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory2.id });
-              return {
-                definitionContainerRoot,
-                definitionContainerChild,
-                indirectCategory2,
-                indirectCategory,
-                definitionContainerChild2,
-                indirectElement,
-                indirectElement2,
-                physicalModel,
-              };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-                [keys.definitionContainerChild.id]: "visible",
-                  [keys.indirectCategory.id]: "visible",
-                    [keys.indirectElement.id]: "visible",
-
-                [keys.definitionContainerChild2.id]: "hidden",
-                  [keys.indirectCategory2.id]: "hidden",
-                    [keys.indirectElement2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing child definition container makes it, all of its contained elements and its parent definition container visible", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-              const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-              const indirectElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-              const indirectSubCategory = insertSubCategory({
-                txn,
-                parentCategoryId: indirectCategory.id,
-                codeValue: "subCategory",
-                modelId: definitionModelChild.id,
-              });
-
-              return { definitionContainerChild, indirectElement, indirectSubCategory, indirectCategory, definitionModelChild, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-visible",
-          });
-        });
-      });
-
-      describe("categories", () => {
-        it("showing category makes it, all of its subCategories and elements visible", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              return { category, subCategory, element, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            expectations: "all-visible",
-          });
-        });
-
-        it("showing category makes it, all of its contained subCategories and elements visible and doesn't affect other categories", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-              const subCategory2 = insertSubCategory({
-                txn,
-                parentCategoryId: category2.id,
-                codeValue: "subCategory2",
-              });
-
-              return { category, category2, subCategory, subCategory2, element, element2, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [
-              { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-              { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-            ],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.category.id]: "visible",
-                [getDefaultSubCategoryId(keys.category.id)]: "visible",
-                [keys.element.id]: "visible",
-                [keys.subCategory.id]: "visible",
-
-              [keys.category2.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-                [keys.element2.id]: "hidden",
-                [keys.subCategory2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing category makes it, all of its contained subCategories and elements visible and doesn't affect non related definition container", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-
-              const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-              const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModel.id });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-              const subCategory2 = insertSubCategory({
-                txn,
-                parentCategoryId: category2.id,
-                codeValue: "subCategory2",
-                modelId: definitionContainer.id,
-              });
-
-              return { definitionContainer, category, category2, subCategory, subCategory2, element, element2, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [
-              { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-              { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-            ],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.category.id]: "visible",
-                [getDefaultSubCategoryId(keys.category.id)]: "visible",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "visible",
-
-              [keys.definitionContainer.id]: "hidden",
-                [keys.category2.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-                  [keys.subCategory2.id]: "hidden",
-                  [keys.element2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing category makes it, all of its subcategories and elements visible, and parent container partially visible if it has more direct child categories", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelRoot.id });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-                modelId: definitionModelRoot.id,
-              });
-              const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-              const subCategory2 = insertSubCategory({
-                txn,
-                parentCategoryId: category2.id,
-                codeValue: "subCategory2",
-                modelId: definitionModelRoot.id,
-              });
-              return { definitionContainerRoot, category, category2, subCategory, subCategory2, element, element2, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [
-              { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-              { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-            ],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-                [keys.category.id]: "visible",
-                  [getDefaultSubCategoryId(keys.category.id)]: "visible",
-                  [keys.subCategory.id]: "visible",
-                  [keys.element.id]: "visible",
-
-                [keys.category2.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.category2.id)]: "hidden",
-                  [keys.subCategory2.id]: "hidden",
-                  [keys.element2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing category makes it, all of its subCategories and elements visible, and parent container partially visible if it has more definition containers", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-              const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-              const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-              const indirectElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-                modelId: definitionModelRoot.id,
-              });
-              return { definitionContainerRoot, definitionContainerChild, category, indirectCategory, subCategory, indirectElement, element, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-                [keys.definitionContainerChild.id]: "hidden",
-                  [keys.indirectCategory.id]: "hidden",
-                    [keys.indirectElement.id]: "hidden",
-
-                [keys.category.id]: "visible",
-                  [getDefaultSubCategoryId(keys.category.id)]: "visible",
-                  [keys.subCategory.id]: "visible",
-                  [keys.element.id]: "visible",
-            },
-          });
-        });
-      });
-
-      describe("subCategories", () => {
-        it("showing subCategory makes it visible and its parent category partially visible, and doesn't affect elements", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              const subCategory2 = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory2",
-              });
-              return { category, subCategory, subCategory2, element, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: [keys.subCategory.id, keys.subCategory2.id] }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-          setupInitialDisplayState({ viewport, elements: [{ id: keys.element.id, visible: false }] });
-          await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.category.id]: "partial",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                [keys.subCategory.id]: "visible",
-                [keys.subCategory2.id]: "hidden",
-                [keys.element.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing subCategory makes it visible and its parent category partially visible, and doesn't affect elements of other categories", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-              return { category, subCategory, category2, element, element2, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-          setupInitialDisplayState({
-            viewport,
-            elements: [
-              { id: keys.element.id, visible: false },
-              { id: keys.element2.id, visible: false },
-            ],
-          });
-
-          await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.category.id]: "partial",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "hidden",
-
-              [keys.category2.id]: "hidden",
-                [keys.element2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing subCategory makes it visible and parents partially visible", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelRoot.id });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-                modelId: definitionModelRoot.id,
-              });
-              return { category, subCategory, definitionContainerRoot, element, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-          setupInitialDisplayState({ viewport, elements: [{ id: keys.element.id, visible: false }] });
-
-          await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-                [keys.category.id]: "partial",
-                  [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                  [keys.subCategory.id]: "visible",
-                  [keys.element.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing subCategory makes it visible and doesn't affect non related definition containers", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              const categoryOfDefinitionContainer = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-              const elementOfDefinitionContainer = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryOfDefinitionContainer.id });
-              const subCategoryOfDefinitionContainer = insertSubCategory({
-                txn,
-                parentCategoryId: categoryOfDefinitionContainer.id,
-                codeValue: "subCategory2",
-                modelId: definitionModelRoot.id,
-              });
-              return {
-                category,
-                subCategory,
-                definitionContainerRoot,
-                categoryOfDefinitionContainer,
-                subCategoryOfDefinitionContainer,
-                element,
-                elementOfDefinitionContainer,
-                physicalModel,
-              };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [
-              { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-              { categoryId: keys.categoryOfDefinitionContainer.id, subCategories: keys.subCategoryOfDefinitionContainer.id },
-            ],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-          setupInitialDisplayState({
-            viewport,
-            elements: [
-              { id: keys.element.id, visible: false },
-              { id: keys.elementOfDefinitionContainer.id, visible: false },
-            ],
-          });
-
-          await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "hidden",
-                [keys.categoryOfDefinitionContainer.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryOfDefinitionContainer.id)]: "hidden",
-                  [keys.subCategoryOfDefinitionContainer.id]: "hidden",
-                  [keys.elementOfDefinitionContainer.id]: "hidden",
-
-              [keys.category.id]: "partial",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "hidden",
-            },
-          });
-        });
-      });
-
-      describe("elements", () => {
-        it("showing element makes it visible and its parent category partially visible, and doesn't affect other subCategories or elements", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              const subCategory2 = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory2",
-              });
-              return { category, subCategory, subCategory2, element, element2, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: [keys.subCategory.id, keys.subCategory2.id] }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(
-            createElementHierarchyNode({ modelId: keys.physicalModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
-            true,
-          );
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.category.id]: "partial",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                [keys.subCategory.id]: "hidden",
-                [keys.subCategory2.id]: "hidden",
-                [keys.element.id]: "visible",
-                [keys.element2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing element makes it visible and its parent category partially visible, and doesn't affect other categories or subCategories", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-              const element2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-              return { category, subCategory, category2, element, element2, physicalModel };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(
-            createElementHierarchyNode({ modelId: keys.physicalModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
-            true,
-          );
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.category.id]: "partial",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                [keys.subCategory.id]: "hidden",
-                [keys.element.id]: "visible",
-
-              [keys.category2.id]: "hidden",
-                [keys.element2.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing element makes it, its children visible and parents partially visible", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelRoot.id });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const childElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id, parentId: element.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-                modelId: definitionModelRoot.id,
-              });
-              return { category, subCategory, definitionContainerRoot, element, physicalModel, childElement };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          await handler.changeVisibility(
-            createElementHierarchyNode({ modelId: keys.physicalModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
-            true,
-          );
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "partial",
-                [keys.category.id]: "partial",
-                  [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                  [keys.subCategory.id]: "hidden",
-                  [keys.element.id]: "visible",
-                    [keys.childElement.id]: "visible",
-            },
-          });
-        });
-
-        it("showing subCategory makes it visible and doesn't affect non related definition containers", async () => {
-          await using buildIModelResult = await buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-              const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-              const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-              const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-              const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-              const subCategory = insertSubCategory({
-                txn,
-                parentCategoryId: category.id,
-                codeValue: "subCategory",
-              });
-              const categoryOfDefinitionContainer = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-              const elementOfDefinitionContainer = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryOfDefinitionContainer.id });
-              const subCategoryOfDefinitionContainer = insertSubCategory({
-                txn,
-                parentCategoryId: categoryOfDefinitionContainer.id,
-                codeValue: "subCategory2",
-                modelId: definitionModelRoot.id,
-              });
-              return {
-                category,
-                subCategory,
-                definitionContainerRoot,
-                categoryOfDefinitionContainer,
-                subCategoryOfDefinitionContainer,
-                element,
-                elementOfDefinitionContainer,
-                physicalModel,
-              };
-            }),
-          );
-
-          const { imodelConnection, ...keys } = buildIModelResult;
-
-          using visibilityTestData = await createVisibilityTestData({
-            imodelConnection,
-            subCategoriesOfCategories: [
-              { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-              { categoryId: keys.categoryOfDefinitionContainer.id, subCategories: keys.subCategoryOfDefinitionContainer.id },
-            ],
-            hierarchyConfig: { elements: { nodes: "include" } },
-          });
-          const { handler, provider, viewport } = visibilityTestData;
-
-          setupInitialDisplayState({
-            viewport,
-            elements: [
-              { id: keys.element.id, visible: false },
-              { id: keys.elementOfDefinitionContainer.id, visible: false },
-            ],
-          });
-
-          await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
-          await validateCategoriesTreeHierarchyVisibility({
-            provider,
-            handler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [keys.definitionContainerRoot.id]: "hidden",
-                [keys.categoryOfDefinitionContainer.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.categoryOfDefinitionContainer.id)]: "hidden",
-                  [keys.subCategoryOfDefinitionContainer.id]: "hidden",
-                  [keys.elementOfDefinitionContainer.id]: "hidden",
-
-              [keys.category.id]: "partial",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
-                [keys.subCategory.id]: "visible",
-                [keys.element.id]: "hidden",
-            },
-          });
-        });
-      });
-
-      ["2d" as const, "3d" as const].forEach((viewType) => {
-        const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
-        describe(`intermediate ${viewType} categories`, () => {
-          let buildIModelResult: Awaited<ReturnType<typeof createIntermediateCategoriesIModel>>;
-          let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
-
-          async function createIntermediateCategoriesIModel() {
-            return buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const elementsModel = insertElementsModel({ txn, codeValue: "elements model" });
-                const categoryA = insertCategory({ txn, codeValue: "categoryA" });
-                const categoryB = insertCategory({ txn, codeValue: "categoryB" });
-                const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
-                const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
-                return { categoryA, categoryB, parentElement, childElement, elementsModel };
-              }),
-            );
-          }
-
-          beforeAll(async () => {
-            buildIModelResult = await createIntermediateCategoriesIModel();
-          });
-
-          beforeEach(async () => {
-            visibilityTestData = await createVisibilityTestData({
-              imodelConnection: buildIModelResult.imodelConnection,
-              hierarchyConfig: { elements: { nodes: "include" } },
-              viewType,
-            });
-          });
-
-          afterEach(() => {
-            visibilityTestData[Symbol.dispose]();
-          });
-
-          afterAll(async () => {
-            await buildIModelResult.imodelConnection.close();
-          });
-
-          it("showing intermediate category makes its elements visible and parent element partially visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createCategoryHierarchyNode({
-                id: keys.categoryB.id,
-                modelIds: [keys.elementsModel.id],
-                hasChildren: true,
-                parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
-              }),
-              true,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.parentElement.id]: "partial",
-                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
-                      [keys.childElement.id]: "visible",
-
-                [keys.categoryB.id]: "hidden",
-              },
-            });
-          });
-
-          it("showing child element under intermediate category makes it visible and parents partially visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.elementsModel.id,
-                categoryId: keys.categoryB.id,
-                elementId: keys.childElement.id,
-                parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
-              }),
-              true,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.parentElement.id]: "partial",
-                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
-                      [keys.childElement.id]: "visible",
-
-                [keys.categoryB.id]: "hidden",
-              },
-            });
-          });
-
-          it("showing parent element makes children under intermediate category visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.elementsModel.id,
-                categoryId: keys.categoryA.id,
-                elementId: keys.parentElement.id,
-                hasChildren: true,
-              }),
-              true,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  // Category has a sub-category which is hidden
-                  [keys.parentElement.id]: "visible",
-                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
-                      [keys.childElement.id]: "visible",
-
-                [keys.categoryB.id]: "hidden",
-              },
-            });
-          });
-        });
-
-        describe(`intermediate ${viewType} categories under sub-model`, () => {
-          let buildIModelResult: Awaited<ReturnType<typeof createSubModelIntermediateCategoriesIModel>>;
-          let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
-
-          async function createSubModelIntermediateCategoriesIModel() {
-            return buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const elementsModel = insertElementsModel({ txn, codeValue: "elements model" });
-                const categoryA = insertCategory({ txn, codeValue: "categoryA" });
-                const categoryB = insertCategory({ txn, codeValue: "categoryB" });
-                const modeledElement = insertModeledElement({
-                  txn,
-                  modelId: elementsModel.id,
-                  categoryId: categoryA.id,
-                });
-                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-                const subModelElement = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
-                return { categoryA, categoryB, modeledElement, subModel, subModelElement, elementsModel };
-              }),
-            );
-          }
-
-          beforeAll(async () => {
-            buildIModelResult = await createSubModelIntermediateCategoriesIModel();
-          });
-
-          beforeEach(async () => {
-            visibilityTestData = await createVisibilityTestData({
-              imodelConnection: buildIModelResult.imodelConnection,
-              hierarchyConfig: { elements: { nodes: "include" } },
-              viewType,
-            });
-          });
-
-          afterEach(() => {
-            visibilityTestData[Symbol.dispose]();
-          });
-
-          afterAll(async () => {
-            await buildIModelResult.imodelConnection.close();
-          });
-
-          it("showing intermediate category under sub-model makes its elements visible and modeled element partially visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createCategoryHierarchyNode({
-                id: keys.categoryB.id,
-                modelIds: [keys.modeledElement.id],
-                hasChildren: true,
-              }),
-              true,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.modeledElement.id]: "partial",
-                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
-                      [keys.subModelElement.id]: "visible",
-
-                [keys.categoryB.id]: "hidden",
-              },
-            });
-          });
-
-          it("showing element under intermediate category in sub-model makes it visible and parents partially visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.modeledElement.id,
-                categoryId: keys.categoryB.id,
-                elementId: keys.subModelElement.id,
-              }),
-              true,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.modeledElement.id]: "partial",
-                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
-                      [keys.subModelElement.id]: "visible",
-
-                [keys.categoryB.id]: "hidden",
-              },
-            });
-          });
-
-          it("showing modeled element makes sub-model elements under intermediate category visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.elementsModel.id,
-                categoryId: keys.categoryA.id,
-                elementId: keys.modeledElement.id,
-                hasChildren: true,
-              }),
-              true,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  // Category has a sub-category which is hidden
-                  [keys.modeledElement.id]: "visible",
-                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
-                      [keys.subModelElement.id]: "visible",
-
-                [keys.categoryB.id]: "hidden",
-              },
-            });
-          });
-        });
-      });
-
-      interface IModelWithSubModelIds {
-        modeledElement: InstanceKey;
-        model: InstanceKey;
-        category: InstanceKey;
-        subModelCategory?: InstanceKey;
-        subModelElement?: InstanceKey;
-        subModel: InstanceKey;
       }
 
-      const testCases: Array<{
-        describeName: string;
-        createIModel: () => Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds>;
-        cases: Array<{
-          only?: boolean;
-          name: string;
-          getTargetNode: (ids: IModelWithSubModelIds) => NonGroupingHierarchyNode | GroupingHierarchyNode;
-          expectations: (ids: IModelWithSubModelIds) => "all-visible" | "all-hidden" | VisibilityExpectations;
-        }>;
-      }> = [
-        {
-          describeName: "with modeled elements",
-          createIModel: async function createIModel(): Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds> {
-            return buildIModel(async (imodel, testSchema) =>
-              withEditTxn(imodel, (txn) => {
-                const rootSubject: InstanceKey = { className: CLASS_NAME_Subject, id: IModel.rootSubjectId };
-                const partition = insertPhysicalPartition({ txn, codeValue: "model", parentId: rootSubject.id });
-                const model = insertPhysicalSubModel({ txn, modeledElementId: partition.id });
-                const category = insertSpatialCategory({ txn, codeValue: "category" });
-                const modeledElement = insertPhysicalElement({
-                  txn,
-                  userLabel: `element`,
-                  modelId: model.id,
-                  categoryId: category.id,
-                  classFullName: testSchema.items.SubModelablePhysicalObject.fullName,
-                });
-                const subModel = insertPhysicalSubModel({ txn, modeledElementId: modeledElement.id });
-                const subModelCategory = insertSpatialCategory({ txn, codeValue: "category2" });
-                const subModelElement = insertPhysicalElement({ txn, userLabel: `element2`, modelId: subModel.id, categoryId: subModelCategory.id });
-                return {
-                  modeledElement,
-                  model,
-                  category,
-                  subModelCategory,
-                  subModelElement,
-                  subModel,
-                };
-              }),
-            );
-          },
-          cases: [
-            {
-              name: "modeled element's children display is turned on when its category display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.category.id, hasChildren: true }),
-              // prettier-ignore
-              expectations: (ids) => ({
-                [ids.category.id]: "visible",
-                  [ids.modeledElement.id]: "visible",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
-                      [ids.subModelElement!.id]: "visible",
+      async function createSiblingCategoriesIModel() {
+        return buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            // Structure of the iModel:
+            // - Parent DefinitionContainer
+            //   - Category
+            //    - Element
+            //   - Child DefinitionContainer
+            //     - Child Category
+            //       - Child element
+            //     - Child Category2
+            //       - Child element2
+            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+            const parentDefinitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+            const parentDefinitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefinitionContainer.id });
+            const childDefinitionContainer = insertDefinitionContainer({ txn, codeValue: "child dc", modelId: parentDefinitionModel.id });
+            const childDefinitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefinitionContainer.id });
+            const childCategory = insertCategory({ txn, codeValue: "child cat", modelId: childDefinitionModel.id });
+            const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: childCategory.id });
+            const childCategory2 = insertCategory({ txn, codeValue: "child cat2", modelId: childDefinitionModel.id });
+            const childElement2 = insertElement({ txn, modelId: elementsModel.id, categoryId: childCategory2.id });
 
-                [ids.subModelCategory!.id]: "hidden",
-              }),
-            },
-            {
-              name: "modeled element's children display is turned on when its class grouping node display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) =>
-                createClassGroupingHierarchyNode({
-                  categoryId: ids.category.id,
-                  modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
-                }),
-              // prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory!.id]: "hidden",
+            const category = insertCategory({ txn, codeValue: "cat", modelId: parentDefinitionModel.id });
+            const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+            return {
+              parentDefinitionContainer,
+              childDefinitionContainer,
+              childCategory,
+              childElement,
+              childCategory2,
+              childElement2,
+              category,
+              elementsModel,
+              element,
+            };
+          }),
+        );
+      }
 
-                [ids.category.id]: "partial",
-                  [ids.modeledElement.id]: "visible",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
-                      [ids.subModelElement!.id]: "visible",
-              }),
-            },
-            {
-              name: "modeled element's children display is turned on when its display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) =>
-                createElementHierarchyNode({
-                  modelId: ids.model.id,
-                  categoryId: ids.category.id,
-                  elementId: ids.modeledElement.id,
-                  hasChildren: true,
-                }),
-              // prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory!.id]: "hidden",
+      async function createElementsModelsIModel() {
+        return buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            // Structure of the iModel:
+            // - CategoryA
+            //   - ElementA1 (model1)
+            //   - ElementA2 (model2)
+            // - CategoryB
+            //   - ElementB1 (model1)
+            //   - ElementB2 (model2)
+            const elementsModel1 = insertElementsModel({ txn, codeValue: "m1" });
+            const elementsModel2 = insertElementsModel({ txn, codeValue: "m2" });
+            const categoryA = insertCategory({ txn, codeValue: "catA" });
+            const categoryB = insertCategory({ txn, codeValue: "catB" });
+            const elementA1 = insertElement({ txn, modelId: elementsModel1.id, categoryId: categoryA.id });
+            const elementA2 = insertElement({ txn, modelId: elementsModel2.id, categoryId: categoryA.id });
+            const elementB1 = insertElement({ txn, modelId: elementsModel1.id, categoryId: categoryB.id });
+            const elementB2 = insertElement({ txn, modelId: elementsModel2.id, categoryId: categoryB.id });
+            return { elementsModel1, elementsModel2, categoryA, categoryB, elementA1, elementA2, elementB1, elementB2 };
+          }),
+        );
+      }
 
-                [ids.category.id]: "partial",
-                  [ids.modeledElement.id]: "visible",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
-                      [ids.subModelElement!.id]: "visible",
-              }),
-            },
-            {
-              name: "modeled element's children display is turned on when its sub-model display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) => createModelHierarchyNode({ id: ids.modeledElement.id, hasChildren: true }),
-              // prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory!.id]: "hidden",
+      async function createIntermediateCategoriesIModel() {
+        return buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+            const categoryA = insertCategory({ txn, codeValue: "catA" });
+            const categoryB = insertCategory({ txn, codeValue: "catB" });
+            const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
+            const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
+            return { categoryA, categoryB, parentElement, childElement, elementsModel };
+          }),
+        );
+      }
 
-                [ids.category.id]: "partial",
-                  [ids.modeledElement.id]: "partial",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
-                      [ids.subModelElement!.id]: "visible",
-              }),
-            },
-            {
-              name: "modeled element, its model and category have partial visibility when its sub-model element's category display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.subModelCategory!.id, modelIds: [ids.modeledElement.id] }),
-              // prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory!.id]: "hidden",
+      async function createSubModelIntermediateCategoriesIModel() {
+        return buildIModel(async (imodel) =>
+          withEditTxn(imodel, (txn) => {
+            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+            const categoryA = insertCategory({ txn, codeValue: "catA" });
+            const categoryB = insertCategory({ txn, codeValue: "catB" });
+            const modeledElement = insertModeledElement({
+              txn,
+              modelId: elementsModel.id,
+              categoryId: categoryA.id,
+            });
+            const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+            const subModelElement = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
+            return { categoryA, categoryB, modeledElement, subModel, subModelElement, elementsModel };
+          }),
+        );
+      }
 
-                [ids.category.id]: "partial",
-                  [ids.modeledElement.id]: "partial",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
-                      [ids.subModelElement!.id]: "visible",
-              }),
-            },
-            {
-              name: "modeled element, its model and category have partial visibility when its sub-model element's display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) =>
-                createElementHierarchyNode({
-                  modelId: ids.modeledElement.id,
-                  categoryId: ids.subModelCategory!.id,
-                  elementId: ids.subModelElement!.id,
-                }),
-              // prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.subModelCategory!.id]: "hidden",
+      beforeAll(async () => {
+        simpleIModel = await createSimpleIModel();
+        accessAndCacheSimpleIModel = createAccessAndCache({ imodelConnection: simpleIModel.imodelConnection, viewType });
 
-                [ids.category.id]: "partial",
-                  [ids.modeledElement.id]: "partial",
-                    [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
-                      [ids.subModelElement!.id]: "visible",
-              }),
-            },
-          ],
-        },
-        {
-          describeName: "with modeled elements that have private subModel",
-          createIModel: async function createIModel(): Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds> {
-            return buildIModel(async (imodel, testSchema) =>
-              withEditTxn(imodel, (txn) => {
-                const rootSubject: InstanceKey = { className: CLASS_NAME_Subject, id: IModel.rootSubjectId };
-                const partition = insertPhysicalPartition({ txn, codeValue: "model", parentId: rootSubject.id });
-                const model = insertPhysicalSubModel({ txn, modeledElementId: partition.id });
-                const category = insertSpatialCategory({ txn, codeValue: "category" });
-                const modeledElement = insertPhysicalElement({
-                  txn,
-                  userLabel: `element`,
-                  modelId: model.id,
-                  categoryId: category.id,
-                  classFullName: testSchema.items.SubModelablePhysicalObject.fullName,
-                });
-                const subModel = insertPhysicalSubModel({ txn, modeledElementId: modeledElement.id, isPrivate: true });
-                const subModelCategory = insertSpatialCategory({ txn, codeValue: "category2" });
-                const subModelElement = insertPhysicalElement({ txn, userLabel: `element2`, modelId: subModel.id, categoryId: subModelCategory.id });
-                return {
-                  modeledElement,
-                  model,
-                  category,
-                  subModelCategory,
-                  subModelElement,
-                  subModel,
-                };
-              }),
-            );
-          },
-          cases: [
-            {
-              name: "children are visible when category display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.category.id, hasChildren: true }),
-              // prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.category.id]: "visible",
-                  [ids.modeledElement.id]: "visible",
-              }),
-            },
-            {
-              name: "child elements are visible when elements class grouping node display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) =>
-                createClassGroupingHierarchyNode({
-                  categoryId: ids.category.id,
-                  modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
-                }),
-              // prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.category.id]: "partial",
-                  // Category has hidden sub-category
-                  [ids.modeledElement.id]: "visible",
-              }),
-            },
-            {
-              name: "everything under model is visible when elements display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) =>
-                createElementHierarchyNode({
-                  modelId: ids.model.id,
-                  categoryId: ids.category.id,
-                  elementId: ids.modeledElement.id,
-                  hasChildren: false,
-                }),
-              //prettier-ignore
-              expectations: (ids: IModelWithSubModelIds) => ({
-                [ids.category.id]: "partial",
-                  // Category has hidden sub-category
-                  [ids.modeledElement.id]: "visible",
-              }),
-            },
-          ],
-        },
-        {
-          describeName: "with modeled elements that have subModel with no children",
-          createIModel: async function createIModel(): Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds> {
-            return buildIModel(async (imodel, testSchema) =>
-              withEditTxn(imodel, (txn) => {
-                const rootSubject: InstanceKey = { className: CLASS_NAME_Subject, id: IModel.rootSubjectId };
-                const partition = insertPhysicalPartition({ txn, codeValue: "model", parentId: rootSubject.id });
-                const model = insertPhysicalSubModel({ txn, modeledElementId: partition.id });
-                const category = insertSpatialCategory({ txn, codeValue: "category" });
-                const modeledElement = insertPhysicalElement({
-                  txn,
-                  userLabel: `element`,
-                  modelId: model.id,
-                  categoryId: category.id,
-                  classFullName: testSchema.items.SubModelablePhysicalObject.fullName,
-                });
-                const subModel = insertPhysicalSubModel({ txn, modeledElementId: modeledElement.id });
-                return {
-                  rootSubject,
-                  modeledElement,
-                  model,
-                  category,
-                  subModel,
-                };
-              }),
-            );
-          },
-          cases: [
-            {
-              name: "everything is visible when category display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.category.id, hasChildren: true }),
-              expectations: () => "all-visible",
-            },
-            {
-              name: "everything under model is visible when elements class grouping node display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) =>
-                createClassGroupingHierarchyNode({
-                  categoryId: ids.category.id,
-                  modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
-                }),
-              // Category has partial visibility, since its sub-category is not visible
-              // prettier-ignore
-              expectations: (ids) => ({
-                [ids.category.id]: "partial",
-                  [ids.modeledElement.id]: "visible",
-              }),
-            },
-            {
-              name: "everything under model is visible when elements display is turned on",
-              getTargetNode: (ids: IModelWithSubModelIds) =>
-                createElementHierarchyNode({
-                  modelId: ids.model.id,
-                  categoryId: ids.category.id,
-                  elementId: ids.modeledElement.id,
-                  hasChildren: false,
-                }),
-              // Category has partial visibility, since its sub-category is not visible
-              // prettier-ignore
-              expectations: (ids) => ({
-                [ids.category.id]: "partial",
-                  [ids.modeledElement.id]: "visible",
-              }),
-            },
-          ],
-        },
-      ];
-      testCases.forEach(({ describeName, createIModel, cases }) => {
-        describe(describeName, () => {
-          let iModel: IModelConnection;
-          let createdIds: IModelWithSubModelIds;
+        unrelatedDefContainersIModel = await createUnrelatedDefContainersIModel();
+        accessAndCacheUnrelatedDefContainersIModel = createAccessAndCache({ imodelConnection: unrelatedDefContainersIModel.imodelConnection, viewType });
 
-          beforeAll(async () => {
-            const { imodelConnection, ...ids } = await createIModel();
-            iModel = imodelConnection;
-            createdIds = ids;
+        siblingCategoriesIModel = await createSiblingCategoriesIModel();
+        accessAndCacheSiblingCategoriesIModel = createAccessAndCache({ imodelConnection: siblingCategoriesIModel.imodelConnection, viewType });
+
+        elementsModelsIModel = await createElementsModelsIModel();
+        accessAndCacheElementsModelsIModel = createAccessAndCache({ imodelConnection: elementsModelsIModel.imodelConnection, viewType });
+
+        intermediateCategoriesIModel = await createIntermediateCategoriesIModel();
+        accessAndCacheIntermediateCategoriesIModel = createAccessAndCache({ imodelConnection: intermediateCategoriesIModel.imodelConnection, viewType });
+
+        subModelIntermediateCategoriesIModel = await createSubModelIntermediateCategoriesIModel();
+        accessAndCacheSubModelIntermediateCategoriesIModel = createAccessAndCache({
+          imodelConnection: subModelIntermediateCategoriesIModel.imodelConnection,
+          viewType,
+        });
+      });
+
+      afterAll(async () => {
+        await simpleIModel.imodelConnection.close();
+        await unrelatedDefContainersIModel.imodelConnection.close();
+        await siblingCategoriesIModel.imodelConnection.close();
+        await elementsModelsIModel.imodelConnection.close();
+        await intermediateCategoriesIModel.imodelConnection.close();
+        await subModelIntermediateCategoriesIModel.imodelConnection.close();
+      });
+
+      describe("enabling visibility", () => {
+        it("by default everything is hidden", async () => {
+          const { imodelConnection, ...keys } = simpleIModel;
+
+          using visibilityTestData = await createVisibilityTestData({
+            imodelConnection,
+            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+            ...accessAndCacheSimpleIModel,
+          });
+          const { handler, provider, viewport } = visibilityTestData;
+
+          await validateCategoriesTreeHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+        });
+
+        it("category is partial when multiple models contain category and override for one model is set to 'Show'", async () => {
+          const { imodelConnection, ...keys } = elementsModelsIModel;
+
+          using visibilityTestData = await createVisibilityTestData({
+            imodelConnection,
+            ...accessAndCacheElementsModelsIModel,
+          });
+          const { handler, provider, viewport } = visibilityTestData;
+          setupInitialDisplayState({
+            viewport,
+            models: [
+              { id: keys.elementsModel1.id, visible: true },
+              { id: keys.elementsModel2.id, visible: true },
+            ],
           });
 
-          afterAll(async () => {
-            await iModel.close();
+          viewport.setPerModelCategoryOverride({
+            modelIds: keys.elementsModel1.id,
+            categoryIds: keys.categoryA.id,
+            override: "show",
           });
 
-          cases.forEach(({ name, getTargetNode, expectations, only }) => {
-            (only ? it.only : it)(name, async function () {
+          await validateCategoriesTreeHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: {
+              [keys.categoryA.id]: "partial",
+              [keys.categoryB.id]: "hidden",
+            },
+          });
+        });
+
+        describe("definitionContainers", () => {
+          it("showing definition container turns on children", async () => {
+            const { imodelConnection, ...keys } = simpleIModel;
+
+            const accessAndCache = createAccessAndCache({ imodelConnection, viewType });
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+              ...accessAndCache,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              expectations: "all-visible",
+            });
+          });
+
+          it("showing definition container doesn't affect non contained definition containers", async () => {
+            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [
+                { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+              ],
+              ...accessAndCacheUnrelatedDefContainersIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "visible",
+                  [keys.category.id]: "visible",
+                    [keys.subCategory.id]: "visible",
+                    [keys.defaultSubCategoryId]: "visible",
+
+                [keys.definitionContainer2.id]: "hidden",
+                  [keys.category2.id]: "hidden",
+                    [keys.subCategory2.id]: "hidden",
+                    [keys.defaultSubCategoryId2]: "hidden",
+              },
+            });
+          });
+
+          it("showing definition container affects parent", async () => {
+            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              ...accessAndCacheSiblingCategoriesIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.childDefinitionContainer.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.parentDefinitionContainer.id]: "partial",
+                  [keys.category.id]: "hidden",
+
+                  [keys.childDefinitionContainer.id]: "visible",
+                    [keys.childCategory.id]: "visible",
+                    [keys.childCategory2.id]: "visible",
+              },
+            });
+          });
+        });
+
+        describe("categories", () => {
+          it("showing category of hidden model does not enable other categories", async () => {
+            const { imodelConnection, ...keys } = elementsModelsIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              ...accessAndCacheElementsModelsIModel,
+              hierarchyConfig: { elements: { nodes: "include" } },
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            viewport.changeModelDisplay({ modelIds: keys.elementsModel1.id, display: false });
+            viewport.changeModelDisplay({ modelIds: keys.elementsModel2.id, display: true });
+            viewport.setPerModelCategoryOverride({ modelIds: keys.elementsModel1.id, categoryIds: keys.categoryA.id, override: "hide" });
+            viewport.setPerModelCategoryOverride({ modelIds: keys.elementsModel1.id, categoryIds: keys.categoryB.id, override: "show" });
+            viewport.renderFrame();
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.categoryA.id]: "hidden",
+                  [keys.elementA1.id]: "hidden",
+                  [keys.elementA2.id]: "hidden",
+
+                [keys.categoryB.id]: "hidden",
+                  [keys.elementB1.id]: "hidden",
+                  [keys.elementB2.id]: "hidden",
+              },
+            });
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.categoryA.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.categoryA.id]: "visible",
+                  [keys.elementA1.id]: "visible",
+                  [keys.elementA2.id]: "visible",
+
+                [keys.categoryB.id]: "hidden",
+                  [keys.elementB1.id]: "hidden", // ElementB1 is still hidden even though categoryB used to have a 'show' override
+                  [keys.elementB2.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing category turns on parents and children", async () => {
+            const { imodelConnection, ...keys } = simpleIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+              ...accessAndCacheSimpleIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              expectations: "all-visible",
+            });
+          });
+
+          it("showing category doesn't affect unrelated nodes", async () => {
+            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [
+                { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+              ],
+              ...accessAndCacheUnrelatedDefContainersIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "visible",
+                  [keys.category.id]: "visible",
+                    [keys.defaultSubCategoryId]: "visible",
+                    [keys.subCategory.id]: "visible",
+
+                [keys.definitionContainer2.id]: "hidden",
+                  [keys.category2.id]: "hidden",
+                    [keys.defaultSubCategoryId2]: "hidden",
+                    [keys.subCategory2.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing category makes parent container partially visible if it has more direct child categories", async () => {
+            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              ...accessAndCacheSiblingCategoriesIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.childCategory.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.parentDefinitionContainer.id]: "partial",
+                  [keys.category.id]: "hidden",
+
+                  [keys.childDefinitionContainer.id]: "partial",
+                    [keys.childCategory.id]: "visible",
+                    [keys.childCategory2.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing category makes parent container partially visible if it has more definition containers", async () => {
+            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              ...accessAndCacheSiblingCategoriesIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.parentDefinitionContainer.id]: "partial",
+                  [keys.category.id]: "visible",
+
+                  [keys.childDefinitionContainer.id]: "hidden",
+                    [keys.childCategory.id]: "hidden",
+                    [keys.childCategory2.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("subCategories", () => {
+          it("showing subCategory of hidden model does not affect other categories", async () => {
+            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [
+                { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+              ],
+              ...accessAndCacheUnrelatedDefContainersIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            viewport.changeModelDisplay({ modelIds: keys.elementsModel.id, display: false });
+            viewport.changeCategoryDisplay({ categoryIds: keys.category2.id, display: true });
+            viewport.renderFrame();
+            await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "partial",
+                  [keys.category.id]: "partial",
+                    [keys.defaultSubCategoryId]: "hidden",
+                    [keys.subCategory.id]: "visible",
+
+                [keys.definitionContainer2.id]: "hidden",
+                  [keys.category2.id]: "hidden",
+                    [keys.defaultSubCategoryId2]: "hidden",
+                    [keys.subCategory2.id]: "hidden",
+              },
+            });
+          });
+
+          it("showing subCategory doesn't affect sibling subCategories", async () => {
+            const { imodelConnection, ...keys } = simpleIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+              ...accessAndCacheSimpleIModel,
+            });
+
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "partial",
+                  [keys.category.id]: "partial",
+                    [keys.defaultSubCategoryId]: "hidden",
+                    [keys.subCategory.id]: "visible",
+              },
+            });
+          });
+
+          it("showing subCategory doesn't affect non related nodes", async () => {
+            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [
+                { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+              ],
+              ...accessAndCacheUnrelatedDefContainersIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "partial",
+                  [keys.category.id]: "partial",
+                    [keys.defaultSubCategoryId]: "hidden",
+                    [keys.subCategory.id]: "visible",
+
+                [keys.definitionContainer2.id]: "hidden",
+                  [keys.category2.id]: "hidden",
+                    [keys.defaultSubCategoryId2]: "hidden",
+                    [keys.subCategory2.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("elements set to 'include'", () => {
+          describe("definitionContainers", () => {
+            it("showing definition container turns on children", async () => {
+              const { imodelConnection, ...keys } = simpleIModel;
+
               using visibilityTestData = await createVisibilityTestData({
-                imodelConnection: iModel,
+                imodelConnection,
+                subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSimpleIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
+
+              await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id }), true);
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                expectations: "all-visible",
+              });
+            });
+
+            it("showing definition container doesn't affect non contained definition containers", async () => {
+              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [
+                  { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                  { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+                ],
+                ...accessAndCacheUnrelatedDefContainersIModel,
                 hierarchyConfig: { elements: { nodes: "include" } },
               });
               const { handler, provider, viewport } = visibilityTestData;
 
-              const nodeToChangeVisibility = getTargetNode(createdIds);
+              await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id }), true);
               await validateCategoriesTreeHierarchyVisibility({
                 provider,
                 handler,
                 viewport,
-                expectations: "all-hidden",
+                // prettier-ignore
+                expectations: {
+                  [keys.definitionContainer.id]: "visible",
+                      [keys.category.id]: "visible",
+                        [keys.defaultSubCategoryId]: "visible",
+                        [keys.subCategory.id]: "visible",
+                        [keys.element.id]: "visible",
+
+                  [keys.definitionContainer2.id]: "hidden",
+                      [keys.category2.id]: "hidden",
+                        [keys.defaultSubCategoryId2]: "hidden",
+                        [keys.subCategory2.id]: "hidden",
+                        [keys.element2.id]: "hidden",
+                },
               });
-              await handler.changeVisibility(nodeToChangeVisibility, true);
-              await validateCategoriesTreeHierarchyVisibility({
-                provider,
-                handler,
-                viewport,
-                expectations: expectations(createdIds),
+            });
+
+            it("showing child definition container affects parent", async () => {
+              const { imodelConnection, ...keys } = siblingCategoriesIModel;
+
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSiblingCategoriesIModel,
               });
-              await handler.changeVisibility(nodeToChangeVisibility, false);
+              const { handler, provider, viewport } = visibilityTestData;
+
+              await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.childDefinitionContainer.id }), true);
               await validateCategoriesTreeHierarchyVisibility({
                 provider,
                 handler,
                 viewport,
-                expectations: "all-hidden",
+                // prettier-ignore
+                expectations: {
+                  [keys.parentDefinitionContainer.id]: "partial",
+                    [keys.category.id]: "hidden",
+                      [keys.element.id]: "hidden",
+
+                    [keys.childDefinitionContainer.id]: "visible",
+                      [keys.childCategory.id]: "visible",
+                        [keys.childElement.id]: "visible",
+
+                      [keys.childCategory2.id]: "visible",
+                        [keys.childElement2.id]: "visible",
+                },
               });
             });
           });
-        });
-      });
-    });
 
-    describe("enabling category visibility through overrides", () => {
-      it("category is partial when multiple models contain category and override for one model is set to 'Show'", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "1" });
-            const physicalModel2 = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "2" });
+          describe("categories", () => {
+            it("showing category turns on children", async () => {
+              const { imodelConnection, ...keys } = simpleIModel;
 
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            insertPhysicalElement({ txn, modelId: physicalModel2.id, categoryId: category.id });
-            return { category, physicalModel, physicalModel2 };
-          }),
-        );
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSimpleIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({ imodelConnection });
-        const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({
-          viewport,
-          models: [
-            { id: keys.physicalModel.id, visible: true },
-            { id: keys.physicalModel2.id, visible: true },
-          ],
-        });
-
-        viewport.setPerModelCategoryOverride({
-          modelIds: keys.physicalModel.id,
-          categoryIds: keys.category.id,
-          override: "show",
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: {
-            [keys.category.id]: "partial",
-          },
-        });
-      });
-    });
-
-    describe("enabling category visibility through model selector", () => {
-      it("category is visible when only one model contains category and model is enabled through model selector", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            return { category, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({ imodelConnection });
-        const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, categories: [{ id: keys.category.id, visible: true }] });
-
-        viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: true });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: "all-visible",
-        });
-      });
-
-      it("category is partial when multiple models contain category and one model is enabled through model selector", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "1" });
-            const physicalModel2 = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "2" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            insertPhysicalElement({ txn, modelId: physicalModel2.id, categoryId: category.id });
-            return { category, physicalModel, physicalModel2 };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({ imodelConnection });
-        const { handler, provider, viewport } = visibilityTestData;
-        setupInitialDisplayState({ viewport, categories: [{ id: keys.category.id, visible: true }] });
-
-        viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: true });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: {
-            [keys.category.id]: "partial",
-          },
-        });
-      });
-    });
-  });
-
-  describe("disabling visibility", () => {
-    it("by default everything is visible", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCategory", modelId: definitionModel.id });
-          return { category, physicalModel, subCategory };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-      using visibilityTestData = await createVisibilityTestData({
-        imodelConnection,
-        subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-        visibleByDefault: true,
-      });
-      const { handler, provider, viewport } = visibilityTestData;
-
-      await validateCategoriesTreeHierarchyVisibility({
-        provider,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-    });
-
-    describe("definitionContainers", () => {
-      it("hiding definition container makes it and all of its contained elements hidden", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-
-            const directCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            const indirectSubCategory = insertSubCategory({
-              txn,
-              parentCategoryId: indirectCategory.id,
-              codeValue: "subCategory",
-              modelId: definitionModelChild.id,
-            });
-            return { definitionContainerRoot, definitionContainerChild, directCategory, indirectCategory, indirectSubCategory, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id }],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerRoot.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: "all-hidden",
-        });
-      });
-
-      it("hiding definition container makes it and all of its contained elements hidden and doesn't affect non contained definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            const indirectSubCategory = insertSubCategory({
-              txn,
-              parentCategoryId: indirectCategory.id,
-              codeValue: "subCategory",
-              modelId: definitionModelChild.id,
+              await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                expectations: "all-visible",
+              });
             });
 
-            const definitionContainerRoot2 = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot2" });
-            const definitionModelRoot2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot2.id });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot2.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({ txn, parentCategoryId: category2.id, codeValue: "subCategory2", modelId: definitionModelRoot2.id });
+            it("showing category doesn't affect other categories", async () => {
+              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
 
-            return {
-              definitionContainerRoot,
-              definitionContainerChild,
-              indirectCategory,
-              indirectSubCategory,
-              definitionContainerRoot2,
-              category2,
-              subCategory2,
-              physicalModel,
-            };
-          }),
-        );
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [
+                  { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                  { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+                ],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheUnrelatedDefContainersIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+              await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.definitionContainer.id]: "visible",
+                    [keys.category.id]: "visible",
+                      [keys.defaultSubCategoryId]: "visible",
+                      [keys.element.id]: "visible",
+                      [keys.subCategory.id]: "visible",
 
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerRoot.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "hidden",
-              [keys.definitionContainerChild.id]: "hidden",
-                [keys.indirectCategory.id]: "hidden",
-                  [keys.indirectSubCategory.id]: "hidden",
-                  [getDefaultSubCategoryId(keys.indirectCategory.id)]: "hidden",
-
-            [keys.definitionContainerRoot2.id]: "visible",
-              [keys.category2.id]: "visible",
-                [keys.subCategory2.id]: "visible",
-                [getDefaultSubCategoryId(keys.category2.id)]: "visible",
-          },
-        });
-      });
-
-      it("hiding definition container makes it and all of its contained elements hidden, and parent container partially visible if it has more direct child categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-
-            const directCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory1", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: directCategory.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            return { definitionContainerRoot, definitionContainerChild, directCategory, indirectCategory, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.directCategory.id]: "visible",
-
-              [keys.definitionContainerChild.id]: "hidden",
-                [keys.indirectCategory.id]: "hidden",
-          },
-        });
-      });
-
-      it("hiding definition container makes it and all of its contained elements hidden, and parent container partially visible if it has more definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-            const definitionContainerChild2 = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild2", modelId: definitionModelRoot.id });
-            const definitionModelChild2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild2.id });
-            const indirectCategory2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelChild2.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory2.id });
-            return { definitionContainerRoot, definitionContainerChild, indirectCategory2, indirectCategory, definitionContainerChild2, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.definitionContainerChild.id]: "hidden",
-                [keys.indirectCategory.id]: "hidden",
-
-              [keys.definitionContainerChild2.id]: "visible",
-                [keys.indirectCategory2.id]: "visible",
-          },
-        });
-      });
-
-      it("hiding child definition container makes it, all of its contained elements and its parent definition container hidden", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-            const indirectSubCategory = insertSubCategory({
-              txn,
-              parentCategoryId: indirectCategory.id,
-              codeValue: "subCategory",
-              modelId: definitionModelChild.id,
+                  [keys.definitionContainer2.id]: "hidden",
+                    [keys.category2.id]: "hidden",
+                      [keys.defaultSubCategoryId2]: "hidden",
+                      [keys.element2.id]: "hidden",
+                      [keys.subCategory2.id]: "hidden",
+                },
+              });
             });
 
-            return { definitionContainerRoot, definitionContainerChild, indirectCategory, indirectSubCategory, physicalModel };
-          }),
-        );
+            it("showing category doesn't affect non related definition container", async () => {
+              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.indirectCategory.id, subCategories: keys.indirectSubCategory.id }],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [
+                  { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                  { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+                ],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheUnrelatedDefContainersIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
 
-        await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainerChild.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: "all-hidden",
-        });
-      });
-    });
+              await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.definitionContainer.id]: "visible",
+                    [keys.category.id]: "visible",
+                      [keys.defaultSubCategoryId]: "visible",
+                      [keys.subCategory.id]: "visible",
+                      [keys.element.id]: "visible",
 
-    describe("categories", () => {
-      it("hiding category makes it and all of its subCategories hidden", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            return { category, subCategory, physicalModel };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: "all-hidden",
-        });
-      });
-
-      it("hiding category makes it, all of its contained subCategories hidden and doesn't affect other categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category2.id,
-              codeValue: "subCategory2",
+                  [keys.definitionContainer2.id]: "hidden",
+                    [keys.category2.id]: "hidden",
+                      [keys.defaultSubCategoryId2]: "hidden",
+                      [keys.subCategory2.id]: "hidden",
+                      [keys.element2.id]: "hidden",
+                },
+              });
             });
 
-            return { category, category2, subCategory, subCategory2, physicalModel };
-          }),
-        );
+            it("showing category makes parent container partially visible if it has more direct child categories", async () => {
+              const { imodelConnection, ...keys } = siblingCategoriesIModel;
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSiblingCategoriesIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
 
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "hidden",
-              [keys.subCategory.id]: "hidden",
-              [getDefaultSubCategoryId(keys.category.id)]: "hidden",
+              await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.childCategory.id }), true);
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.parentDefinitionContainer.id]: "partial",
+                    [keys.category.id]: "hidden",
+                      [keys.element.id]: "hidden",
 
-            [keys.category2.id]: "visible",
-              [keys.subCategory2.id]: "visible",
-              [getDefaultSubCategoryId(keys.category2.id)]: "visible",
-          },
-        });
-      });
+                    [keys.childDefinitionContainer.id]: "partial",
+                      [keys.childCategory.id]: "visible",
+                        [keys.childElement.id]: "visible",
 
-      it("hiding category makes it, all of its contained subCategories hidden and doesn't affect non related definition container", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
+                      [keys.childCategory2.id]: "hidden",
+                        [keys.childElement2.id]: "hidden",
+                },
+              });
             });
 
-            const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModel.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category2.id,
-              codeValue: "subCategory2",
-              modelId: definitionContainer.id,
+            it("showing category makes parent container partially visible if it has more definition containers", async () => {
+              const { imodelConnection, ...keys } = siblingCategoriesIModel;
+
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSiblingCategoriesIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
+
+              await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), true);
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.parentDefinitionContainer.id]: "partial",
+                    [keys.category.id]: "visible",
+                      [keys.element.id]: "visible",
+
+                    [keys.childDefinitionContainer.id]: "hidden",
+                      [keys.childCategory.id]: "hidden",
+                        [keys.childElement.id]: "hidden",
+
+                      [keys.childCategory2.id]: "hidden",
+                        [keys.childElement2.id]: "hidden",
+                },
+              });
+            });
+          });
+
+          describe("subCategories", () => {
+            it("showing subCategory doesn't affect category elements", async () => {
+              const { imodelConnection, ...keys } = simpleIModel;
+
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSimpleIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
+              setupInitialDisplayState({ viewport, elements: [{ id: keys.element.id, visible: false }] });
+              await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.definitionContainer.id]: "partial",
+                    [keys.category.id]: "partial",
+                      [keys.defaultSubCategoryId]: "hidden",
+                      [keys.subCategory.id]: "visible",
+                      [keys.element.id]: "hidden",
+                },
+              });
             });
 
-            return { definitionContainer, category, category2, subCategory, subCategory2, physicalModel };
-          }),
-        );
+            it("showing subCategory doesn't affect non related elements", async () => {
+              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [
+                  { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                  { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+                ],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheUnrelatedDefContainersIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
+              setupInitialDisplayState({
+                viewport,
+                elements: [
+                  { id: keys.element.id, visible: false },
+                  { id: keys.element2.id, visible: false },
+                ],
+              });
 
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "hidden",
-              [keys.subCategory.id]: "hidden",
-              [getDefaultSubCategoryId(keys.category.id)]: "hidden",
+              await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), true);
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.definitionContainer.id]: "partial",
+                    [keys.category.id]: "partial",
+                      [keys.defaultSubCategoryId]: "hidden",
+                      [keys.subCategory.id]: "visible",
+                      [keys.element.id]: "hidden",
 
-            [keys.definitionContainer.id]: "visible",
-              [keys.category2.id]: "visible",
-                [keys.subCategory2.id]: "visible",
-                [getDefaultSubCategoryId(keys.category2.id)]: "visible",
-          },
-        });
-      });
-
-      it("hiding category makes it and all of its subcategories hidden, and parent container partially visible if it has more direct child categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-              modelId: definitionModelRoot.id,
+                  [keys.definitionContainer2.id]: "hidden",
+                    [keys.category2.id]: "hidden",
+                      [keys.defaultSubCategoryId2]: "hidden",
+                      [keys.subCategory2.id]: "hidden",
+                      [keys.element2.id]: "hidden",
+                },
+              });
             });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category2.id,
-              codeValue: "subCategory2",
-              modelId: definitionModelRoot.id,
+          });
+
+          describe("elements", () => {
+            it("showing element doesn't affect sibling subCategories or elements", async () => {
+              await using buildIModelResult = await buildIModel(async (imodel) =>
+                withEditTxn(imodel, (txn) => {
+                  const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+
+                  const category = insertCategory({ txn, codeValue: "cat" });
+                  const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                  const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+                  const subCategory = insertSubCategory({
+                    txn,
+                    parentCategoryId: category.id,
+                    codeValue: "subCat",
+                  });
+                  const subCategory2 = insertSubCategory({
+                    txn,
+                    parentCategoryId: category.id,
+                    codeValue: "subCat2",
+                  });
+                  return { category, subCategory, subCategory2, element, element2, elementsModel };
+                }),
+              );
+
+              const { imodelConnection, ...keys } = buildIModelResult;
+              const accessAndCache = createAccessAndCache({ imodelConnection, viewType });
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: [keys.subCategory.id, keys.subCategory2.id] }],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCache,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({ modelId: keys.elementsModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
+                true,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.category.id]: "partial",
+                    [getDefaultSubCategoryId(keys.category.id)]: "hidden",
+                    [keys.subCategory.id]: "hidden",
+                    [keys.subCategory2.id]: "hidden",
+                    [keys.element.id]: "visible",
+                    [keys.element2.id]: "hidden",
+                },
+              });
             });
-            return { definitionContainerRoot, category, category2, subCategory, subCategory2, physicalModel };
-          }),
-        );
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
-          ],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+            it("showing element doesn't affect not related categories or subCategories", async () => {
+              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
 
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "hidden",
-                [keys.subCategory.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [
+                  { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                  { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+                ],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheUnrelatedDefContainersIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
 
-              [keys.category2.id]: "visible",
-                [keys.subCategory2.id]: "visible",
-                [getDefaultSubCategoryId(keys.category2.id)]: "visible",
-          },
-        });
-      });
+              await handler.changeVisibility(
+                createElementHierarchyNode({ modelId: keys.elementsModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
+                true,
+              );
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.definitionContainer.id]: "partial",
+                    [keys.category.id]: "partial",
+                      [keys.defaultSubCategoryId]: "hidden",
+                      [keys.subCategory.id]: "hidden",
+                      [keys.element.id]: "visible",
 
-      it("hiding category makes it and all of its subCategories hidden, and parent container partially visible if it has more definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const definitionContainerChild = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerChild", modelId: definitionModelRoot.id });
-            const definitionModelChild = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerChild.id });
-            const indirectCategory = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelChild.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: indirectCategory.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-              modelId: definitionModelRoot.id,
+                  [keys.definitionContainer2.id]: "hidden",
+                    [keys.category2.id]: "hidden",
+                      [keys.defaultSubCategoryId2]: "hidden",
+                      [keys.subCategory2.id]: "hidden",
+                      [keys.element2.id]: "hidden",
+                },
+              });
             });
-            return { definitionContainerRoot, definitionContainerChild, category, indirectCategory, subCategory, physicalModel };
-          }),
-        );
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+            it("showing element turns on category and its parents", async () => {
+              const { imodelConnection, ...keys } = simpleIModel;
 
-        await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "hidden",
-                [keys.subCategory.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category.id)]: "hidden",
+              using visibilityTestData = await createVisibilityTestData({
+                imodelConnection,
+                subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSimpleIModel,
+              });
+              const { handler, provider, viewport } = visibilityTestData;
 
-              [keys.definitionContainerChild.id]: "visible",
-                [keys.indirectCategory.id]: "visible",
-          },
-        });
-      });
-    });
-
-    describe("subCategories", () => {
-      it("hiding subCategory makes it hidden and its parent category partially visible, and doesn't affect other subCategories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
+              await handler.changeVisibility(
+                createElementHierarchyNode({ modelId: keys.elementsModel.id, categoryId: keys.category.id, elementId: keys.element.id }),
+                true,
+              );
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.definitionContainer.id]: "partial",
+                    [keys.category.id]: "partial",
+                      [keys.defaultSubCategoryId]: "hidden",
+                      [keys.subCategory.id]: "hidden",
+                      [keys.element.id]: "visible",
+                },
+              });
             });
-            const subCategory2 = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory2",
+          });
+
+          describe("intermediate categories", () => {
+            let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
+
+            beforeEach(async () => {
+              visibilityTestData = await createVisibilityTestData({
+                imodelConnection: intermediateCategoriesIModel.imodelConnection,
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheIntermediateCategoriesIModel,
+              });
             });
-            return { category, subCategory, subCategory2, physicalModel };
-          }),
-        );
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: [keys.subCategory.id, keys.subCategory2.id] }],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "partial",
-              [getDefaultSubCategoryId(keys.category.id)]: "visible",
-              [keys.subCategory.id]: "hidden",
-              [keys.subCategory2.id]: "visible",
-          },
-        });
-      });
-
-      it("hiding subCategory makes it hidden and its parent category partially visible, and doesn't affect other categories", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
+            afterEach(() => {
+              visibilityTestData[Symbol.dispose]();
             });
-            const category2 = insertSpatialCategory({ txn, codeValue: "SpatialCategory2" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category2.id });
-            return { category, subCategory, category2, physicalModel };
-          }),
-        );
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+            it("showing intermediate category makes its elements visible and parent element partially visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = intermediateCategoriesIModel;
 
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-              [getDefaultSubCategoryId(keys.category.id)]: "visible",
+              await handler.changeVisibility(
+                createCategoryHierarchyNode({
+                  id: keys.categoryB.id,
+                  modelIds: [keys.elementsModel.id],
+                  hasChildren: true,
+                  parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
+                }),
+                true,
+              );
 
-            [keys.category2.id]: "visible",
-          },
-        });
-      });
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.parentElement.id]: "partial",
+                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
+                        [keys.childElement.id]: "visible",
 
-      it("hiding subCategory makes it hidden and parents partially visible", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-              modelId: definitionModelRoot.id,
+                  [keys.categoryB.id]: "hidden",
+                },
+              });
             });
-            return { category, subCategory, definitionContainerRoot, physicalModel };
-          }),
-        );
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+            it("showing child element under intermediate category makes it visible and parents partially visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = intermediateCategoriesIModel;
 
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "partial",
-              [keys.category.id]: "partial",
-                [keys.subCategory.id]: "hidden",
-                [getDefaultSubCategoryId(keys.category.id)]: "visible",
-          },
-        });
-      });
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.elementsModel.id,
+                  categoryId: keys.categoryB.id,
+                  elementId: keys.childElement.id,
+                  parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
+                }),
+                true,
+              );
 
-      it("hiding subCategory makes it hidden and doesn't affect non related definition containers", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-            const definitionContainerRoot = insertDefinitionContainer({ txn, codeValue: "DefinitionContainerRoot" });
-            const definitionModelRoot = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainerRoot.id });
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.parentElement.id]: "partial",
+                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
+                        [keys.childElement.id]: "visible",
 
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
+                  [keys.categoryB.id]: "hidden",
+                },
+              });
             });
-            const categoryOfDefinitionContainer = insertSpatialCategory({ txn, codeValue: "SpatialCategory2", modelId: definitionModelRoot.id });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: categoryOfDefinitionContainer.id });
-            const subCategoryOfDefinitionContainer = insertSubCategory({
-              txn,
-              parentCategoryId: categoryOfDefinitionContainer.id,
-              codeValue: "subCategory2",
-              modelId: definitionModelRoot.id,
+
+            it("showing parent element makes children under intermediate category visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = intermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.elementsModel.id,
+                  categoryId: keys.categoryA.id,
+                  elementId: keys.parentElement.id,
+                  hasChildren: true,
+                }),
+                true,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    // Category has a sub-category which is hidden
+                    [keys.parentElement.id]: "visible",
+                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "visible",
+                        [keys.childElement.id]: "visible",
+
+                  [keys.categoryB.id]: "hidden",
+                },
+              });
             });
-            return { category, subCategory, definitionContainerRoot, categoryOfDefinitionContainer, subCategoryOfDefinitionContainer, physicalModel };
-          }),
-        );
+          });
 
-        const { imodelConnection, ...keys } = buildIModelResult;
-        using visibilityTestData = await createVisibilityTestData({
-          imodelConnection,
-          subCategoriesOfCategories: [
-            { categoryId: keys.category.id, subCategories: keys.subCategory.id },
-            { categoryId: keys.categoryOfDefinitionContainer.id, subCategories: keys.subCategoryOfDefinitionContainer.id },
-          ],
-          visibleByDefault: true,
-        });
-        const { handler, provider, viewport } = visibilityTestData;
+          describe("intermediate categories under sub-model", () => {
+            let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
 
-        await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), false);
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [keys.definitionContainerRoot.id]: "visible",
-              [keys.categoryOfDefinitionContainer.id]: "visible",
-                [keys.subCategoryOfDefinitionContainer.id]: "visible",
-                [getDefaultSubCategoryId(keys.categoryOfDefinitionContainer.id)]: "visible",
+            beforeEach(async () => {
+              visibilityTestData = await createVisibilityTestData({
+                imodelConnection: subModelIntermediateCategoriesIModel.imodelConnection,
+                hierarchyConfig: { elements: { nodes: "include" } },
+                ...accessAndCacheSubModelIntermediateCategoriesIModel,
+              });
+            });
 
-            [keys.category.id]: "partial",
-              [keys.subCategory.id]: "hidden",
-              [getDefaultSubCategoryId(keys.category.id)]: "visible",
-          },
-        });
-      });
-    });
+            afterEach(() => {
+              visibilityTestData[Symbol.dispose]();
+            });
 
-    describe("elements set to 'include'", () => {
-      ["2d" as const, "3d" as const].forEach((viewType) => {
-        const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
-        describe(`intermediate ${viewType} categories`, () => {
-          let buildIModelResult: Awaited<ReturnType<typeof createIntermediateCategoriesIModel>>;
-          let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
+            it("showing intermediate category under sub-model makes its elements visible and modeled element partially visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = subModelIntermediateCategoriesIModel;
 
-          async function createIntermediateCategoriesIModel() {
-            return buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const elementsModel = insertElementsModel({ txn, codeValue: "elements model" });
-                const categoryA = insertCategory({ txn, codeValue: "categoryA" });
-                const categoryB = insertCategory({ txn, codeValue: "categoryB" });
-                const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
-                const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
-                return { categoryA, categoryB, parentElement, childElement, elementsModel };
-              }),
-            );
+              await handler.changeVisibility(
+                createCategoryHierarchyNode({
+                  id: keys.categoryB.id,
+                  modelIds: [keys.modeledElement.id],
+                  hasChildren: true,
+                }),
+                true,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.modeledElement.id]: "partial",
+                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
+                        [keys.subModelElement.id]: "visible",
+
+                  [keys.categoryB.id]: "hidden",
+                },
+              });
+            });
+
+            it("showing element under intermediate category in sub-model makes it visible and parents partially visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = subModelIntermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.modeledElement.id,
+                  categoryId: keys.categoryB.id,
+                  elementId: keys.subModelElement.id,
+                }),
+                true,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.modeledElement.id]: "partial",
+                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
+                        [keys.subModelElement.id]: "visible",
+
+                  [keys.categoryB.id]: "hidden",
+                },
+              });
+            });
+
+            it("showing modeled element makes sub-model elements under intermediate category visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = subModelIntermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.elementsModel.id,
+                  categoryId: keys.categoryA.id,
+                  elementId: keys.modeledElement.id,
+                  hasChildren: true,
+                }),
+                true,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    // Category has a sub-category which is hidden
+                    [keys.modeledElement.id]: "visible",
+                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "visible",
+                        [keys.subModelElement.id]: "visible",
+
+                  [keys.categoryB.id]: "hidden",
+                },
+              });
+            });
+          });
+
+          interface IModelWithSubModelIds {
+            modeledElement: InstanceKey;
+            model: InstanceKey;
+            category: InstanceKey;
+            subModelCategory?: InstanceKey;
+            subModelElement?: InstanceKey;
+            subModel: InstanceKey;
           }
 
-          beforeAll(async () => {
-            buildIModelResult = await createIntermediateCategoriesIModel();
-          });
-
-          beforeEach(async () => {
-            visibilityTestData = await createVisibilityTestData({
-              imodelConnection: buildIModelResult.imodelConnection,
-              hierarchyConfig: { elements: { nodes: "include" } },
-              visibleByDefault: true,
-              viewType,
-            });
-          });
-
-          afterEach(() => {
-            visibilityTestData[Symbol.dispose]();
-          });
-
-          afterAll(async () => {
-            await buildIModelResult.imodelConnection.close();
-          });
-
-          it("hiding intermediate category makes its elements hidden", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createCategoryHierarchyNode({
-                id: keys.categoryB.id,
-                modelIds: [keys.elementsModel.id],
-                hasChildren: true,
-                parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
-              }),
-              false,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.parentElement.id]: "partial",
-                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
-                      [keys.childElement.id]: "hidden",
-
-                [keys.categoryB.id]: "visible",
+          const testCases: Array<{
+            describeName: string;
+            createIModel: () => Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds>;
+            cases: Array<{
+              only?: boolean;
+              name: string;
+              getTargetNode: (ids: IModelWithSubModelIds) => NonGroupingHierarchyNode | GroupingHierarchyNode;
+              expectations: (ids: IModelWithSubModelIds) => "all-visible" | "all-hidden" | VisibilityExpectations;
+            }>;
+          }> = [
+            {
+              describeName: "with modeled elements",
+              createIModel: async function createIModel(): Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds> {
+                return buildIModel(async (imodel) =>
+                  withEditTxn(imodel, (txn) => {
+                    const model = insertElementsModel({ txn, codeValue: "m" });
+                    const category = insertCategory({ txn, codeValue: "cat" });
+                    const modeledElement = insertModeledElement({
+                      txn,
+                      userLabel: `el`,
+                      modelId: model.id,
+                      categoryId: category.id,
+                    });
+                    const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                    const subModelCategory = insertCategory({ txn, codeValue: "cat2" });
+                    const subModelElement = insertElement({ txn, userLabel: `el2`, modelId: subModel.id, categoryId: subModelCategory.id });
+                    return {
+                      modeledElement,
+                      model,
+                      category,
+                      subModelCategory,
+                      subModelElement,
+                      subModel,
+                    };
+                  }),
+                );
               },
-            });
-          });
+              cases: [
+                {
+                  name: "modeled element's children display is turned on when its category display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.category.id, hasChildren: true }),
+                  // prettier-ignore
+                  expectations: (ids) => ({
+                    [ids.category.id]: "visible",
+                      [ids.modeledElement.id]: "visible",
+                        [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                          [ids.subModelElement!.id]: "visible",
 
-          it("hiding child element under intermediate category makes it hidden and parents partially visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
+                    [ids.subModelCategory!.id]: "hidden",
+                  }),
+                },
+                {
+                  name: "modeled element's children display is turned on when its class grouping node display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createClassGroupingHierarchyNode({
+                      categoryId: ids.category.id,
+                      modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
+                    }),
+                  // prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.subModelCategory!.id]: "hidden",
 
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.elementsModel.id,
-                categoryId: keys.categoryB.id,
-                elementId: keys.childElement.id,
-                parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
-              }),
-              false,
-            );
+                    [ids.category.id]: "partial",
+                      [ids.modeledElement.id]: "visible",
+                        [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                          [ids.subModelElement!.id]: "visible",
+                  }),
+                },
+                {
+                  name: "modeled element's children display is turned on when its display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createElementHierarchyNode({
+                      modelId: ids.model.id,
+                      categoryId: ids.category.id,
+                      elementId: ids.modeledElement.id,
+                      hasChildren: true,
+                    }),
+                  // prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.subModelCategory!.id]: "hidden",
 
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.parentElement.id]: "partial",
-                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
-                      [keys.childElement.id]: "hidden",
+                    [ids.category.id]: "partial",
+                      [ids.modeledElement.id]: "visible",
+                        [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                          [ids.subModelElement!.id]: "visible",
+                  }),
+                },
+                {
+                  name: "modeled element's children display is turned on when its sub-model display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) => createModelHierarchyNode({ id: ids.modeledElement.id, hasChildren: true }),
+                  // prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.subModelCategory!.id]: "hidden",
 
-                [keys.categoryB.id]: "visible",
+                    [ids.category.id]: "partial",
+                      [ids.modeledElement.id]: "partial",
+                        [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                          [ids.subModelElement!.id]: "visible",
+                  }),
+                },
+                {
+                  name: "modeled element, its model and category have partial visibility when its sub-model element's category display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createCategoryHierarchyNode({ id: ids.subModelCategory!.id, modelIds: [ids.modeledElement.id] }),
+                  // prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.subModelCategory!.id]: "hidden",
+
+                    [ids.category.id]: "partial",
+                      [ids.modeledElement.id]: "partial",
+                        [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                          [ids.subModelElement!.id]: "visible",
+                  }),
+                },
+                {
+                  name: "modeled element, its model and category have partial visibility when its sub-model element's display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createElementHierarchyNode({
+                      modelId: ids.modeledElement.id,
+                      categoryId: ids.subModelCategory!.id,
+                      elementId: ids.subModelElement!.id,
+                    }),
+                  // prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.subModelCategory!.id]: "hidden",
+
+                    [ids.category.id]: "partial",
+                      [ids.modeledElement.id]: "partial",
+                        [`${ids.modeledElement.id}-${ids.subModelCategory!.id}`]: "visible",
+                          [ids.subModelElement!.id]: "visible",
+                  }),
+                },
+              ],
+            },
+            {
+              describeName: "with modeled elements that have private subModel",
+              createIModel: async function createIModel(): Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds> {
+                return buildIModel(async (imodel) =>
+                  withEditTxn(imodel, (txn) => {
+                    const model = insertElementsModel({ txn, codeValue: "model" });
+                    const category = insertCategory({ txn, codeValue: "cat" });
+                    const modeledElement = insertModeledElement({
+                      txn,
+                      userLabel: `el`,
+                      modelId: model.id,
+                      categoryId: category.id,
+                    });
+                    const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id, isPrivate: true });
+                    const subModelCategory = insertCategory({ txn, codeValue: "category2" });
+                    const subModelElement = insertElement({ txn, userLabel: `element2`, modelId: subModel.id, categoryId: subModelCategory.id });
+                    return {
+                      modeledElement,
+                      model,
+                      category,
+                      subModelCategory,
+                      subModelElement,
+                      subModel,
+                    };
+                  }),
+                );
               },
-            });
-          });
-
-          it("hiding parent element makes children under intermediate category hidden", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.elementsModel.id,
-                categoryId: keys.categoryA.id,
-                elementId: keys.parentElement.id,
-                hasChildren: true,
-              }),
-              false,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  // Category has a sub-category which is visible
-                  [keys.parentElement.id]: "hidden",
-                    [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
-                      [keys.childElement.id]: "hidden",
-
-                [keys.categoryB.id]: "visible",
+              cases: [
+                {
+                  name: "children are visible when category display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.category.id, hasChildren: true }),
+                  // prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.category.id]: "visible",
+                      [ids.modeledElement.id]: "visible",
+                  }),
+                },
+                {
+                  name: "child elements are visible when elements class grouping node display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createClassGroupingHierarchyNode({
+                      categoryId: ids.category.id,
+                      modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
+                    }),
+                  // prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.category.id]: "partial",
+                      // Category has hidden sub-category
+                      [ids.modeledElement.id]: "visible",
+                  }),
+                },
+                {
+                  name: "everything under model is visible when elements display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createElementHierarchyNode({
+                      modelId: ids.model.id,
+                      categoryId: ids.category.id,
+                      elementId: ids.modeledElement.id,
+                      hasChildren: false,
+                    }),
+                  //prettier-ignore
+                  expectations: (ids: IModelWithSubModelIds) => ({
+                    [ids.category.id]: "partial",
+                      // Category has hidden sub-category
+                      [ids.modeledElement.id]: "visible",
+                  }),
+                },
+              ],
+            },
+            {
+              describeName: "with modeled elements that have subModel with no children",
+              createIModel: async function createIModel(): Promise<{ imodelConnection: IModelConnection } & IModelWithSubModelIds> {
+                return buildIModel(async (imodel) =>
+                  withEditTxn(imodel, (txn) => {
+                    const model = insertElementsModel({ txn, codeValue: "m" });
+                    const category = insertCategory({ txn, codeValue: "cat" });
+                    const modeledElement = insertModeledElement({
+                      txn,
+                      userLabel: `el`,
+                      modelId: model.id,
+                      categoryId: category.id,
+                    });
+                    const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+                    return {
+                      modeledElement,
+                      model,
+                      category,
+                      subModel,
+                    };
+                  }),
+                );
               },
-            });
-          });
-        });
+              cases: [
+                {
+                  name: "everything is visible when category display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) => createCategoryHierarchyNode({ id: ids.category.id, hasChildren: true }),
+                  expectations: () => "all-visible",
+                },
+                {
+                  name: "everything under model is visible when elements class grouping node display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createClassGroupingHierarchyNode({
+                      categoryId: ids.category.id,
+                      modelElementsMap: new Map([[ids.model.id, { elementIds: new Set([ids.modeledElement.id]) }]]),
+                    }),
+                  // Category has partial visibility, since its sub-category is not visible
+                  // prettier-ignore
+                  expectations: (ids) => ({
+                    [ids.category.id]: "partial",
+                      [ids.modeledElement.id]: "visible",
+                  }),
+                },
+                {
+                  name: "everything under model is visible when elements display is turned on",
+                  getTargetNode: (ids: IModelWithSubModelIds) =>
+                    createElementHierarchyNode({
+                      modelId: ids.model.id,
+                      categoryId: ids.category.id,
+                      elementId: ids.modeledElement.id,
+                      hasChildren: false,
+                    }),
+                  // Category has partial visibility, since its sub-category is not visible
+                  // prettier-ignore
+                  expectations: (ids) => ({
+                    [ids.category.id]: "partial",
+                      [ids.modeledElement.id]: "visible",
+                  }),
+                },
+              ],
+            },
+          ];
+          testCases.forEach(({ describeName, createIModel, cases }) => {
+            describe(describeName, () => {
+              let iModel: IModelConnection;
+              let accessAndCache: ReturnType<typeof createAccessAndCache>;
+              let createdIds: IModelWithSubModelIds;
 
-        describe(`intermediate ${viewType} categories under sub-model`, () => {
-          let buildIModelResult: Awaited<ReturnType<typeof createSubModelIntermediateCategoriesIModel>>;
-          let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
+              beforeAll(async () => {
+                const { imodelConnection, ...ids } = await createIModel();
+                iModel = imodelConnection;
+                accessAndCache = createAccessAndCache({ imodelConnection: iModel, viewType });
+                createdIds = ids;
+              });
 
-          async function createSubModelIntermediateCategoriesIModel() {
-            return buildIModel(async (imodel) =>
-              withEditTxn(imodel, (txn) => {
-                const elementsModel = insertElementsModel({ txn, codeValue: "elements model" });
-                const categoryA = insertCategory({ txn, codeValue: "categoryA" });
-                const categoryB = insertCategory({ txn, codeValue: "categoryB" });
-                const modeledElement = insertModeledElement({
-                  txn,
-                  modelId: elementsModel.id,
-                  categoryId: categoryA.id,
+              afterAll(async () => {
+                await iModel.close();
+              });
+
+              cases.forEach(({ name, getTargetNode, expectations, only }) => {
+                (only ? it.only : it)(name, async function () {
+                  using visibilityTestData = await createVisibilityTestData({
+                    imodelConnection: iModel,
+                    hierarchyConfig: { elements: { nodes: "include" } },
+                    ...accessAndCache,
+                  });
+                  const { handler, provider, viewport } = visibilityTestData;
+
+                  const nodeToChangeVisibility = getTargetNode(createdIds);
+                  await validateCategoriesTreeHierarchyVisibility({
+                    provider,
+                    handler,
+                    viewport,
+                    expectations: "all-hidden",
+                  });
+                  await handler.changeVisibility(nodeToChangeVisibility, true);
+                  await validateCategoriesTreeHierarchyVisibility({
+                    provider,
+                    handler,
+                    viewport,
+                    expectations: expectations(createdIds),
+                  });
+                  await handler.changeVisibility(nodeToChangeVisibility, false);
+                  await validateCategoriesTreeHierarchyVisibility({
+                    provider,
+                    handler,
+                    viewport,
+                    expectations: "all-hidden",
+                  });
                 });
-                const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-                const subModelElement = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
-                return { categoryA, categoryB, modeledElement, subModel, subModelElement, elementsModel };
-              }),
-            );
-          }
-
-          beforeAll(async () => {
-            buildIModelResult = await createSubModelIntermediateCategoriesIModel();
-          });
-
-          beforeEach(async () => {
-            visibilityTestData = await createVisibilityTestData({
-              imodelConnection: buildIModelResult.imodelConnection,
-              hierarchyConfig: { elements: { nodes: "include" } },
-              visibleByDefault: true,
-              viewType,
-            });
-          });
-
-          afterEach(() => {
-            visibilityTestData[Symbol.dispose]();
-          });
-
-          afterAll(async () => {
-            await buildIModelResult.imodelConnection.close();
-          });
-
-          it("hiding intermediate category under sub-model makes its elements hidden", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createCategoryHierarchyNode({
-                id: keys.categoryB.id,
-                modelIds: [keys.modeledElement.id],
-                hasChildren: true,
-              }),
-              false,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.modeledElement.id]: "partial",
-                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
-                      [keys.subModelElement.id]: "hidden",
-
-                [keys.categoryB.id]: "visible",
-              },
-            });
-          });
-
-          it("hiding element under intermediate category in sub-model makes it hidden and parents partially visible", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.modeledElement.id,
-                categoryId: keys.categoryB.id,
-                elementId: keys.subModelElement.id,
-              }),
-              false,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                [keys.categoryA.id]: "partial",
-                  [keys.modeledElement.id]: "partial",
-                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
-                      [keys.subModelElement.id]: "hidden",
-
-                [keys.categoryB.id]: "visible",
-              },
-            });
-          });
-
-          it("hiding modeled element makes sub-model elements under intermediate category hidden", async () => {
-            const { handler, provider, viewport } = visibilityTestData;
-            const keys = buildIModelResult;
-
-            await handler.changeVisibility(
-              createElementHierarchyNode({
-                modelId: keys.elementsModel.id,
-                categoryId: keys.categoryA.id,
-                elementId: keys.modeledElement.id,
-                hasChildren: true,
-              }),
-              false,
-            );
-
-            await validateCategoriesTreeHierarchyVisibility({
-              provider,
-              handler,
-              viewport,
-              // prettier-ignore
-              expectations: {
-                // Category has a sub-category which is visible
-                [keys.categoryA.id]: "partial",
-                  [keys.modeledElement.id]: "hidden",
-                    [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
-                      [keys.subModelElement.id]: "hidden",
-
-                [keys.categoryB.id]: "visible",
-              },
-            });
-          });
-        });
-      });
-    });
-
-    describe("disabling category visibility through overrides", () => {
-      it("category is partial when multiple models contain category and override for one model is set to 'Hide'", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "1" });
-            const physicalModel2 = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "2" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            insertPhysicalElement({ txn, modelId: physicalModel2.id, categoryId: category.id });
-            return { category, physicalModel, physicalModel2 };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        viewport.setPerModelCategoryOverride({
-          modelIds: keys.physicalModel.id,
-          categoryIds: keys.category.id,
-          override: "hide",
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: {
-            [keys.category.id]: "partial",
-          },
-        });
-      });
-    });
-
-    describe("disabling category visibility through model selector", () => {
-      it("category is partial when multiple models contain category and one model is disabled through model selector", async () => {
-        await using buildIModelResult = await buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "1" });
-            const physicalModel2 = insertPhysicalModelWithPartition({ txn, partitionParentId: IModel.rootSubjectId, codeValue: "2" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory" });
-            insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            insertPhysicalElement({ txn, modelId: physicalModel2.id, categoryId: category.id });
-            return { category, physicalModel, physicalModel2 };
-          }),
-        );
-
-        const { imodelConnection, ...keys } = buildIModelResult;
-
-        using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true });
-        const { handler, provider, viewport } = visibilityTestData;
-
-        viewport.changeModelDisplay({ modelIds: keys.physicalModel.id, display: false });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider,
-          handler,
-          viewport,
-          expectations: {
-            [keys.category.id]: "partial",
-          },
-        });
-      });
-    });
-  });
-
-  describe("search nodes", () => {
-    async function createFilteredVisibilityTestData({
-      imodelConnection,
-      searchPaths,
-      view,
-      visibleByDefault,
-      subCategoriesOfCategories,
-    }: Parameters<typeof createVisibilityTestData>[0] & {
-      searchPaths: HierarchySearchTree[];
-      view: "2d" | "3d";
-      visibleByDefault?: boolean;
-      subCategoriesOfCategories: Array<{ categoryId: string; subCategories: Id64Arg }>;
-    }) {
-      const hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration = mergeWithDefaults({
-        defaults: defaultHierarchyConfiguration,
-        overrides: {
-          elements: { nodes: "include" },
-          categories: { withoutElements: "include" },
-        },
-      });
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView(view).elementClass, type: view });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: view, baseIdsCache });
-      const viewport = createTreeWidgetTestingViewport({
-        iModel: imodelConnection,
-        viewType: view,
-        visibleByDefault,
-        subCategoriesOfCategories,
-      });
-      const visibilityHandlerWithSearchPaths = createCategoriesTreeVisibilityHandler({
-        idsCache,
-        searchPaths,
-        imodelAccess,
-        viewport,
-        hierarchyConfig,
-      });
-      const defaultVisibilityHandler = createCategoriesTreeVisibilityHandler({
-        idsCache,
-        imodelAccess,
-        viewport,
-        hierarchyConfig,
-      });
-      const defaultProvider = createProvider({ idsCache, imodelAccess, hierarchyConfig, viewType: view });
-      const providerWithSearchPaths = createProvider({ idsCache, imodelAccess, searchPaths, hierarchyConfig, viewType: view });
-      return {
-        defaultVisibilityHandler,
-        visibilityHandlerWithSearchPaths,
-        defaultProvider,
-        providerWithSearchPaths,
-        imodelConnection,
-        imodelAccess,
-        viewport,
-        [Symbol.dispose]() {
-          defaultVisibilityHandler[Symbol.dispose]();
-          visibilityHandlerWithSearchPaths[Symbol.dispose]();
-          defaultProvider[Symbol.dispose]();
-          providerWithSearchPaths[Symbol.dispose]();
-        },
-      };
-    }
-
-    it("returns 'disabled' when node has search paths but visibility handler doesn't", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const category = insertSpatialCategory({ txn, codeValue: "category" });
-          const subCategory = insertSubCategory({
-            txn,
-            parentCategoryId: category.id,
-            codeValue: "subCategory",
-          });
-          return { category, subCategory };
-        }),
-      );
-      const { imodelConnection, ...keys } = buildIModelResult;
-      const hierarchyConfig: RequiredCategoriesTreeHierarchyConfiguration = mergeWithDefaults({
-        defaults: defaultHierarchyConfiguration,
-        overrides: {
-          elements: { nodes: "include" },
-          categories: { withoutElements: "include" },
-        },
-      });
-      const imodelAccess = createIModelAccess(imodelConnection);
-      const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView("3d").elementClass, type: "3d" });
-      const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: "3d", baseIdsCache });
-      const viewport = createTreeWidgetTestingViewport({
-        iModel: imodelConnection,
-        viewType: "3d",
-        visibleByDefault: true,
-        subCategoriesOfCategories: [
-          {
-            categoryId: keys.category.id,
-            subCategories: [keys.subCategory.id, getDefaultSubCategoryId(keys.category.id)],
-          },
-        ],
-      });
-      using visibilityHandlerWithoutSearchPaths = createCategoriesTreeVisibilityHandler({
-        idsCache,
-        searchPaths: undefined,
-        imodelAccess,
-        viewport,
-        hierarchyConfig,
-      });
-
-      using providerWithSearchPaths = createProvider({
-        idsCache,
-        imodelAccess,
-        searchPaths: [{ identifier: keys.category, children: [{ identifier: keys.subCategory }] }],
-        hierarchyConfig,
-      });
-      await validateCategoriesTreeHierarchyVisibility({
-        provider: providerWithSearchPaths,
-        handler: visibilityHandlerWithoutSearchPaths,
-        viewport,
-        // prettier-ignore
-        expectations: {
-            [keys.category.id]: "disabled",
-              [keys.subCategory.id]: "visible",
-          },
-      });
-    });
-
-    describe("category with sub-categories hierarchy", () => {
-      let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
-      let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
-      async function createIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-            });
-
-            const siblingCategory = insertSpatialCategory({ txn, codeValue: "sibling category" });
-            const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
-            const siblingSubCategory = insertSubCategory({
-              txn,
-              parentCategoryId: siblingCategory.id,
-              codeValue: "sibling SubCategory",
-            });
-
-            return {
-              category,
-              subCategory,
-              siblingCategory,
-              siblingSubCategory,
-              defaultSubCategory,
-              defaultSiblingSubCategory,
-              searchPaths: [{ identifier: category, children: [{ identifier: defaultSubCategory }] }],
-            };
-          }),
-        );
-      }
-
-      beforeAll(async () => {
-        createIModelResult = await createIModel();
-      });
-
-      beforeEach(async function () {
-        visibilityTestData = await createFilteredVisibilityTestData({
-          imodelConnection: createIModelResult.imodelConnection,
-          searchPaths: createIModelResult.searchPaths,
-          view: "3d",
-          visibleByDefault: false,
-          subCategoriesOfCategories: [
-            { categoryId: createIModelResult.category.id, subCategories: [createIModelResult.subCategory.id, createIModelResult.defaultSubCategory.id] },
-            {
-              categoryId: createIModelResult.siblingCategory.id,
-              subCategories: [createIModelResult.siblingSubCategory.id, createIModelResult.defaultSiblingSubCategory.id],
-            },
-          ],
-        });
-      });
-
-      afterEach(() => {
-        visibilityTestData[Symbol.dispose]();
-      });
-
-      afterAll(async () => {
-        await createIModelResult.imodelConnection.close();
-      });
-
-      it("showing category changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, subCategory, defaultSubCategory, siblingCategory, siblingSubCategory, defaultSiblingSubCategory } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createCategoryHierarchyNode({
-            id: category.id,
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [{ identifier: defaultSubCategory }],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "visible",
-              [defaultSubCategory.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [defaultSubCategory.id]: "visible",
-              [subCategory.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingSubCategory.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing search target sub-category changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, subCategory, defaultSubCategory, siblingCategory, siblingSubCategory, defaultSiblingSubCategory } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createSubCategoryHierarchyNode({
-            id: defaultSubCategory.id,
-            categoryId: category.id,
-            parentKeys: [category],
-            search: { isSearchTarget: true },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "visible",
-              [defaultSubCategory.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [defaultSubCategory.id]: "visible",
-              [subCategory.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingSubCategory.id]: "hidden",
-              [defaultSiblingSubCategory.id]: "hidden",
-          },
-        });
-      });
-    });
-
-    describe("category with child elements hierarchy", () => {
-      let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
-      let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
-      async function createIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
-            const parentElement1 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const parentElement2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const childElement11 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id, parentId: parentElement1.id });
-            const childElement12 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id, parentId: parentElement1.id });
-            const childElement21 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id, parentId: parentElement2.id });
-
-            const siblingCategory = insertSpatialCategory({ txn, codeValue: "sibling category" });
-            const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
-            const siblingElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: siblingCategory.id });
-
-            return {
-              category,
-              defaultSubCategory,
-              parentElement1,
-              parentElement2,
-              element,
-              childElement11,
-              childElement12,
-              childElement21,
-              defaultSiblingSubCategory,
-              siblingElement,
-              siblingCategory,
-              physicalModel,
-              searchPaths: [
-                { identifier: category, children: [{ identifier: parentElement1, children: [{ identifier: childElement11 }] }] },
-                { identifier: category, children: [{ identifier: parentElement2, isTarget: true, children: [{ identifier: childElement21 }] }] },
-              ],
-            };
-          }),
-        );
-      }
-
-      beforeAll(async () => {
-        createIModelResult = await createIModel();
-      });
-
-      beforeEach(async function () {
-        visibilityTestData = await createFilteredVisibilityTestData({
-          imodelConnection: createIModelResult.imodelConnection,
-          searchPaths: createIModelResult.searchPaths,
-          view: "3d",
-          visibleByDefault: false,
-          subCategoriesOfCategories: [
-            { categoryId: createIModelResult.category.id, subCategories: createIModelResult.defaultSubCategory.id },
-            { categoryId: createIModelResult.siblingCategory.id, subCategories: createIModelResult.defaultSiblingSubCategory.id },
-          ],
-        });
-        visibilityTestData.viewport.setNeverDrawn({
-          elementIds: new Set([
-            createIModelResult.element.id,
-            createIModelResult.childElement11.id,
-            createIModelResult.childElement12.id,
-            createIModelResult.siblingElement.id,
-            createIModelResult.childElement21.id,
-            createIModelResult.parentElement1.id,
-            createIModelResult.parentElement2.id,
-          ]),
-        });
-      });
-
-      afterEach(() => {
-        visibilityTestData[Symbol.dispose]();
-      });
-
-      afterAll(async () => {
-        await createIModelResult.imodelConnection.close();
-      });
-
-      it("showing category changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, siblingElement, parentElement1, childElement11, childElement12, parentElement2, childElement21, siblingCategory } =
-          createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createCategoryHierarchyNode({
-            id: category.id,
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [{ identifier: parentElement1, children: [{ identifier: childElement11 }] }, { identifier: parentElement2 }],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "visible",
-              [parentElement1.id]: "visible",
-                [childElement11.id]: "visible",
-
-              [parentElement2.id]: "visible",
-                [childElement21.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement1.id]: "partial",
-                [childElement11.id]: "visible",
-                [childElement12.id]: "hidden",
-
-              [parentElement2.id]: "visible",
-                [childElement21.id]: "visible",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing parent element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          element,
-          siblingElement,
-          parentElement1,
-          childElement11,
-          childElement12,
-          parentElement2,
-          childElement21,
-          siblingCategory,
-          physicalModel,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: parentElement1.id,
-            parentKeys: [category],
-            modelId: physicalModel.id,
-            categoryId: category.id,
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [{ identifier: childElement11 }],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [parentElement1.id]: "visible",
-                [childElement11.id]: "visible",
-
-              [parentElement2.id]: "hidden",
-                [childElement21.id]: "hidden",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement1.id]: "partial",
-                [childElement11.id]: "visible",
-                [childElement12.id]: "hidden",
-
-              [parentElement2.id]: "hidden",
-                [childElement21.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing search target child element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          element,
-          siblingElement,
-          parentElement1,
-          childElement11,
-          childElement12,
-          parentElement2,
-          childElement21,
-          siblingCategory,
-          physicalModel,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: childElement11.id,
-            parentKeys: [category, parentElement1],
-            modelId: physicalModel.id,
-            categoryId: category.id,
-            search: { isSearchTarget: true },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [parentElement1.id]: "partial",
-                [childElement11.id]: "visible",
-
-              [parentElement2.id]: "hidden",
-                [childElement21.id]: "hidden",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement1.id]: "partial",
-                [childElement11.id]: "visible",
-                [childElement12.id]: "hidden",
-
-              [parentElement2.id]: "hidden",
-                [childElement21.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing search target parent element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          element,
-          siblingElement,
-          parentElement1,
-          childElement11,
-          childElement12,
-          parentElement2,
-          childElement21,
-          siblingCategory,
-          physicalModel,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: parentElement2.id,
-            parentKeys: [category],
-            modelId: physicalModel.id,
-            categoryId: category.id,
-            search: { isSearchTarget: true, childrenTargetPaths: [{ identifier: childElement21 }] },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [parentElement1.id]: "hidden",
-                [childElement11.id]: "hidden",
-
-              [parentElement2.id]: "visible",
-                [childElement21.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement1.id]: "hidden",
-                [childElement11.id]: "hidden",
-                [childElement12.id]: "hidden",
-
-              [parentElement2.id]: "visible",
-                [childElement21.id]: "visible",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing search target child element of search target parent element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          element,
-          siblingElement,
-          parentElement1,
-          childElement11,
-          childElement12,
-          parentElement2,
-          childElement21,
-          siblingCategory,
-          physicalModel,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: childElement21.id,
-            parentKeys: [category, parentElement2],
-            modelId: physicalModel.id,
-            categoryId: category.id,
-            search: { isSearchTarget: true, hasSearchTargetAncestor: true },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [parentElement1.id]: "hidden",
-                [childElement11.id]: "hidden",
-
-              [parentElement2.id]: "partial",
-                [childElement21.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement1.id]: "hidden",
-                [childElement11.id]: "hidden",
-                [childElement12.id]: "hidden",
-
-              [parentElement2.id]: "partial",
-                [childElement21.id]: "visible",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-          },
-        });
-      });
-    });
-
-    describe("category with elements which are search targets and have search target ancestor", () => {
-      let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
-      let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
-      async function createIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
-            const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const parentElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const childElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id, parentId: parentElement.id });
-            const childOfChild1 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id, parentId: childElement.id });
-            const childOfChild2 = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id, parentId: childElement.id });
-
-            return {
-              category,
-              defaultSubCategory,
-              parentElement,
-              element,
-              childElement,
-              physicalModel,
-              childOfChild1,
-              childOfChild2,
-              searchPaths: [
-                {
-                  identifier: category,
-                  children: [
-                    { identifier: parentElement, isTarget: true, children: [{ identifier: childElement, children: [{ identifier: childOfChild1 }] }] },
-                  ],
-                },
-              ],
-            };
-          }),
-        );
-      }
-
-      beforeAll(async () => {
-        createIModelResult = await createIModel();
-      });
-
-      beforeEach(async function () {
-        visibilityTestData = await createFilteredVisibilityTestData({
-          imodelConnection: createIModelResult.imodelConnection,
-          searchPaths: createIModelResult.searchPaths,
-          view: "3d",
-          visibleByDefault: false,
-          subCategoriesOfCategories: [{ categoryId: createIModelResult.category.id, subCategories: createIModelResult.defaultSubCategory.id }],
-        });
-        visibilityTestData.viewport.setNeverDrawn({
-          elementIds: new Set([
-            createIModelResult.element.id,
-            createIModelResult.parentElement.id,
-            createIModelResult.childElement.id,
-            createIModelResult.childOfChild1.id,
-            createIModelResult.childOfChild2.id,
-          ]),
-        });
-      });
-
-      afterEach(() => {
-        visibilityTestData[Symbol.dispose]();
-      });
-
-      afterAll(async () => {
-        await createIModelResult.imodelConnection.close();
-      });
-
-      it("showing category changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2 } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createCategoryHierarchyNode({
-            id: category.id,
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [
-                { identifier: parentElement, isTarget: true, children: [{ identifier: childElement, children: [{ identifier: childOfChild1 }] }] },
-              ],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "visible",
-              [parentElement.id]: "visible",
-                [childElement.id]: "visible",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement.id]: "visible",
-                [childElement.id]: "visible",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "visible",
-          },
-        });
-      });
-
-      it("showing search target parent element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, physicalModel } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: parentElement.id,
-            parentKeys: [category, { type: "class-grouping", className: CLASS_NAME_GeometricElement3d }],
-            modelId: physicalModel.id,
-            categoryId: category.id,
-            search: { isSearchTarget: true, childrenTargetPaths: [{ identifier: childElement, children: [{ identifier: childOfChild1 }] }] },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "visible",
-              [parentElement.id]: "visible",
-                [childElement.id]: "visible",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement.id]: "visible",
-                [childElement.id]: "visible",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "visible",
-          },
-        });
-      });
-
-      it("showing child element of search target parent element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, physicalModel } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: childElement.id,
-            parentKeys: [
-              category,
-              { type: "class-grouping", className: CLASS_NAME_GeometricElement3d },
-              parentElement,
-              { type: "class-grouping", className: CLASS_NAME_GeometricElement3d },
-            ],
-            modelId: physicalModel.id,
-            categoryId: category.id,
-            search: { isSearchTarget: false, hasSearchTargetAncestor: true, childrenTargetPaths: [{ identifier: childOfChild1 }] },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [parentElement.id]: "partial",
-                [childElement.id]: "visible",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement.id]: "partial",
-                [childElement.id]: "visible",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "visible",
-          },
-        });
-      });
-
-      it("showing nested child search target element with search target ancestor element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { category, element, parentElement, childElement, childOfChild1, childOfChild2, physicalModel } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: childOfChild1.id,
-            parentKeys: [
-              category,
-              { type: "class-grouping", className: CLASS_NAME_GeometricElement3d },
-              parentElement,
-              { type: "class-grouping", className: CLASS_NAME_GeometricElement3d },
-              childElement,
-              { type: "class-grouping", className: CLASS_NAME_GeometricElement3d },
-            ],
-            modelId: physicalModel.id,
-            categoryId: category.id,
-            search: { isSearchTarget: true, hasSearchTargetAncestor: true },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [parentElement.id]: "partial",
-                [childElement.id]: "partial",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "hidden",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [parentElement.id]: "partial",
-                [childElement.id]: "partial",
-                  [childOfChild1.id]: "visible",
-                  [childOfChild2.id]: "hidden",
-          },
-        });
-      });
-    });
-
-    ["2d" as const, "3d" as const].forEach((viewType) => {
-      const { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement } = getInsertFunctionByViewType(viewType);
-      describe(`${viewType} category with intermediate categories hierarchy`, () => {
-        let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
-        let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
-        async function createIModel() {
-          return buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const elementsModel = insertElementsModel({ txn, codeValue: "elements model" });
-
-              const categoryA = insertCategory({ txn, codeValue: "categoryA" });
-              const defaultSubCategoryA = { id: getDefaultSubCategoryId(categoryA.id), className: CLASS_NAME_SubCategory };
-              const categoryB = insertCategory({ txn, codeValue: "categoryB" });
-              const defaultSubCategoryB = { id: getDefaultSubCategoryId(categoryB.id), className: CLASS_NAME_SubCategory };
-              const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
-              const childElement1 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
-              const childElement2 = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
-              const siblingElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
-
-              return {
-                categoryA,
-                categoryB,
-                defaultSubCategoryA,
-                defaultSubCategoryB,
-                parentElement,
-                childElement1,
-                childElement2,
-                siblingElement,
-                elementsModel,
-                searchPaths: [
-                  {
-                    identifier: categoryA,
-                    children: [
-                      {
-                        identifier: parentElement,
-                        children: [{ identifier: categoryB, children: [{ identifier: childElement1 }] }],
-                      },
-                    ],
-                  },
-                ],
-              };
-            }),
-          );
-        }
-
-        beforeAll(async () => {
-          createIModelResult = await createIModel();
-        });
-
-        beforeEach(async function () {
-          visibilityTestData = await createFilteredVisibilityTestData({
-            imodelConnection: createIModelResult.imodelConnection,
-            searchPaths: createIModelResult.searchPaths,
-            view: viewType,
-            visibleByDefault: false,
-            subCategoriesOfCategories: [
-              { categoryId: createIModelResult.categoryA.id, subCategories: createIModelResult.defaultSubCategoryA.id },
-              { categoryId: createIModelResult.categoryB.id, subCategories: createIModelResult.defaultSubCategoryB.id },
-            ],
-          });
-          visibilityTestData.viewport.setNeverDrawn({
-            elementIds: new Set([
-              createIModelResult.parentElement.id,
-              createIModelResult.childElement1.id,
-              createIModelResult.childElement2.id,
-              createIModelResult.siblingElement.id,
-            ]),
-          });
-        });
-
-        afterEach(() => {
-          visibilityTestData[Symbol.dispose]();
-        });
-
-        afterAll(async () => {
-          await createIModelResult.imodelConnection.close();
-        });
-
-        it("showing intermediate category changes visibility for related nodes in search paths", async () => {
-          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
-          await visibilityHandlerWithSearchPaths.changeVisibility(
-            createCategoryHierarchyNode({
-              id: categoryB.id,
-              modelIds: [elementsModel.id],
-              hasChildren: true,
-              parentKeys: [categoryA, parentElement],
-              parentElementsPath: [{ elementIds: [parentElement.id], categoryIds: categoryA.id }],
-              search: {
-                isSearchTarget: false,
-                childrenTargetPaths: [{ identifier: childElement1 }],
-              },
-            }),
-            true,
-          );
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: providerWithSearchPaths,
-            handler: visibilityHandlerWithSearchPaths,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [parentElement.id]: "partial",
-                  [`${parentElement.id}-${categoryB.id}`]: "visible",
-                    [childElement1.id]: "visible",
-            },
-          });
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: defaultProvider,
-            handler: defaultVisibilityHandler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [parentElement.id]: "partial",
-                  [`${parentElement.id}-${categoryB.id}`]: "partial",
-                    [childElement1.id]: "visible",
-                    [childElement2.id]: "hidden",
-                [siblingElement.id]: "hidden",
-
-              [categoryB.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing child element under intermediate category changes visibility for related nodes in search paths", async () => {
-          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
-          await visibilityHandlerWithSearchPaths.changeVisibility(
-            createElementHierarchyNode({
-              elementId: childElement1.id,
-              modelId: elementsModel.id,
-              categoryId: categoryB.id,
-              parentKeys: [categoryA, parentElement, categoryB],
-              parentElementsPath: [{ elementIds: [parentElement.id], categoryIds: categoryA.id }],
-              search: { isSearchTarget: true },
-            }),
-            true,
-          );
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: providerWithSearchPaths,
-            handler: visibilityHandlerWithSearchPaths,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [parentElement.id]: "partial",
-                  [`${parentElement.id}-${categoryB.id}`]: "visible",
-                    [childElement1.id]: "visible",
-            },
-          });
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: defaultProvider,
-            handler: defaultVisibilityHandler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [parentElement.id]: "partial",
-                  [`${parentElement.id}-${categoryB.id}`]: "partial",
-                    [childElement1.id]: "visible",
-                    [childElement2.id]: "hidden",
-                [siblingElement.id]: "hidden",
-
-              [categoryB.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing parent element changes visibility for intermediate category children in search paths", async () => {
-          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement, elementsModel } = createIModelResult;
-          await visibilityHandlerWithSearchPaths.changeVisibility(
-            createElementHierarchyNode({
-              elementId: parentElement.id,
-              modelId: elementsModel.id,
-              categoryId: categoryA.id,
-              parentKeys: [categoryA],
-              hasChildren: true,
-              search: {
-                isSearchTarget: false,
-                childrenTargetPaths: [{ identifier: categoryB, children: [{ identifier: childElement1 }] }],
-              },
-            }),
-            true,
-          );
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: providerWithSearchPaths,
-            handler: visibilityHandlerWithSearchPaths,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "visible",
-                [parentElement.id]: "visible",
-                  [`${parentElement.id}-${categoryB.id}`]: "visible",
-                    [childElement1.id]: "visible",
-            },
-          });
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: defaultProvider,
-            handler: defaultVisibilityHandler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [parentElement.id]: "partial",
-                  [`${parentElement.id}-${categoryB.id}`]: "partial",
-                    [childElement1.id]: "visible",
-                    [childElement2.id]: "hidden",
-                [siblingElement.id]: "hidden",
-
-              [categoryB.id]: "hidden",
-            },
-          });
-        });
-
-        it("showing root category changes visibility for intermediate category children in search paths", async () => {
-          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, parentElement, childElement1, childElement2, siblingElement } = createIModelResult;
-          await visibilityHandlerWithSearchPaths.changeVisibility(
-            createCategoryHierarchyNode({
-              id: categoryA.id,
-              hasChildren: true,
-              search: {
-                isSearchTarget: false,
-                childrenTargetPaths: [{ identifier: parentElement, children: [{ identifier: categoryB, children: [{ identifier: childElement1 }] }] }],
-              },
-            }),
-            true,
-          );
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: providerWithSearchPaths,
-            handler: visibilityHandlerWithSearchPaths,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "visible",
-                [parentElement.id]: "visible",
-                  [`${parentElement.id}-${categoryB.id}`]: "visible",
-                    [childElement1.id]: "visible",
-            },
-          });
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: defaultProvider,
-            handler: defaultVisibilityHandler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [parentElement.id]: "partial",
-                  [`${parentElement.id}-${categoryB.id}`]: "partial",
-                    [childElement1.id]: "visible",
-                    [childElement2.id]: "hidden",
-                [siblingElement.id]: "hidden",
-
-              [categoryB.id]: "hidden",
-            },
-          });
-        });
-      });
-
-      describe(`${viewType} category with intermediate categories under sub-model hierarchy`, () => {
-        let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
-        let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
-        async function createIModel() {
-          return buildIModel(async (imodel) =>
-            withEditTxn(imodel, (txn) => {
-              const elementsModel = insertElementsModel({ txn, codeValue: "elements model" });
-
-              const categoryA = insertCategory({ txn, codeValue: "categoryA" });
-              const defaultSubCategoryA = { id: getDefaultSubCategoryId(categoryA.id), className: CLASS_NAME_SubCategory };
-              const categoryB = insertCategory({ txn, codeValue: "categoryB" });
-              const defaultSubCategoryB = { id: getDefaultSubCategoryId(categoryB.id), className: CLASS_NAME_SubCategory };
-              const modeledElement = insertModeledElement({
-                txn,
-                modelId: elementsModel.id,
-                categoryId: categoryA.id,
               });
-              const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-              const subModelElement1 = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
-              const subModelElement2 = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
-
-              return {
-                categoryA,
-                categoryB,
-                defaultSubCategoryA,
-                defaultSubCategoryB,
-                modeledElement,
-                subModel,
-                subModelElement1,
-                subModelElement2,
-                elementsModel,
-                searchPaths: [
-                  {
-                    identifier: categoryA,
-                    children: [
-                      {
-                        identifier: modeledElement,
-                        children: [{ identifier: subModel, children: [{ identifier: categoryB, children: [{ identifier: subModelElement1 }] }] }],
-                      },
-                    ],
-                  },
-                ],
-              };
-            }),
-          );
-        }
-
-        beforeAll(async () => {
-          createIModelResult = await createIModel();
-        });
-
-        beforeEach(async function () {
-          visibilityTestData = await createFilteredVisibilityTestData({
-            imodelConnection: createIModelResult.imodelConnection,
-            searchPaths: createIModelResult.searchPaths,
-            view: viewType,
-            visibleByDefault: false,
-            subCategoriesOfCategories: [
-              { categoryId: createIModelResult.categoryA.id, subCategories: createIModelResult.defaultSubCategoryA.id },
-              { categoryId: createIModelResult.categoryB.id, subCategories: createIModelResult.defaultSubCategoryB.id },
-            ],
-          });
-          visibilityTestData.viewport.setNeverDrawn({
-            elementIds: new Set([createIModelResult.modeledElement.id, createIModelResult.subModelElement1.id, createIModelResult.subModelElement2.id]),
+            });
           });
         });
 
-        afterEach(() => {
-          visibilityTestData[Symbol.dispose]();
-        });
+        describe("enabling category visibility through model selector", () => {
+          it("category is visible when only one model contains category and model is enabled through model selector", async () => {
+            const { imodelConnection, ...keys } = simpleIModel;
 
-        afterAll(async () => {
-          await createIModelResult.imodelConnection.close();
-        });
+            using visibilityTestData = await createVisibilityTestData({ imodelConnection, ...accessAndCacheSimpleIModel });
+            const { handler, provider, viewport } = visibilityTestData;
+            setupInitialDisplayState({ viewport, categories: [{ id: keys.category.id, visible: true }] });
 
-        it("showing intermediate category under sub-model changes visibility for related nodes in search paths", async () => {
-          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2 } = createIModelResult;
-          await visibilityHandlerWithSearchPaths.changeVisibility(
-            createCategoryHierarchyNode({
-              id: categoryB.id,
-              modelIds: [modeledElement.id],
-              hasChildren: true,
-              parentKeys: [categoryA, modeledElement, subModel],
-              search: {
-                isSearchTarget: false,
-                childrenTargetPaths: [{ identifier: subModelElement1 }],
+            viewport.changeModelDisplay({ modelIds: keys.elementsModel.id, display: true });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              expectations: "all-visible",
+            });
+          });
+
+          it("category is partial when multiple models contain category and one model is enabled through model selector", async () => {
+            const { imodelConnection, ...keys } = elementsModelsIModel;
+            using visibilityTestData = await createVisibilityTestData({ imodelConnection, ...accessAndCacheElementsModelsIModel });
+            const { handler, provider, viewport } = visibilityTestData;
+            setupInitialDisplayState({ viewport, categories: [{ id: keys.categoryA.id, visible: true }] });
+
+            viewport.changeModelDisplay({ modelIds: keys.elementsModel1.id, display: true });
+
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              expectations: {
+                [keys.categoryA.id]: "partial",
+                [keys.categoryB.id]: "hidden",
               },
-            }),
-            true,
-          );
+            });
+          });
+        });
+      });
+
+      describe("disabling visibility", () => {
+        it("by default everything is visible", async () => {
+          const { imodelConnection, ...keys } = simpleIModel;
+          using visibilityTestData = await createVisibilityTestData({
+            imodelConnection,
+            subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+            visibleByDefault: true,
+            ...accessAndCacheSimpleIModel,
+          });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await validateCategoriesTreeHierarchyVisibility({
-            provider: providerWithSearchPaths,
-            handler: visibilityHandlerWithSearchPaths,
+            provider,
+            handler,
             viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [modeledElement.id]: "partial",
-                  [subModel.id]: "partial",
-                    [`${modeledElement.id}-${categoryB.id}`]: "visible",
-                      [subModelElement1.id]: "visible",
-            },
+            expectations: "all-visible",
+          });
+        });
+
+        it("category is partial when multiple models contain category and override for one model is set to 'Hide'", async () => {
+          const { imodelConnection, ...keys } = elementsModelsIModel;
+          using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true, ...accessAndCacheElementsModelsIModel });
+          const { handler, provider, viewport } = visibilityTestData;
+
+          viewport.setPerModelCategoryOverride({
+            modelIds: keys.elementsModel1.id,
+            categoryIds: keys.categoryA.id,
+            override: "hide",
           });
 
           await validateCategoriesTreeHierarchyVisibility({
-            provider: defaultProvider,
-            handler: defaultVisibilityHandler,
+            provider,
+            handler,
             viewport,
-            // prettier-ignore
             expectations: {
-              [categoryA.id]: "partial",
-                [modeledElement.id]: "partial",
-                  [`${modeledElement.id}-${categoryB.id}`]: "partial",
-                    [subModelElement1.id]: "visible",
-                    [subModelElement2.id]: "hidden",
-
-              [categoryB.id]: "hidden",
+              [keys.categoryA.id]: "partial",
+              [keys.categoryB.id]: "visible",
             },
           });
         });
 
-        it("showing element under intermediate category in sub-model changes visibility for related nodes in search paths", async () => {
-          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2 } = createIModelResult;
-          await visibilityHandlerWithSearchPaths.changeVisibility(
-            createElementHierarchyNode({
-              elementId: subModelElement1.id,
-              modelId: modeledElement.id,
-              categoryId: categoryB.id,
-              parentKeys: [categoryA, modeledElement, subModel, categoryB],
-              search: { isSearchTarget: true },
-            }),
-            true,
-          );
+        it("category is partial when multiple models contain category and one model is disabled through model selector", async () => {
+          const { imodelConnection, ...keys } = elementsModelsIModel;
+          using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true, ...accessAndCacheElementsModelsIModel });
+          const { handler, provider, viewport } = visibilityTestData;
+
+          viewport.changeModelDisplay({ modelIds: keys.elementsModel1.id, display: false });
 
           await validateCategoriesTreeHierarchyVisibility({
-            provider: providerWithSearchPaths,
-            handler: visibilityHandlerWithSearchPaths,
+            provider,
+            handler,
             viewport,
-            // prettier-ignore
             expectations: {
-              [categoryA.id]: "partial",
-                [modeledElement.id]: "partial",
-                  [subModel.id]: "partial",
-                    [`${modeledElement.id}-${categoryB.id}`]: "visible",
-                      [subModelElement1.id]: "visible",
-            },
-          });
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: defaultProvider,
-            handler: defaultVisibilityHandler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [modeledElement.id]: "partial",
-                  [`${modeledElement.id}-${categoryB.id}`]: "partial",
-                    [subModelElement1.id]: "visible",
-                    [subModelElement2.id]: "hidden",
-
-              [categoryB.id]: "hidden",
+              [keys.categoryA.id]: "partial",
+              [keys.categoryB.id]: "partial",
             },
           });
         });
 
-        it("showing modeled element changes visibility for intermediate category children in search paths", async () => {
-          const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-          const { categoryA, categoryB, modeledElement, subModel, subModelElement1, subModelElement2, elementsModel } = createIModelResult;
-          await visibilityHandlerWithSearchPaths.changeVisibility(
-            createElementHierarchyNode({
-              elementId: modeledElement.id,
-              modelId: elementsModel.id,
-              categoryId: categoryA.id,
-              parentKeys: [categoryA],
-              hasChildren: true,
-              search: {
-                isSearchTarget: false,
-                childrenTargetPaths: [{ identifier: subModel, children: [{ identifier: categoryB, children: [{ identifier: subModelElement1 }] }] }],
+        describe("definitionContainers", () => {
+          it("hiding definition container hides children", async () => {
+            const { imodelConnection, ...keys } = simpleIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+              visibleByDefault: true,
+              ...accessAndCacheSimpleIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              expectations: "all-hidden",
+            });
+          });
+
+          it("hiding definition container doesn't affect non contained definition containers", async () => {
+            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [
+                { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+              ],
+              visibleByDefault: true,
+              ...accessAndCacheUnrelatedDefContainersIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "hidden",
+                  [keys.category.id]: "hidden",
+                    [keys.subCategory.id]: "hidden",
+                    [keys.defaultSubCategoryId]: "hidden",
+
+                [keys.definitionContainer2.id]: "visible",
+                  [keys.category2.id]: "visible",
+                    [keys.subCategory2.id]: "visible",
+                    [keys.defaultSubCategoryId2]: "visible",
               },
-            }),
-            true,
-          );
+            });
+          });
+
+          it("hiding definition affects parent", async () => {
+            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              visibleByDefault: true,
+              ...accessAndCacheSiblingCategoriesIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createDefinitionContainerHierarchyNode({ id: keys.childDefinitionContainer.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+
+              expectations: {
+                [keys.parentDefinitionContainer.id]: "partial",
+                  [keys.category.id]: "visible",
+
+                  [keys.childDefinitionContainer.id]: "hidden",
+                    [keys.childCategory.id]: "hidden",
+                    [keys.childCategory2.id]: "hidden",
+              },
+            });
+          });
+        });
+
+        describe("categories", () => {
+          it("hiding category hides children", async () => {
+            const { imodelConnection, ...keys } = simpleIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+              visibleByDefault: true,
+              ...accessAndCacheSimpleIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              expectations: "all-hidden",
+            });
+          });
+
+          it("hiding category doesn't affect non related nodes", async () => {
+            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [
+                { categoryId: keys.category.id, subCategories: keys.subCategory.id },
+                { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
+              ],
+              visibleByDefault: true,
+              ...accessAndCacheUnrelatedDefContainersIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "hidden",
+                  [keys.category.id]: "hidden",
+                    [keys.subCategory.id]: "hidden",
+                    [keys.defaultSubCategoryId]: "hidden",
+
+                [keys.definitionContainer2.id]: "visible",
+                  [keys.category2.id]: "visible",
+                    [keys.subCategory2.id]: "visible",
+                    [keys.defaultSubCategoryId2]: "visible",
+              },
+            });
+          });
+
+          it("hiding category makes parent container partially visible if it has more direct child categories", async () => {
+            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              visibleByDefault: true,
+              ...accessAndCacheSiblingCategoriesIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.childCategory.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.parentDefinitionContainer.id]: "partial",
+                  [keys.category.id]: "visible",
+
+                  [keys.childDefinitionContainer.id]: "partial",
+                    [keys.childCategory.id]: "hidden",
+                    [keys.childCategory2.id]: "visible",
+              },
+            });
+          });
+
+          it("hiding category makes parent container partially visible if it has more definition containers", async () => {
+            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              visibleByDefault: true,
+              ...accessAndCacheSiblingCategoriesIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createCategoryHierarchyNode({ id: keys.category.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+
+              expectations: {
+                [keys.parentDefinitionContainer.id]: "partial",
+                  [keys.category.id]: "hidden",
+
+                  [keys.childDefinitionContainer.id]: "visible",
+                    [keys.childCategory.id]: "visible",
+                    [keys.childCategory2.id]: "visible",
+              },
+            });
+          });
+        });
+
+        describe("subCategories", () => {
+          it("hiding subCategory affects parents and doesn't affect other subCategories", async () => {
+            const { imodelConnection, ...keys } = simpleIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+              visibleByDefault: true,
+              ...accessAndCacheSimpleIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "partial",
+                  [keys.category.id]: "partial",
+                    [getDefaultSubCategoryId(keys.category.id)]: "visible",
+                    [keys.subCategory.id]: "hidden",
+              },
+            });
+          });
+
+          it("hiding subCategory doesn't affect not related nodes", async () => {
+            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            using visibilityTestData = await createVisibilityTestData({
+              imodelConnection,
+              subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
+              visibleByDefault: true,
+              ...accessAndCacheUnrelatedDefContainersIModel,
+            });
+            const { handler, provider, viewport } = visibilityTestData;
+
+            await handler.changeVisibility(createSubCategoryHierarchyNode({ id: keys.subCategory.id, categoryId: keys.category.id }), false);
+            await validateCategoriesTreeHierarchyVisibility({
+              provider,
+              handler,
+              viewport,
+              // prettier-ignore
+              expectations: {
+                [keys.definitionContainer.id]: "partial",
+                  [keys.category.id]: "partial",
+                    [keys.subCategory.id]: "hidden",
+                    [keys.defaultSubCategoryId]: "visible",
+
+                [keys.definitionContainer2.id]: "visible",
+                  [keys.category2.id]: "visible",
+                    [keys.subCategory2.id]: "visible",
+                    [keys.defaultSubCategoryId2]: "visible",
+              },
+            });
+          });
+        });
+
+        describe("elements set to 'include'", () => {
+          describe("intermediate categories", () => {
+            let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
+
+            beforeEach(async () => {
+              visibilityTestData = await createVisibilityTestData({
+                imodelConnection: intermediateCategoriesIModel.imodelConnection,
+                hierarchyConfig: { elements: { nodes: "include" } },
+                visibleByDefault: true,
+                ...accessAndCacheIntermediateCategoriesIModel,
+              });
+            });
+
+            afterEach(() => {
+              visibilityTestData[Symbol.dispose]();
+            });
+
+            it("hiding intermediate category makes its elements hidden", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = intermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createCategoryHierarchyNode({
+                  id: keys.categoryB.id,
+                  modelIds: [keys.elementsModel.id],
+                  hasChildren: true,
+                  parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
+                }),
+                false,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.parentElement.id]: "partial",
+                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
+                        [keys.childElement.id]: "hidden",
+
+                  [keys.categoryB.id]: "visible",
+                },
+              });
+            });
+
+            it("hiding child element under intermediate category makes it hidden and parents partially visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = intermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.elementsModel.id,
+                  categoryId: keys.categoryB.id,
+                  elementId: keys.childElement.id,
+                  parentElementsPath: [{ elementIds: [keys.parentElement.id], categoryIds: keys.categoryA.id }],
+                }),
+                false,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.parentElement.id]: "partial",
+                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
+                        [keys.childElement.id]: "hidden",
+
+                  [keys.categoryB.id]: "visible",
+                },
+              });
+            });
+
+            it("hiding parent element makes children under intermediate category hidden", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = intermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.elementsModel.id,
+                  categoryId: keys.categoryA.id,
+                  elementId: keys.parentElement.id,
+                  hasChildren: true,
+                }),
+                false,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    // Category has a sub-category which is visible
+                    [keys.parentElement.id]: "hidden",
+                      [`${keys.parentElement.id}-${keys.categoryB.id}`]: "hidden",
+                        [keys.childElement.id]: "hidden",
+
+                  [keys.categoryB.id]: "visible",
+                },
+              });
+            });
+          });
+
+          describe("intermediate categories under sub-model", () => {
+            let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
+
+            beforeEach(async () => {
+              visibilityTestData = await createVisibilityTestData({
+                imodelConnection: subModelIntermediateCategoriesIModel.imodelConnection,
+                hierarchyConfig: { elements: { nodes: "include" } },
+                visibleByDefault: true,
+                ...accessAndCacheSubModelIntermediateCategoriesIModel,
+              });
+            });
+
+            afterEach(() => {
+              visibilityTestData[Symbol.dispose]();
+            });
+
+            it("hiding intermediate category under sub-model makes its elements hidden", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = subModelIntermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createCategoryHierarchyNode({
+                  id: keys.categoryB.id,
+                  modelIds: [keys.modeledElement.id],
+                  hasChildren: true,
+                }),
+                false,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.modeledElement.id]: "partial",
+                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
+                        [keys.subModelElement.id]: "hidden",
+
+                  [keys.categoryB.id]: "visible",
+                },
+              });
+            });
+
+            it("hiding element under intermediate category in sub-model makes it hidden and parents partially visible", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = subModelIntermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.modeledElement.id,
+                  categoryId: keys.categoryB.id,
+                  elementId: keys.subModelElement.id,
+                }),
+                false,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  [keys.categoryA.id]: "partial",
+                    [keys.modeledElement.id]: "partial",
+                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
+                        [keys.subModelElement.id]: "hidden",
+
+                  [keys.categoryB.id]: "visible",
+                },
+              });
+            });
+
+            it("hiding modeled element makes sub-model elements under intermediate category hidden", async () => {
+              const { handler, provider, viewport } = visibilityTestData;
+              const keys = subModelIntermediateCategoriesIModel;
+
+              await handler.changeVisibility(
+                createElementHierarchyNode({
+                  modelId: keys.elementsModel.id,
+                  categoryId: keys.categoryA.id,
+                  elementId: keys.modeledElement.id,
+                  hasChildren: true,
+                }),
+                false,
+              );
+
+              await validateCategoriesTreeHierarchyVisibility({
+                provider,
+                handler,
+                viewport,
+                // prettier-ignore
+                expectations: {
+                  // Category has a sub-category which is visible
+                  [keys.categoryA.id]: "partial",
+                    [keys.modeledElement.id]: "hidden",
+                      [`${keys.modeledElement.id}-${keys.categoryB.id}`]: "hidden",
+                        [keys.subModelElement.id]: "hidden",
+
+                  [keys.categoryB.id]: "visible",
+                },
+              });
+            });
+          });
+        });
+      });
+
+      describe("elements.excludedClasses", () => {
+        it("element of an excluded class participates in visibility", async () => {
+          const { imodelConnection, ...keys } = simpleIModel;
+
+          using visibilityTestData = await createVisibilityTestData({
+            imodelConnection,
+            hierarchyConfig: { elements: { nodes: "include", excludedClasses: [getClassesByView(viewType).elementClass] } },
+            ...accessAndCacheSimpleIModel,
+          });
+          const { handler, provider, viewport } = visibilityTestData;
 
           await validateCategoriesTreeHierarchyVisibility({
-            provider: providerWithSearchPaths,
-            handler: visibilityHandlerWithSearchPaths,
+            provider,
+            handler,
+            viewport,
+            expectations: "all-hidden",
+          });
+
+          const definitionContainerNode = createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id });
+          await handler.changeVisibility(definitionContainerNode, true);
+          await validateCategoriesTreeHierarchyVisibility({
+            provider,
+            handler,
+            viewport,
+            expectations: "all-visible",
+          });
+
+          viewport.setNeverDrawn({ elementIds: new Set([keys.element.id]) });
+
+          await validateCategoriesTreeHierarchyVisibility({
+            provider,
+            handler,
             viewport,
             // prettier-ignore
             expectations: {
-              [categoryA.id]: "visible",
-                [modeledElement.id]: "visible",
-                  [subModel.id]: "visible",
-                    [`${modeledElement.id}-${categoryB.id}`]: "visible",
-                      [subModelElement1.id]: "visible",
-            },
-          });
-
-          await validateCategoriesTreeHierarchyVisibility({
-            provider: defaultProvider,
-            handler: defaultVisibilityHandler,
-            viewport,
-            // prettier-ignore
-            expectations: {
-              [categoryA.id]: "partial",
-                [modeledElement.id]: "partial",
-                  [`${modeledElement.id}-${categoryB.id}`]: "partial",
-                    [subModelElement1.id]: "visible",
-                    [subModelElement2.id]: "hidden",
-
-              [categoryB.id]: "hidden",
+              [keys.definitionContainer.id]: "partial",
+                [keys.category.id]: "partial",
+                  [keys.defaultSubCategoryId]: "visible",
+                  [keys.subCategory.id]: "visible",
             },
           });
         });
-      });
-    });
-
-    describe("category with modeled elements hierarchy", () => {
-      let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
-      let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
-      async function createIModel() {
-        return buildIModel(async (imodel, testSchema) =>
-          withEditTxn(imodel, (txn) => {
-            const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-
-            const category = insertSpatialCategory({ txn, codeValue: "category" });
-            const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
-            const element = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-            const modeledElement = insertPhysicalElement({
-              txn,
-              userLabel: `modeled element`,
-              modelId: physicalModel.id,
-              categoryId: category.id,
-              classFullName: testSchema.items.SubModelablePhysicalObject.fullName,
-            });
-            const subModel = insertPhysicalSubModel({ txn, modeledElementId: modeledElement.id });
-            const subModelCategory = insertSpatialCategory({ txn, codeValue: "subModel category" });
-            const subModelElement = insertPhysicalElement({ txn, userLabel: `subModel element`, modelId: subModel.id, categoryId: subModelCategory.id });
-            const subModelElement2 = insertPhysicalElement({ txn, userLabel: `subModel element 2`, modelId: subModel.id, categoryId: subModelCategory.id });
-            const defaultSubCategoryOfSubModelCategory = { id: getDefaultSubCategoryId(subModelCategory.id), className: CLASS_NAME_SubCategory };
-
-            const otherSubModelCategory = insertSpatialCategory({ txn, codeValue: "other subModel category" });
-            const otherSubModelElement = insertPhysicalElement({
-              txn,
-              userLabel: `other subModel element`,
-              modelId: subModel.id,
-              categoryId: otherSubModelCategory.id,
-            });
-            const defaultSubCategoryOfOtherSubModelCategory = { id: getDefaultSubCategoryId(otherSubModelCategory.id), className: CLASS_NAME_SubCategory };
-
-            const siblingCategory = insertSpatialCategory({ txn, codeValue: "sibling category" });
-            const siblingElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: siblingCategory.id });
-            const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
-
-            return {
-              category,
-              physicalModel,
-              defaultSubCategory,
-              element,
-              modeledElement,
-              subModel,
-              subModelCategory,
-              subModelElement,
-              subModelElement2,
-              defaultSubCategoryOfSubModelCategory,
-              otherSubModelCategory,
-              otherSubModelElement,
-              defaultSubCategoryOfOtherSubModelCategory,
-              siblingCategory,
-              siblingElement,
-              defaultSiblingSubCategory,
-              searchPaths: [
-                {
-                  identifier: category,
-                  children: [
-                    {
-                      identifier: modeledElement,
-                      children: [{ identifier: subModel, children: [{ identifier: subModelCategory, children: [{ identifier: subModelElement }] }] }],
-                    },
-                  ],
-                },
-              ],
-            };
-          }),
-        );
-      }
-
-      beforeAll(async () => {
-        createIModelResult = await createIModel();
-      });
-
-      beforeEach(async function () {
-        visibilityTestData = await createFilteredVisibilityTestData({
-          imodelConnection: createIModelResult.imodelConnection,
-          searchPaths: createIModelResult.searchPaths,
-          view: "3d",
-          visibleByDefault: false,
-          subCategoriesOfCategories: [
-            { categoryId: createIModelResult.category.id, subCategories: createIModelResult.defaultSubCategory.id },
-            { categoryId: createIModelResult.subModelCategory.id, subCategories: createIModelResult.defaultSubCategoryOfSubModelCategory.id },
-            {
-              categoryId: createIModelResult.otherSubModelCategory.id,
-              subCategories: createIModelResult.defaultSubCategoryOfOtherSubModelCategory.id,
-            },
-            { categoryId: createIModelResult.siblingCategory.id, subCategories: createIModelResult.defaultSiblingSubCategory.id },
-          ],
-        });
-      });
-
-      afterEach(() => {
-        visibilityTestData[Symbol.dispose]();
-      });
-
-      afterAll(async () => {
-        await createIModelResult.imodelConnection.close();
-      });
-
-      it("showing category changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          modeledElement,
-          subModel,
-          subModelCategory,
-          subModelElement,
-          siblingCategory,
-          siblingElement,
-          element,
-          subModelElement2,
-          otherSubModelCategory,
-          otherSubModelElement,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createCategoryHierarchyNode({
-            id: category.id,
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [
-                {
-                  identifier: modeledElement,
-                  children: [{ identifier: subModel, children: [{ identifier: subModelCategory, children: [{ identifier: subModelElement }] }] }],
-                },
-              ],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "visible",
-              [modeledElement.id]: "visible",
-                [`${subModel.id}-${subModelCategory.id}`]: "visible",
-                  [subModelElement.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [modeledElement.id]: "partial",
-                [`${subModel.id}-${subModelCategory.id}`]: "partial",
-                  [subModelElement.id]: "visible",
-                  [subModelElement2.id]: "hidden",
-                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
-                  [otherSubModelElement.id]: "hidden",
-
-            [otherSubModelCategory.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-
-            [subModelCategory.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing modeled element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          modeledElement,
-          subModel,
-          subModelCategory,
-          subModelElement,
-          siblingCategory,
-          siblingElement,
-          element,
-          subModelElement2,
-          otherSubModelCategory,
-          otherSubModelElement,
-          physicalModel,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: modeledElement.id,
-            categoryId: category.id,
-            parentKeys: [category],
-            modelId: physicalModel.id,
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [{ identifier: subModel, children: [{ identifier: subModelCategory, children: [{ identifier: subModelElement }] }] }],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "visible",
-              [modeledElement.id]: "visible",
-                [`${subModel.id}-${subModelCategory.id}`]: "visible",
-                  [subModelElement.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [modeledElement.id]: "partial",
-                [`${subModel.id}-${subModelCategory.id}`]: "partial",
-                  [subModelElement.id]: "visible",
-                  [subModelElement2.id]: "hidden",
-                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
-                  [otherSubModelElement.id]: "hidden",
-
-            [otherSubModelCategory.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-
-            [subModelCategory.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing category of subModel changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          modeledElement,
-          subModel,
-          subModelCategory,
-          subModelElement,
-          siblingCategory,
-          siblingElement,
-          element,
-          subModelElement2,
-          otherSubModelCategory,
-          otherSubModelElement,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createCategoryHierarchyNode({
-            id: subModelCategory.id,
-            parentKeys: [category, modeledElement, subModel],
-            modelIds: [subModel.id],
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [{ identifier: subModelElement }],
-            },
-          }),
-          true,
-        );
-        // In this case when turning on subModelCategory, only subModelElement is put into always drawn list (due to search paths).
-        // Because subModelElement and subModelCategory visibility is not affected by visibility of nodes above them (in hierarchy),
-        // visibility handler does not change the visibility of modeledElement or category (They get partial visibility because their subModels are visible, but they themselves are not).
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [modeledElement.id]: "partial",
-                [`${subModel.id}-${subModelCategory.id}`]: "visible",
-                  [subModelElement.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [modeledElement.id]: "partial",
-                [`${subModel.id}-${subModelCategory.id}`]: "partial",
-                  [subModelElement.id]: "visible",
-                  [subModelElement2.id]: "hidden",
-                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
-                  [otherSubModelElement.id]: "hidden",
-
-            [otherSubModelCategory.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-
-            [subModelCategory.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing search target subModel element changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const {
-          category,
-          modeledElement,
-          subModel,
-          subModelCategory,
-          subModelElement,
-          siblingCategory,
-          siblingElement,
-          element,
-          subModelElement2,
-          otherSubModelCategory,
-          otherSubModelElement,
-        } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createElementHierarchyNode({
-            elementId: subModelElement.id,
-            parentKeys: [category, modeledElement, subModelCategory],
-            categoryId: subModelCategory.id,
-            modelId: subModel.id,
-            search: { isSearchTarget: true },
-          }),
-          true,
-        );
-
-        // In this case when turning on subModelElement visibility, it is put into always drawn list.
-        // Because subModelElement and subModelCategory visibility is not affected by visibility of nodes above them (in hierarchy),
-        // visibility handler does not change the visibility of modeledElement or category (They get partial visibility because their subModels are visible, but they themselves are not).
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [modeledElement.id]: "partial",
-                [`${subModel.id}-${subModelCategory.id}`]: "visible",
-                  [subModelElement.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [category.id]: "partial",
-              [element.id]: "hidden",
-
-              [modeledElement.id]: "partial",
-                [`${subModel.id}-${subModelCategory.id}`]: "partial",
-                  [subModelElement.id]: "visible",
-                  [subModelElement2.id]: "hidden",
-                [`${subModel.id}-${otherSubModelCategory.id}`]: "hidden",
-                  [otherSubModelElement.id]: "hidden",
-
-            [otherSubModelCategory.id]: "hidden",
-
-            [siblingCategory.id]: "hidden",
-              [siblingElement.id]: "hidden",
-
-            [subModelCategory.id]: "hidden",
-          },
-        });
-      });
-    });
-
-    describe("category under definition container hierarchy", () => {
-      let createIModelResult: Awaited<ReturnType<typeof createIModel>>;
-      let visibilityTestData: Awaited<ReturnType<typeof createFilteredVisibilityTestData>>;
-      async function createIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-            const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-            const category = insertSpatialCategory({ txn, codeValue: "category", modelId: definitionModel.id });
-            const defaultSubCategory = { id: getDefaultSubCategoryId(category.id), className: CLASS_NAME_SubCategory };
-            const subCategory = insertSubCategory({
-              txn,
-              parentCategoryId: category.id,
-              codeValue: "subCategory",
-              modelId: definitionModel.id,
-            });
-
-            const siblingCategory = insertSpatialCategory({ txn, codeValue: "sibling category", modelId: definitionModel.id });
-            const defaultSiblingSubCategory = { id: getDefaultSubCategoryId(siblingCategory.id), className: CLASS_NAME_SubCategory };
-
-            return {
-              definitionContainer,
-              category,
-              defaultSubCategory,
-              subCategory,
-              siblingCategory,
-              defaultSiblingSubCategory,
-              searchPaths: [{ identifier: definitionContainer, children: [{ identifier: category, children: [{ identifier: defaultSubCategory }] }] }],
-            };
-          }),
-        );
-      }
-
-      beforeAll(async () => {
-        createIModelResult = await createIModel();
-      });
-
-      beforeEach(async function () {
-        visibilityTestData = await createFilteredVisibilityTestData({
-          imodelConnection: createIModelResult.imodelConnection,
-          searchPaths: createIModelResult.searchPaths,
-          view: "3d",
-          visibleByDefault: false,
-          subCategoriesOfCategories: [
-            { categoryId: createIModelResult.category.id, subCategories: [createIModelResult.subCategory.id, createIModelResult.defaultSubCategory.id] },
-            { categoryId: createIModelResult.siblingCategory.id, subCategories: createIModelResult.defaultSiblingSubCategory.id },
-          ],
-        });
-      });
-
-      afterEach(() => {
-        visibilityTestData[Symbol.dispose]();
-      });
-
-      afterAll(async () => {
-        await createIModelResult.imodelConnection.close();
-      });
-
-      it("showing definition container changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createDefinitionContainerHierarchyNode({
-            id: definitionContainer.id,
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [{ identifier: category, children: [{ identifier: defaultSubCategory }] }],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [definitionContainer.id]: "visible",
-              [category.id]: "visible",
-                [defaultSubCategory.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [definitionContainer.id]: "partial",
-              [category.id]: "partial",
-                [defaultSubCategory.id]: "visible",
-                [subCategory.id]: "hidden",
-
-              [siblingCategory.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing category changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createCategoryHierarchyNode({
-            id: category.id,
-            parentKeys: [definitionContainer],
-            search: {
-              isSearchTarget: false,
-              childrenTargetPaths: [{ identifier: defaultSubCategory }],
-            },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [definitionContainer.id]: "visible",
-              [category.id]: "visible",
-                [defaultSubCategory.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [definitionContainer.id]: "partial",
-              [category.id]: "partial",
-                [defaultSubCategory.id]: "visible",
-                [subCategory.id]: "hidden",
-
-              [siblingCategory.id]: "hidden",
-          },
-        });
-      });
-
-      it("showing search target sub-category changes visibility for related nodes in search paths", async () => {
-        const { defaultVisibilityHandler, visibilityHandlerWithSearchPaths, viewport, defaultProvider, providerWithSearchPaths } = visibilityTestData;
-        const { definitionContainer, category, siblingCategory, defaultSubCategory, subCategory } = createIModelResult;
-        await visibilityHandlerWithSearchPaths.changeVisibility(
-          createSubCategoryHierarchyNode({
-            id: defaultSubCategory.id,
-            parentKeys: [definitionContainer, category],
-            categoryId: category.id,
-            search: { isSearchTarget: true },
-          }),
-          true,
-        );
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: providerWithSearchPaths,
-          handler: visibilityHandlerWithSearchPaths,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [definitionContainer.id]: "visible",
-              [category.id]: "visible",
-                [defaultSubCategory.id]: "visible",
-          },
-        });
-
-        await validateCategoriesTreeHierarchyVisibility({
-          provider: defaultProvider,
-          handler: defaultVisibilityHandler,
-          viewport,
-          // prettier-ignore
-          expectations: {
-            [definitionContainer.id]: "partial",
-              [category.id]: "partial",
-                [defaultSubCategory.id]: "visible",
-                [subCategory.id]: "hidden",
-
-              [siblingCategory.id]: "hidden",
-          },
-        });
-      });
-    });
-  });
-
-  describe("elements.excludedClasses", () => {
-    it("element of an excluded class participates in visibility", async () => {
-      await using buildIModelResult = await buildIModel(async (imodel) =>
-        withEditTxn(imodel, (txn) => {
-          const physicalModel = insertPhysicalModelWithPartition({ txn, codeValue: "TestPhysicalModel" });
-          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "DefinitionContainer" });
-          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-          const category = insertSpatialCategory({ txn, codeValue: "SpatialCategory", modelId: definitionModel.id });
-          const excludedElement = insertPhysicalElement({ txn, modelId: physicalModel.id, categoryId: category.id });
-          return { physicalModel, definitionContainer, category, excludedElement };
-        }),
-      );
-
-      const { imodelConnection, ...keys } = buildIModelResult;
-
-      using visibilityTestData = await createVisibilityTestData({
-        imodelConnection,
-        hierarchyConfig: { elements: { nodes: "include", excludedClasses: [CLASS_NAME_GeometricElement3d] } },
-      });
-      const { handler, provider, viewport } = visibilityTestData;
-
-      await validateCategoriesTreeHierarchyVisibility({
-        provider,
-        handler,
-        viewport,
-        expectations: "all-hidden",
-      });
-
-      const definitionContainerNode = createDefinitionContainerHierarchyNode({ id: keys.definitionContainer.id });
-      await handler.changeVisibility(definitionContainerNode, true);
-      await validateCategoriesTreeHierarchyVisibility({
-        provider,
-        handler,
-        viewport,
-        expectations: "all-visible",
-      });
-
-      viewport.setNeverDrawn({ elementIds: new Set([keys.excludedElement.id]) });
-
-      await validateCategoriesTreeHierarchyVisibility({
-        provider,
-        handler,
-        viewport,
-        // prettier-ignore
-        expectations: {
-          [keys.definitionContainer.id]: "partial",
-            [keys.category.id]: "partial",
-        },
       });
     });
   });
 });
-
-interface VisibilityInfo {
-  id: Id64String;
-  visible: boolean;
-}
-
-function setupInitialDisplayState(props: {
-  viewport: TreeWidgetTestingViewport;
-  categories?: Array<VisibilityInfo>;
-  subCategories?: Array<VisibilityInfo>;
-  models?: Array<VisibilityInfo>;
-  elements?: Array<VisibilityInfo>;
-}) {
-  const { viewport } = props;
-  const categories = props.categories ?? [];
-  const elements = props.elements ?? [];
-  const subCategories = props.subCategories ?? [];
-  const models = props.models ?? [];
-  for (const subCategoryInfo of subCategories) {
-    viewport.changeSubCategoryDisplay({ subCategoryId: subCategoryInfo.id, display: subCategoryInfo.visible });
-  }
-  for (const categoryInfo of categories) {
-    viewport.changeCategoryDisplay({ categoryIds: categoryInfo.id, display: categoryInfo.visible, enableAllSubCategories: false });
-  }
-  const alwaysDrawn = elements.filter(({ visible }) => visible).map(({ id }) => id);
-  if (alwaysDrawn.length > 0) {
-    viewport.setAlwaysDrawn({ elementIds: new Set([...alwaysDrawn, ...(viewport.alwaysDrawn ?? [])]) });
-  }
-  const neverDrawn = elements.filter(({ visible }) => !visible).map(({ id }) => id);
-  if (neverDrawn.length > 0) {
-    viewport.setNeverDrawn({ elementIds: new Set([...neverDrawn, ...(viewport.neverDrawn ?? [])]) });
-  }
-
-  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => visible).map(({ id }) => id), display: true });
-  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => !visible).map(({ id }) => id), display: false });
-  viewport.renderFrame();
-}
-
-async function validateCategoriesTreeHierarchyVisibility(props: Omit<Props<typeof validateHierarchyVisibility>, "validateNodeVisibility">) {
-  return validateHierarchyVisibility({
-    ...props,
-    validateNodeVisibility,
-  });
-}

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/CategoriesTreeVisibilityHandler.test.ts
@@ -121,222 +121,25 @@ describe("CategoriesTreeVisibilityHandler", () => {
       };
     }
     describe(`${viewType} view`, () => {
-      let simpleIModel: Awaited<ReturnType<typeof createSimpleIModel>>;
-      let accessAndCacheSimpleIModel: ReturnType<typeof createAccessAndCache>;
-
-      let unrelatedDefContainersIModel: Awaited<ReturnType<typeof createUnrelatedDefContainersIModel>>;
-      let accessAndCacheUnrelatedDefContainersIModel: ReturnType<typeof createAccessAndCache>;
-
-      let siblingCategoriesIModel: Awaited<ReturnType<typeof createSiblingCategoriesIModel>>;
-      let accessAndCacheSiblingCategoriesIModel: ReturnType<typeof createAccessAndCache>;
-
-      let elementsModelsIModel: Awaited<ReturnType<typeof createElementsModelsIModel>>;
-      let accessAndCacheElementsModelsIModel: ReturnType<typeof createAccessAndCache>;
-
-      let intermediateCategoriesIModel: Awaited<ReturnType<typeof createIntermediateCategoriesIModel>>;
-      let accessAndCacheIntermediateCategoriesIModel: ReturnType<typeof createAccessAndCache>;
-
-      let subModelIntermediateCategoriesIModel: Awaited<ReturnType<typeof createSubModelIntermediateCategoriesIModel>>;
-      let accessAndCacheSubModelIntermediateCategoriesIModel: ReturnType<typeof createAccessAndCache>;
-
-      async function createSimpleIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            // Structure of the iModel:
-            // - DefinitionContainer
-            //   - Category
-            //     - Default SubCategory
-            //     - SubCategory
-            //     - Element
-            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
-            const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
-            const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-
-            const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
-            const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
-            return { definitionContainer, category, subCategory, elementsModel, element, defaultSubCategoryId: getDefaultSubCategoryId(category.id) };
-          }),
-        );
-      }
-
-      async function createUnrelatedDefContainersIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            // Structure of the iModel:
-            // - DefinitionContainer
-            //   - Category
-            //     - Default SubCategory
-            //     - SubCategory
-            //     - Element
-            //
-            // - DefinitionContainer2
-            //   - Category2
-            //     - Default SubCategory2
-            //     - SubCategory2
-            //     - Element2
-            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
-            const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
-            const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
-            const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
-            const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
-            const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
-
-            const definitionContainer2 = insertDefinitionContainer({ txn, codeValue: "dc2" });
-            const definitionModel2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer2.id });
-            const category2 = insertCategory({ txn, codeValue: "cat2", modelId: definitionModel2.id });
-            const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: category2.id });
-            const subCategory2 = insertSubCategory({ txn, parentCategoryId: category2.id, codeValue: "subCat2", modelId: definitionModel2.id });
-            return {
-              definitionContainer,
-              category,
-              subCategory,
-              elementsModel,
-              element,
-              defaultSubCategoryId: getDefaultSubCategoryId(category.id),
-              definitionContainer2,
-              category2,
-              subCategory2,
-              element2,
-              defaultSubCategoryId2: getDefaultSubCategoryId(category2.id),
-            };
-          }),
-        );
-      }
-
-      async function createSiblingCategoriesIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            // Structure of the iModel:
-            // - Parent DefinitionContainer
-            //   - Category
-            //    - Element
-            //   - Child DefinitionContainer
-            //     - Child Category
-            //       - Child element
-            //     - Child Category2
-            //       - Child element2
-            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
-            const parentDefinitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
-            const parentDefinitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefinitionContainer.id });
-            const childDefinitionContainer = insertDefinitionContainer({ txn, codeValue: "child dc", modelId: parentDefinitionModel.id });
-            const childDefinitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefinitionContainer.id });
-            const childCategory = insertCategory({ txn, codeValue: "child cat", modelId: childDefinitionModel.id });
-            const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: childCategory.id });
-            const childCategory2 = insertCategory({ txn, codeValue: "child cat2", modelId: childDefinitionModel.id });
-            const childElement2 = insertElement({ txn, modelId: elementsModel.id, categoryId: childCategory2.id });
-
-            const category = insertCategory({ txn, codeValue: "cat", modelId: parentDefinitionModel.id });
-            const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
-            return {
-              parentDefinitionContainer,
-              childDefinitionContainer,
-              childCategory,
-              childElement,
-              childCategory2,
-              childElement2,
-              category,
-              elementsModel,
-              element,
-            };
-          }),
-        );
-      }
-
-      async function createElementsModelsIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            // Structure of the iModel:
-            // - CategoryA
-            //   - ElementA1 (model1)
-            //   - ElementA2 (model2)
-            // - CategoryB
-            //   - ElementB1 (model1)
-            //   - ElementB2 (model2)
-            const elementsModel1 = insertElementsModel({ txn, codeValue: "m1" });
-            const elementsModel2 = insertElementsModel({ txn, codeValue: "m2" });
-            const categoryA = insertCategory({ txn, codeValue: "catA" });
-            const categoryB = insertCategory({ txn, codeValue: "catB" });
-            const elementA1 = insertElement({ txn, modelId: elementsModel1.id, categoryId: categoryA.id });
-            const elementA2 = insertElement({ txn, modelId: elementsModel2.id, categoryId: categoryA.id });
-            const elementB1 = insertElement({ txn, modelId: elementsModel1.id, categoryId: categoryB.id });
-            const elementB2 = insertElement({ txn, modelId: elementsModel2.id, categoryId: categoryB.id });
-            return { elementsModel1, elementsModel2, categoryA, categoryB, elementA1, elementA2, elementB1, elementB2 };
-          }),
-        );
-      }
-
-      async function createIntermediateCategoriesIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
-            const categoryA = insertCategory({ txn, codeValue: "catA" });
-            const categoryB = insertCategory({ txn, codeValue: "catB" });
-            const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
-            const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
-            return { categoryA, categoryB, parentElement, childElement, elementsModel };
-          }),
-        );
-      }
-
-      async function createSubModelIntermediateCategoriesIModel() {
-        return buildIModel(async (imodel) =>
-          withEditTxn(imodel, (txn) => {
-            const elementsModel = insertElementsModel({ txn, codeValue: "m" });
-            const categoryA = insertCategory({ txn, codeValue: "catA" });
-            const categoryB = insertCategory({ txn, codeValue: "catB" });
-            const modeledElement = insertModeledElement({
-              txn,
-              modelId: elementsModel.id,
-              categoryId: categoryA.id,
-            });
-            const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
-            const subModelElement = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
-            return { categoryA, categoryB, modeledElement, subModel, subModelElement, elementsModel };
-          }),
-        );
-      }
+      let datasets: Awaited<ReturnType<typeof createDatasets>>;
 
       beforeAll(async () => {
-        simpleIModel = await createSimpleIModel();
-        accessAndCacheSimpleIModel = createAccessAndCache({ imodelConnection: simpleIModel.imodelConnection, viewType });
-
-        unrelatedDefContainersIModel = await createUnrelatedDefContainersIModel();
-        accessAndCacheUnrelatedDefContainersIModel = createAccessAndCache({ imodelConnection: unrelatedDefContainersIModel.imodelConnection, viewType });
-
-        siblingCategoriesIModel = await createSiblingCategoriesIModel();
-        accessAndCacheSiblingCategoriesIModel = createAccessAndCache({ imodelConnection: siblingCategoriesIModel.imodelConnection, viewType });
-
-        elementsModelsIModel = await createElementsModelsIModel();
-        accessAndCacheElementsModelsIModel = createAccessAndCache({ imodelConnection: elementsModelsIModel.imodelConnection, viewType });
-
-        intermediateCategoriesIModel = await createIntermediateCategoriesIModel();
-        accessAndCacheIntermediateCategoriesIModel = createAccessAndCache({ imodelConnection: intermediateCategoriesIModel.imodelConnection, viewType });
-
-        subModelIntermediateCategoriesIModel = await createSubModelIntermediateCategoriesIModel();
-        accessAndCacheSubModelIntermediateCategoriesIModel = createAccessAndCache({
-          imodelConnection: subModelIntermediateCategoriesIModel.imodelConnection,
-          viewType,
-        });
+        datasets = await createDatasets(viewType);
       });
 
       afterAll(async () => {
-        await simpleIModel.imodelConnection.close();
-        await unrelatedDefContainersIModel.imodelConnection.close();
-        await siblingCategoriesIModel.imodelConnection.close();
-        await elementsModelsIModel.imodelConnection.close();
-        await intermediateCategoriesIModel.imodelConnection.close();
-        await subModelIntermediateCategoriesIModel.imodelConnection.close();
+        await datasets[Symbol.asyncDispose]();
       });
 
       describe("enabling visibility", () => {
         it("by default everything is hidden", async () => {
-          const { imodelConnection, ...keys } = simpleIModel;
+          const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
           using visibilityTestData = await createVisibilityTestData({
             imodelConnection,
             subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-            ...accessAndCacheSimpleIModel,
+            idsCache,
+            imodelAccess,
           });
           const { handler, provider, viewport } = visibilityTestData;
 
@@ -349,11 +152,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
         });
 
         it("category is partial when multiple models contain category and override for one model is set to 'Show'", async () => {
-          const { imodelConnection, ...keys } = elementsModelsIModel;
+          const { imodelConnection, idsCache, imodelAccess, keys } = datasets.elementsModels;
 
           using visibilityTestData = await createVisibilityTestData({
             imodelConnection,
-            ...accessAndCacheElementsModelsIModel,
+            idsCache,
+            imodelAccess,
           });
           const { handler, provider, viewport } = visibilityTestData;
           setupInitialDisplayState({
@@ -383,13 +187,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         describe("definitionContainers", () => {
           it("showing definition container turns on children", async () => {
-            const { imodelConnection, ...keys } = simpleIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
-            const accessAndCache = createAccessAndCache({ imodelConnection, viewType });
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-              ...accessAndCache,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -403,7 +207,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing definition container doesn't affect non contained definition containers", async () => {
-            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
@@ -411,7 +215,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 { categoryId: keys.category.id, subCategories: keys.subCategory.id },
                 { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
               ],
-              ...accessAndCacheUnrelatedDefContainersIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -436,11 +241,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing definition container affects parent", async () => {
-            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
-              ...accessAndCacheSiblingCategoriesIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -464,10 +270,11 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         describe("categories", () => {
           it("showing category of hidden model does not enable other categories", async () => {
-            const { imodelConnection, ...keys } = elementsModelsIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.elementsModels;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
-              ...accessAndCacheElementsModelsIModel,
+              idsCache,
+              imodelAccess,
               hierarchyConfig: { elements: { nodes: "include" } },
             });
             const { handler, provider, viewport } = visibilityTestData;
@@ -511,12 +318,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing category turns on parents and children", async () => {
-            const { imodelConnection, ...keys } = simpleIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-              ...accessAndCacheSimpleIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -530,7 +338,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing category doesn't affect unrelated nodes", async () => {
-            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
@@ -538,7 +346,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 { categoryId: keys.category.id, subCategories: keys.subCategory.id },
                 { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
               ],
-              ...accessAndCacheUnrelatedDefContainersIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -563,11 +372,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing category makes parent container partially visible if it has more direct child categories", async () => {
-            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
-              ...accessAndCacheSiblingCategoriesIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -589,11 +399,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing category makes parent container partially visible if it has more definition containers", async () => {
-            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
-              ...accessAndCacheSiblingCategoriesIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -617,14 +428,15 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         describe("subCategories", () => {
           it("showing subCategory of hidden model does not affect other categories", async () => {
-            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [
                 { categoryId: keys.category.id, subCategories: keys.subCategory.id },
                 { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
               ],
-              ...accessAndCacheUnrelatedDefContainersIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -652,12 +464,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing subCategory doesn't affect sibling subCategories", async () => {
-            const { imodelConnection, ...keys } = simpleIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
-              ...accessAndCacheSimpleIModel,
+              idsCache,
+              imodelAccess,
             });
 
             const { handler, provider, viewport } = visibilityTestData;
@@ -679,7 +492,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("showing subCategory doesn't affect non related nodes", async () => {
-            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
@@ -687,7 +500,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 { categoryId: keys.category.id, subCategories: keys.subCategory.id },
                 { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
               ],
-              ...accessAndCacheUnrelatedDefContainersIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -715,13 +529,14 @@ describe("CategoriesTreeVisibilityHandler", () => {
         describe("elements set to 'include'", () => {
           describe("definitionContainers", () => {
             it("showing definition container turns on children", async () => {
-              const { imodelConnection, ...keys } = simpleIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
                 subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSimpleIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -735,7 +550,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing definition container doesn't affect non contained definition containers", async () => {
-              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
@@ -743,7 +558,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   { categoryId: keys.category.id, subCategories: keys.subCategory.id },
                   { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
                 ],
-                ...accessAndCacheUnrelatedDefContainersIModel,
+                idsCache,
+                imodelAccess,
                 hierarchyConfig: { elements: { nodes: "include" } },
               });
               const { handler, provider, viewport } = visibilityTestData;
@@ -771,12 +587,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing child definition container affects parent", async () => {
-              const { imodelConnection, ...keys } = siblingCategoriesIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSiblingCategoriesIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -804,13 +621,14 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
           describe("categories", () => {
             it("showing category turns on children", async () => {
-              const { imodelConnection, ...keys } = simpleIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
                 subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSimpleIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -824,7 +642,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing category doesn't affect other categories", async () => {
-              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
@@ -833,7 +651,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
                 ],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheUnrelatedDefContainersIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -860,7 +679,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing category doesn't affect non related definition container", async () => {
-              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
@@ -869,7 +688,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
                 ],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheUnrelatedDefContainersIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -896,12 +716,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing category makes parent container partially visible if it has more direct child categories", async () => {
-              const { imodelConnection, ...keys } = siblingCategoriesIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSiblingCategoriesIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -927,12 +748,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing category makes parent container partially visible if it has more definition containers", async () => {
-              const { imodelConnection, ...keys } = siblingCategoriesIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSiblingCategoriesIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -960,13 +782,14 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
           describe("subCategories", () => {
             it("showing subCategory doesn't affect category elements", async () => {
-              const { imodelConnection, ...keys } = simpleIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
                 subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSimpleIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
               setupInitialDisplayState({ viewport, elements: [{ id: keys.element.id, visible: false }] });
@@ -988,7 +811,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing subCategory doesn't affect non related elements", async () => {
-              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
@@ -997,7 +820,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
                 ],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheUnrelatedDefContainersIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
               setupInitialDisplayState({
@@ -1086,7 +910,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing element doesn't affect not related categories or subCategories", async () => {
-              const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
@@ -1095,7 +919,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                   { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
                 ],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheUnrelatedDefContainersIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -1125,13 +950,14 @@ describe("CategoriesTreeVisibilityHandler", () => {
             });
 
             it("showing element turns on category and its parents", async () => {
-              const { imodelConnection, ...keys } = simpleIModel;
+              const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
               using visibilityTestData = await createVisibilityTestData({
                 imodelConnection,
                 subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSimpleIModel,
+                idsCache,
+                imodelAccess,
               });
               const { handler, provider, viewport } = visibilityTestData;
 
@@ -1159,10 +985,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
             let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
 
             beforeEach(async () => {
+              const { imodelConnection, idsCache, imodelAccess } = datasets.intermediateCategories;
               visibilityTestData = await createVisibilityTestData({
-                imodelConnection: intermediateCategoriesIModel.imodelConnection,
+                imodelConnection,
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheIntermediateCategoriesIModel,
+                idsCache,
+                imodelAccess,
               });
             });
 
@@ -1172,7 +1000,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("showing intermediate category makes its elements visible and parent element partially visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = intermediateCategoriesIModel;
+              const { keys } = datasets.intermediateCategories;
 
               await handler.changeVisibility(
                 createCategoryHierarchyNode({
@@ -1202,7 +1030,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("showing child element under intermediate category makes it visible and parents partially visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = intermediateCategoriesIModel;
+              const { keys } = datasets.intermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -1232,7 +1060,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("showing parent element makes children under intermediate category visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = intermediateCategoriesIModel;
+              const { keys } = datasets.intermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -1266,10 +1094,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
             let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
 
             beforeEach(async () => {
+              const { imodelConnection, idsCache, imodelAccess } = datasets.subModelIntermediateCategories;
               visibilityTestData = await createVisibilityTestData({
-                imodelConnection: subModelIntermediateCategoriesIModel.imodelConnection,
+                imodelConnection,
                 hierarchyConfig: { elements: { nodes: "include" } },
-                ...accessAndCacheSubModelIntermediateCategoriesIModel,
+                idsCache,
+                imodelAccess,
               });
             });
 
@@ -1279,7 +1109,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("showing intermediate category under sub-model makes its elements visible and modeled element partially visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = subModelIntermediateCategoriesIModel;
+              const { keys } = datasets.subModelIntermediateCategories;
 
               await handler.changeVisibility(
                 createCategoryHierarchyNode({
@@ -1308,7 +1138,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("showing element under intermediate category in sub-model makes it visible and parents partially visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = subModelIntermediateCategoriesIModel;
+              const { keys } = datasets.subModelIntermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -1337,7 +1167,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("showing modeled element makes sub-model elements under intermediate category visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = subModelIntermediateCategoriesIModel;
+              const { keys } = datasets.subModelIntermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -1696,9 +1526,9 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         describe("enabling category visibility through model selector", () => {
           it("category is visible when only one model contains category and model is enabled through model selector", async () => {
-            const { imodelConnection, ...keys } = simpleIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
-            using visibilityTestData = await createVisibilityTestData({ imodelConnection, ...accessAndCacheSimpleIModel });
+            using visibilityTestData = await createVisibilityTestData({ imodelConnection, idsCache, imodelAccess });
             const { handler, provider, viewport } = visibilityTestData;
             setupInitialDisplayState({ viewport, categories: [{ id: keys.category.id, visible: true }] });
 
@@ -1713,8 +1543,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("category is partial when multiple models contain category and one model is enabled through model selector", async () => {
-            const { imodelConnection, ...keys } = elementsModelsIModel;
-            using visibilityTestData = await createVisibilityTestData({ imodelConnection, ...accessAndCacheElementsModelsIModel });
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.elementsModels;
+            using visibilityTestData = await createVisibilityTestData({ imodelConnection, idsCache, imodelAccess });
             const { handler, provider, viewport } = visibilityTestData;
             setupInitialDisplayState({ viewport, categories: [{ id: keys.categoryA.id, visible: true }] });
 
@@ -1735,12 +1565,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       describe("disabling visibility", () => {
         it("by default everything is visible", async () => {
-          const { imodelConnection, ...keys } = simpleIModel;
+          const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
           using visibilityTestData = await createVisibilityTestData({
             imodelConnection,
             subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
             visibleByDefault: true,
-            ...accessAndCacheSimpleIModel,
+            idsCache,
+            imodelAccess,
           });
           const { handler, provider, viewport } = visibilityTestData;
 
@@ -1753,8 +1584,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
         });
 
         it("category is partial when multiple models contain category and override for one model is set to 'Hide'", async () => {
-          const { imodelConnection, ...keys } = elementsModelsIModel;
-          using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true, ...accessAndCacheElementsModelsIModel });
+          const { imodelConnection, idsCache, imodelAccess, keys } = datasets.elementsModels;
+          using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true, idsCache, imodelAccess });
           const { handler, provider, viewport } = visibilityTestData;
 
           viewport.setPerModelCategoryOverride({
@@ -1775,8 +1606,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
         });
 
         it("category is partial when multiple models contain category and one model is disabled through model selector", async () => {
-          const { imodelConnection, ...keys } = elementsModelsIModel;
-          using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true, ...accessAndCacheElementsModelsIModel });
+          const { imodelConnection, idsCache, imodelAccess, keys } = datasets.elementsModels;
+          using visibilityTestData = await createVisibilityTestData({ imodelConnection, visibleByDefault: true, idsCache, imodelAccess });
           const { handler, provider, viewport } = visibilityTestData;
 
           viewport.changeModelDisplay({ modelIds: keys.elementsModel1.id, display: false });
@@ -1794,12 +1625,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         describe("definitionContainers", () => {
           it("hiding definition container hides children", async () => {
-            const { imodelConnection, ...keys } = simpleIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
               visibleByDefault: true,
-              ...accessAndCacheSimpleIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -1813,7 +1645,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("hiding definition container doesn't affect non contained definition containers", async () => {
-            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [
@@ -1821,7 +1653,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
               ],
               visibleByDefault: true,
-              ...accessAndCacheUnrelatedDefContainersIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -1846,11 +1679,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("hiding definition affects parent", async () => {
-            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               visibleByDefault: true,
-              ...accessAndCacheSiblingCategoriesIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -1875,12 +1709,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         describe("categories", () => {
           it("hiding category hides children", async () => {
-            const { imodelConnection, ...keys } = simpleIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
               visibleByDefault: true,
-              ...accessAndCacheSimpleIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -1894,7 +1729,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("hiding category doesn't affect non related nodes", async () => {
-            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [
@@ -1902,7 +1737,8 @@ describe("CategoriesTreeVisibilityHandler", () => {
                 { categoryId: keys.category2.id, subCategories: keys.subCategory2.id },
               ],
               visibleByDefault: true,
-              ...accessAndCacheUnrelatedDefContainersIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -1927,11 +1763,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("hiding category makes parent container partially visible if it has more direct child categories", async () => {
-            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               visibleByDefault: true,
-              ...accessAndCacheSiblingCategoriesIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -1953,11 +1790,12 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("hiding category makes parent container partially visible if it has more definition containers", async () => {
-            const { imodelConnection, ...keys } = siblingCategoriesIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.siblingCategories;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               visibleByDefault: true,
-              ...accessAndCacheSiblingCategoriesIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -1982,12 +1820,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
         describe("subCategories", () => {
           it("hiding subCategory affects parents and doesn't affect other subCategories", async () => {
-            const { imodelConnection, ...keys } = simpleIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
               visibleByDefault: true,
-              ...accessAndCacheSimpleIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -2007,12 +1846,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
           });
 
           it("hiding subCategory doesn't affect not related nodes", async () => {
-            const { imodelConnection, ...keys } = unrelatedDefContainersIModel;
+            const { imodelConnection, idsCache, imodelAccess, keys } = datasets.unrelatedDefContainers;
             using visibilityTestData = await createVisibilityTestData({
               imodelConnection,
               subCategoriesOfCategories: [{ categoryId: keys.category.id, subCategories: keys.subCategory.id }],
               visibleByDefault: true,
-              ...accessAndCacheUnrelatedDefContainersIModel,
+              idsCache,
+              imodelAccess,
             });
             const { handler, provider, viewport } = visibilityTestData;
 
@@ -2042,11 +1882,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
             let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
 
             beforeEach(async () => {
+              const { imodelConnection, idsCache, imodelAccess } = datasets.intermediateCategories;
               visibilityTestData = await createVisibilityTestData({
-                imodelConnection: intermediateCategoriesIModel.imodelConnection,
+                imodelConnection,
                 hierarchyConfig: { elements: { nodes: "include" } },
                 visibleByDefault: true,
-                ...accessAndCacheIntermediateCategoriesIModel,
+                idsCache,
+                imodelAccess,
               });
             });
 
@@ -2056,7 +1898,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("hiding intermediate category makes its elements hidden", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = intermediateCategoriesIModel;
+              const { keys } = datasets.intermediateCategories;
 
               await handler.changeVisibility(
                 createCategoryHierarchyNode({
@@ -2086,7 +1928,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("hiding child element under intermediate category makes it hidden and parents partially visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = intermediateCategoriesIModel;
+              const { keys } = datasets.intermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -2116,7 +1958,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("hiding parent element makes children under intermediate category hidden", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = intermediateCategoriesIModel;
+              const { keys } = datasets.intermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -2150,11 +1992,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
             let visibilityTestData: Awaited<ReturnType<typeof createVisibilityTestData>>;
 
             beforeEach(async () => {
+              const { imodelConnection, idsCache, imodelAccess } = datasets.subModelIntermediateCategories;
               visibilityTestData = await createVisibilityTestData({
-                imodelConnection: subModelIntermediateCategoriesIModel.imodelConnection,
+                imodelConnection,
                 hierarchyConfig: { elements: { nodes: "include" } },
                 visibleByDefault: true,
-                ...accessAndCacheSubModelIntermediateCategoriesIModel,
+                idsCache,
+                imodelAccess,
               });
             });
 
@@ -2164,7 +2008,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("hiding intermediate category under sub-model makes its elements hidden", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = subModelIntermediateCategoriesIModel;
+              const { keys } = datasets.subModelIntermediateCategories;
 
               await handler.changeVisibility(
                 createCategoryHierarchyNode({
@@ -2193,7 +2037,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("hiding element under intermediate category in sub-model makes it hidden and parents partially visible", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = subModelIntermediateCategoriesIModel;
+              const { keys } = datasets.subModelIntermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -2222,7 +2066,7 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
             it("hiding modeled element makes sub-model elements under intermediate category hidden", async () => {
               const { handler, provider, viewport } = visibilityTestData;
-              const keys = subModelIntermediateCategoriesIModel;
+              const { keys } = datasets.subModelIntermediateCategories;
 
               await handler.changeVisibility(
                 createElementHierarchyNode({
@@ -2256,12 +2100,13 @@ describe("CategoriesTreeVisibilityHandler", () => {
 
       describe("elements.excludedClasses", () => {
         it("element of an excluded class participates in visibility", async () => {
-          const { imodelConnection, ...keys } = simpleIModel;
+          const { imodelConnection, idsCache, imodelAccess, keys } = datasets.simple;
 
           using visibilityTestData = await createVisibilityTestData({
             imodelConnection,
             hierarchyConfig: { elements: { nodes: "include", excludedClasses: [getClassesByView(viewType).elementClass] } },
-            ...accessAndCacheSimpleIModel,
+            idsCache,
+            imodelAccess,
           });
           const { handler, provider, viewport } = visibilityTestData;
 
@@ -2300,3 +2145,176 @@ describe("CategoriesTreeVisibilityHandler", () => {
     });
   });
 });
+
+async function createDatasets(viewType: "2d" | "3d") {
+  const imodels: IModelConnection[] = [];
+  const { insertElementsModel, insertModeledElement, insertCategory, insertElement, insertElementsSubModel } = getInsertFunctionByViewType(viewType);
+
+  return {
+    [Symbol.asyncDispose]: async () => Promise.all(imodels.map(async (imodel) => imodel.close())),
+    ["simple"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          // Structure of the iModel:
+          // - DefinitionContainer
+          //   - Category
+          //     - Default SubCategory
+          //     - SubCategory
+          //     - Element
+          const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+
+          const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+          const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
+          return { definitionContainer, category, subCategory, elementsModel, element, defaultSubCategoryId: getDefaultSubCategoryId(category.id) };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+    ["unrelatedDefContainers"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          // Structure of the iModel:
+          // - DefinitionContainer
+          //   - Category
+          //     - Default SubCategory
+          //     - SubCategory
+          //     - Element
+          //
+          // - DefinitionContainer2
+          //   - Category2
+          //     - Default SubCategory2
+          //     - SubCategory2
+          //     - Element2
+          const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+          const definitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+          const definitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer.id });
+          const category = insertCategory({ txn, codeValue: "cat", modelId: definitionModel.id });
+          const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+          const subCategory = insertSubCategory({ txn, parentCategoryId: category.id, codeValue: "subCat", modelId: definitionModel.id });
+
+          const definitionContainer2 = insertDefinitionContainer({ txn, codeValue: "dc2" });
+          const definitionModel2 = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: definitionContainer2.id });
+          const category2 = insertCategory({ txn, codeValue: "cat2", modelId: definitionModel2.id });
+          const element2 = insertElement({ txn, modelId: elementsModel.id, categoryId: category2.id });
+          const subCategory2 = insertSubCategory({ txn, parentCategoryId: category2.id, codeValue: "subCat2", modelId: definitionModel2.id });
+          return {
+            definitionContainer,
+            category,
+            subCategory,
+            elementsModel,
+            element,
+            defaultSubCategoryId: getDefaultSubCategoryId(category.id),
+            definitionContainer2,
+            category2,
+            subCategory2,
+            element2,
+            defaultSubCategoryId2: getDefaultSubCategoryId(category2.id),
+          };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+    ["siblingCategories"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          // Structure of the iModel:
+          // - Parent DefinitionContainer
+          //   - Category
+          //    - Element
+          //   - Child DefinitionContainer
+          //     - Child Category
+          //       - Child element
+          //     - Child Category2
+          //       - Child element2
+          const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+          const parentDefinitionContainer = insertDefinitionContainer({ txn, codeValue: "dc" });
+          const parentDefinitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: parentDefinitionContainer.id });
+          const childDefinitionContainer = insertDefinitionContainer({ txn, codeValue: "child dc", modelId: parentDefinitionModel.id });
+          const childDefinitionModel = insertSubModel({ txn, classFullName: CLASS_NAME_DefinitionModel, modeledElementId: childDefinitionContainer.id });
+          const childCategory = insertCategory({ txn, codeValue: "child cat", modelId: childDefinitionModel.id });
+          const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: childCategory.id });
+          const childCategory2 = insertCategory({ txn, codeValue: "child cat2", modelId: childDefinitionModel.id });
+          const childElement2 = insertElement({ txn, modelId: elementsModel.id, categoryId: childCategory2.id });
+
+          const category = insertCategory({ txn, codeValue: "cat", modelId: parentDefinitionModel.id });
+          const element = insertElement({ txn, modelId: elementsModel.id, categoryId: category.id });
+          return {
+            parentDefinitionContainer,
+            childDefinitionContainer,
+            childCategory,
+            childElement,
+            childCategory2,
+            childElement2,
+            category,
+            elementsModel,
+            element,
+          };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+    ["elementsModels"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          // Structure of the iModel:
+          // - CategoryA
+          //   - ElementA1 (model1)
+          //   - ElementA2 (model2)
+          // - CategoryB
+          //   - ElementB1 (model1)
+          //   - ElementB2 (model2)
+          const elementsModel1 = insertElementsModel({ txn, codeValue: "m1" });
+          const elementsModel2 = insertElementsModel({ txn, codeValue: "m2" });
+          const categoryA = insertCategory({ txn, codeValue: "catA" });
+          const categoryB = insertCategory({ txn, codeValue: "catB" });
+          const elementA1 = insertElement({ txn, modelId: elementsModel1.id, categoryId: categoryA.id });
+          const elementA2 = insertElement({ txn, modelId: elementsModel2.id, categoryId: categoryA.id });
+          const elementB1 = insertElement({ txn, modelId: elementsModel1.id, categoryId: categoryB.id });
+          const elementB2 = insertElement({ txn, modelId: elementsModel2.id, categoryId: categoryB.id });
+          return { elementsModel1, elementsModel2, categoryA, categoryB, elementA1, elementA2, elementB1, elementB2 };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+    ["intermediateCategories"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+          const categoryA = insertCategory({ txn, codeValue: "catA" });
+          const categoryB = insertCategory({ txn, codeValue: "catB" });
+          const parentElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryA.id });
+          const childElement = insertElement({ txn, modelId: elementsModel.id, categoryId: categoryB.id, parentId: parentElement.id });
+          return { categoryA, categoryB, parentElement, childElement, elementsModel };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+    ["subModelIntermediateCategories"]: await (async () => {
+      const { imodelConnection, ...keys } = await buildIModel(async (imodel) =>
+        withEditTxn(imodel, (txn) => {
+          const elementsModel = insertElementsModel({ txn, codeValue: "m" });
+          const categoryA = insertCategory({ txn, codeValue: "catA" });
+          const categoryB = insertCategory({ txn, codeValue: "catB" });
+          const modeledElement = insertModeledElement({
+            txn,
+            modelId: elementsModel.id,
+            categoryId: categoryA.id,
+          });
+          const subModel = insertElementsSubModel({ txn, modeledElementId: modeledElement.id });
+          const subModelElement = insertElement({ txn, modelId: subModel.id, categoryId: categoryB.id });
+          return { categoryA, categoryB, modeledElement, subModel, subModelElement, elementsModel };
+        }),
+      );
+      imodels.push(imodelConnection);
+      return { imodelConnection, keys, ...createAccessAndCache({ imodelConnection, viewType }) };
+    })(),
+  };
+}

--- a/packages/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
+++ b/packages/tree-widget/src/test/trees/categories-tree/internal/Utils.ts
@@ -13,20 +13,28 @@ import {
   insertSpatialCategory,
   insertSubModel,
 } from "test-utilities";
+import { BaseIdsCache } from "../../../../tree-widget-react/shared/internal/caches/BaseIdsCache.js";
 import {
   CLASS_NAME_DefinitionContainer,
   CLASS_NAME_Element,
   CLASS_NAME_SubCategory,
 } from "../../../../tree-widget-react/shared/internal/ClassNameDefinitions.js";
 import { getClassesByView } from "../../../../tree-widget-react/shared/internal/Utils.js";
+import { CategoriesTreeIdsCache } from "../../../../tree-widget-react/trees/categories-tree/internal/CategoriesTreeIdsCache.js";
 import { TestSchema } from "../../../IModelUtils.js";
+import { validateHierarchyVisibility } from "../../../shared/VisibilityValidation.js";
+import { createIModelAccess } from "../../Common.js";
+import { validateNodeVisibility } from "./VisibilityValidation.js";
 
 import type { EditTxn } from "@itwin/core-backend";
 import type { Id64Array, Id64String } from "@itwin/core-bentley";
+import type { IModelConnection } from "@itwin/core-frontend";
 import type { ClassGroupingNodeKey, GroupingHierarchyNode, NonGroupingHierarchyNode } from "@itwin/presentation-hierarchies";
-import type { EC, InstanceKey } from "@itwin/presentation-shared";
+import type { EC, InstanceKey, Props } from "@itwin/presentation-shared";
 import type { ElementId, ModelId } from "../../../../tree-widget-react/shared/internal/Types.js";
 import type { ParentElementsPath } from "../../../../tree-widget-react/shared/internal/Utils.js";
+import type { IModelAccess } from "../../Common.js";
+import type { TreeWidgetTestingViewport } from "../../TreeUtils.js";
 
 /** @internal */
 export function createCategoryHierarchyNode(props: {
@@ -207,4 +215,62 @@ export function getInsertFunctionByViewType(viewType: "2d" | "3d") {
       classFullName: `${TestSchema.Name}.${viewType === "3d" ? TestSchema.ModeledElement3dClassName : TestSchema.ModeledElement2dClassName}`,
     });
   return { insertCategory, insertElement, insertElementsModel, insertElementsSubModel, insertModeledElement };
+}
+
+interface VisibilityInfo {
+  id: Id64String;
+  visible: boolean;
+}
+
+export function setupInitialDisplayState(props: {
+  viewport: TreeWidgetTestingViewport;
+  categories?: Array<VisibilityInfo>;
+  subCategories?: Array<VisibilityInfo>;
+  models?: Array<VisibilityInfo>;
+  elements?: Array<VisibilityInfo>;
+}) {
+  const { viewport } = props;
+  const categories = props.categories ?? [];
+  const elements = props.elements ?? [];
+  const subCategories = props.subCategories ?? [];
+  const models = props.models ?? [];
+  for (const subCategoryInfo of subCategories) {
+    viewport.changeSubCategoryDisplay({ subCategoryId: subCategoryInfo.id, display: subCategoryInfo.visible });
+  }
+  for (const categoryInfo of categories) {
+    viewport.changeCategoryDisplay({ categoryIds: categoryInfo.id, display: categoryInfo.visible, enableAllSubCategories: false });
+  }
+  const alwaysDrawn = elements.filter(({ visible }) => visible).map(({ id }) => id);
+  if (alwaysDrawn.length > 0) {
+    viewport.setAlwaysDrawn({ elementIds: new Set([...alwaysDrawn, ...(viewport.alwaysDrawn ?? [])]) });
+  }
+  const neverDrawn = elements.filter(({ visible }) => !visible).map(({ id }) => id);
+  if (neverDrawn.length > 0) {
+    viewport.setNeverDrawn({ elementIds: new Set([...neverDrawn, ...(viewport.neverDrawn ?? [])]) });
+  }
+
+  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => visible).map(({ id }) => id), display: true });
+  viewport.changeModelDisplay({ modelIds: models.filter(({ visible }) => !visible).map(({ id }) => id), display: false });
+  viewport.renderFrame();
+}
+
+export async function validateCategoriesTreeHierarchyVisibility(props: Omit<Props<typeof validateHierarchyVisibility>, "validateNodeVisibility">) {
+  return validateHierarchyVisibility({
+    ...props,
+    validateNodeVisibility,
+  });
+}
+
+export function createAccessAndCache({ imodelConnection, viewType }: { imodelConnection: IModelConnection; viewType: "2d" | "3d" }): {
+  imodelAccess: IModelAccess;
+  idsCache: CategoriesTreeIdsCache;
+} {
+  const imodelAccess = createIModelAccess(imodelConnection);
+  const baseIdsCache = new BaseIdsCache({ queryExecutor: imodelAccess, elementClassName: getClassesByView(viewType).elementClass, type: viewType });
+  const idsCache = new CategoriesTreeIdsCache({ queryExecutor: imodelAccess, type: viewType, baseIdsCache });
+
+  return {
+    imodelAccess,
+    idsCache,
+  };
 }

--- a/packages/tree-widget/vitest.config.ts
+++ b/packages/tree-widget/vitest.config.ts
@@ -11,6 +11,11 @@ const logsToIgnore = ["CSS variable not found", "ECClass 'PresentationRules.Rule
 
 export default defineConfig({
   test: {
+    onConsoleLog(log) {
+      if (logsToIgnore.some((logToIgnore) => log.includes(logToIgnore))) {
+        return false;
+      }
+    },
     projects: [
       {
         test: {
@@ -20,11 +25,6 @@ export default defineConfig({
           include: ["src/test/**/*.test.ts?(x)"],
           exclude: [...configDefaults.exclude, "src/test/components/**"],
           setupFiles: ["src/test/setup.ts"],
-          onConsoleLog(log) {
-            if (logsToIgnore.some((logToIgnore) => log.includes(logToIgnore))) {
-              return false;
-            }
-          },
           restoreMocks: true,
           testTimeout: 60000,
           server: {


### PR DESCRIPTION
Part of #1567 
- All categories tree tests now check `2d` and `3d` case.
- Changed visibility handler tests to share imodels between tests.
- Changed ids cache tests to share imodels between tests.
- Moved `Search` tests from visibility `CategoriesTreeVisibilityHandler.test.ts` -> `CategoriesTreeVisibilityHandler.Search.test.ts`.
- Removed some unnecessary tests.

There are now more tests than before due to `2d` case being checked everywhere (previously only some test suites checked `2d` case).
Now `Categories` tests run faser:
```ts
// Old
// Tests  268 passed (268)
// Duration  48.06s
// New
// Tests  379 passed (379)
// Duration  32.24s
```